### PR TITLE
Add support for weapon base damage conversion

### DIFF
--- a/src/Data/Bases/axe.lua
+++ b/src/Data/Bases/axe.lua
@@ -214,7 +214,7 @@ itemBases["Ember Greataxe"] = {
 	tags = { axe = true, two_hand_weapon = true, weapon = true, twohand = true, default = true, },
 	influenceTags = { shaper = "2h_axe_shaper", elder = "2h_axe_elder", adjudicator = "2h_axe_adjudicator", basilisk = "2h_axe_basilisk", crusader = "2h_axe_crusader", eyrie = "2h_axe_eyrie", cleansing = "2h_axe_cleansing", tangle = "2h_axe_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 58, PhysicalMax = 154, CritChanceBase = 5, AttackRateBase = 1.2, Range = 13, },
+	weapon = { FireMin = 58, FireMax = 154, CritChanceBase = 5, AttackRateBase = 1.2, Range = 13, },
 	req = { level = 50, },
 }
 itemBases["Ceremonial Halberd"] = {

--- a/src/Data/Bases/bow.lua
+++ b/src/Data/Bases/bow.lua
@@ -64,7 +64,7 @@ itemBases["Cultist Bow"] = {
 	tags = { two_hand_weapon = true, vaal_basetype = true, ranged = true, weapon = true, default = true, twohand = true, bow = true, },
 	influenceTags = { shaper = "bow_shaper", elder = "bow_elder", adjudicator = "bow_adjudicator", basilisk = "bow_basilisk", crusader = "bow_crusader", eyrie = "bow_eyrie", cleansing = "bow_cleansing", tangle = "bow_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 36, PhysicalMax = 59, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
+	weapon = { ChaosMin = 36, ChaosMax = 59, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
 	req = { level = 33, },
 }
 itemBases["Zealot Bow"] = {
@@ -166,7 +166,7 @@ itemBases["Advanced Cultist Bow"] = {
 	tags = { two_hand_weapon = true, ranged = true, weapon = true, default = true, twohand = true, bow = true, },
 	influenceTags = { shaper = "bow_shaper", elder = "bow_elder", adjudicator = "bow_adjudicator", basilisk = "bow_basilisk", crusader = "bow_crusader", eyrie = "bow_eyrie", cleansing = "bow_cleansing", tangle = "bow_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 41, PhysicalMax = 69, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
+	weapon = { ChaosMin = 41, ChaosMax = 69, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
 	req = { level = 59, },
 }
 itemBases["Advanced Zealot Bow"] = {
@@ -222,7 +222,7 @@ itemBases["Expert Cultist Bow"] = {
 	tags = { two_hand_weapon = true, ranged = true, weapon = true, default = true, twohand = true, bow = true, },
 	influenceTags = { shaper = "bow_shaper", elder = "bow_elder", adjudicator = "bow_adjudicator", basilisk = "bow_basilisk", crusader = "bow_crusader", eyrie = "bow_eyrie", cleansing = "bow_cleansing", tangle = "bow_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 52, PhysicalMax = 87, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
+	weapon = { ChaosMin = 52, ChaosMax = 87, CritChanceBase = 5, AttackRateBase = 1.2, Range = 120, },
 	req = { level = 79, },
 }
 itemBases["Expert Zealot Bow"] = {

--- a/src/Data/Bases/dagger.lua
+++ b/src/Data/Bases/dagger.lua
@@ -55,7 +55,7 @@ itemBases["Moon Dagger"] = {
 	tags = { maraketh_basetype = true, onehand = true, one_hand_weapon = true, weapon = true, dagger = true, default = true, },
 	influenceTags = { shaper = "dagger_shaper", elder = "dagger_elder", adjudicator = "dagger_adjudicator", basilisk = "dagger_basilisk", crusader = "dagger_crusader", eyrie = "dagger_eyrie", cleansing = "dagger_cleansing", tangle = "dagger_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 11, PhysicalMax = 26, CritChanceBase = 15, AttackRateBase = 1.55, Range = 10, },
+	weapon = { ColdMin = 11, ColdMax = 26, CritChanceBase = 15, AttackRateBase = 1.55, Range = 10, },
 	req = { level = 20, },
 }
 itemBases["Engraved Knife"] = {

--- a/src/Data/Bases/mace.lua
+++ b/src/Data/Bases/mace.lua
@@ -17,7 +17,7 @@ itemBases["Smithing Hammer"] = {
 	tags = { onehand = true, ezomyte_basetype = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "mace_shaper", elder = "mace_elder", adjudicator = "mace_adjudicator", basilisk = "mace_basilisk", crusader = "mace_crusader", eyrie = "mace_eyrie", cleansing = "mace_cleansing", tangle = "mace_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 9, PhysicalMax = 15, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
+	weapon = { PhysicalMin = 4, PhysicalMax = 7, FireMin = 4, FireMax = 7, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
 	req = { },
 }
 itemBases["Slim Mace"] = {
@@ -128,7 +128,7 @@ itemBases["Advanced Smithing Hammer"] = {
 	tags = { onehand = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "mace_shaper", elder = "mace_elder", adjudicator = "mace_adjudicator", basilisk = "mace_basilisk", crusader = "mace_crusader", eyrie = "mace_eyrie", cleansing = "mace_cleansing", tangle = "mace_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 38, PhysicalMax = 64, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
+	weapon = { PhysicalMin = 19, PhysicalMax = 32, FireMin = 19, FireMax = 32, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
 	req = { level = 45, },
 }
 itemBases["Advanced Slim Mace"] = {
@@ -202,7 +202,7 @@ itemBases["Expert Smithing Hammer"] = {
 	tags = { onehand = true, mace = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "mace_shaper", elder = "mace_elder", adjudicator = "mace_adjudicator", basilisk = "mace_basilisk", crusader = "mace_crusader", eyrie = "mace_eyrie", cleansing = "mace_cleansing", tangle = "mace_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 61, PhysicalMax = 101, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
+	weapon = { PhysicalMin = 30, PhysicalMax = 50, FireMin = 30, FireMax = 50, CritChanceBase = 5, AttackRateBase = 1.45, Range = 11, },
 	req = { level = 77, },
 }
 itemBases["Expert Warpick"] = {

--- a/src/Data/Bases/spear.lua
+++ b/src/Data/Bases/spear.lua
@@ -110,7 +110,7 @@ itemBases["Striking Spear"] = {
 	tags = { onehand = true, spear = true, weapon = true, one_hand_weapon = true, default = true, },
 	influenceTags = { shaper = "spear_shaper", elder = "spear_elder", adjudicator = "spear_adjudicator", basilisk = "spear_basilisk", crusader = "spear_crusader", eyrie = "spear_eyrie", cleansing = "spear_cleansing", tangle = "spear_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 23, PhysicalMax = 91, CritChanceBase = 5, AttackRateBase = 1.6, Range = 15, },
+	weapon = { LightningMin = 23, LightningMax = 91, CritChanceBase = 5, AttackRateBase = 1.6, Range = 15, },
 	req = { level = 55, },
 }
 itemBases["Helix Spear"] = {

--- a/src/Data/Bases/staff.lua
+++ b/src/Data/Bases/staff.lua
@@ -145,7 +145,7 @@ itemBases["Crackling Quarterstaff"] = {
 	tags = { two_hand_weapon = true, warstaff = true, maraketh_basetype = true, weapon = true, twohand = true, default = true, },
 	influenceTags = { shaper = "warstaff_shaper", elder = "warstaff_elder", adjudicator = "warstaff_adjudicator", basilisk = "warstaff_basilisk", crusader = "warstaff_crusader", eyrie = "warstaff_eyrie", cleansing = "warstaff_cleansing", tangle = "warstaff_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 13, PhysicalMax = 54, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
+	weapon = { LightningMin = 13, LightningMax = 54, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
 	req = { level = 16, },
 }
 itemBases["Crescent Quarterstaff"] = {
@@ -267,7 +267,7 @@ itemBases["Advanced Crackling Quarterstaff"] = {
 	tags = { two_hand_weapon = true, warstaff = true, weapon = true, twohand = true, default = true, },
 	influenceTags = { shaper = "warstaff_shaper", elder = "warstaff_elder", adjudicator = "warstaff_adjudicator", basilisk = "warstaff_basilisk", crusader = "warstaff_crusader", eyrie = "warstaff_eyrie", cleansing = "warstaff_cleansing", tangle = "warstaff_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 30, PhysicalMax = 57, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
+	weapon = { LightningMin = 30, LightningMax = 57, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
 	req = { level = 51, },
 }
 itemBases["Advanced Crescent Quarterstaff"] = {
@@ -339,7 +339,7 @@ itemBases["Expert Crackling Quarterstaff"] = {
 	tags = { two_hand_weapon = true, warstaff = true, weapon = true, twohand = true, default = true, },
 	influenceTags = { shaper = "warstaff_shaper", elder = "warstaff_elder", adjudicator = "warstaff_adjudicator", basilisk = "warstaff_basilisk", crusader = "warstaff_crusader", eyrie = "warstaff_eyrie", cleansing = "warstaff_cleansing", tangle = "warstaff_tangle" },
 	implicitModTypes = { },
-	weapon = { PhysicalMin = 43, PhysicalMax = 172, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
+	weapon = { LightningMin = 43, LightningMax = 172, CritChanceBase = 10, AttackRateBase = 1.4, Range = 13, },
 	req = { level = 78, },
 }
 itemBases["Expert Barrier Quarterstaff"] = {


### PR DESCRIPTION
This adds support for exporting weapon bases with hidden implicit mods that convert base damage (e.g. Smithing Hammer, Cultist Bow).
The handling of different damage type calculations is already implemented.
