### PR TITLE
allow CritMultiplier INC modifiers

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2784,6 +2784,8 @@ function calcs.offence(env, actor, activeSkill)
 				output.CritMultiplier = 1
 			else
 				local extraDamage = skillModList:Sum("BASE", cfg, "CritMultiplier") / 100
+				local extraDamageInc = 1 + skillModList:Sum("INC", cfg, "CritMultiplier") / 100
+				extraDamage = extraDamage * extraDamageInc
 				local multiOverride = skillModList:Override(skillCfg, "CritMultiplier")
 				if multiOverride then
 					extraDamage = (multiOverride - 100) / 100


### PR DESCRIPTION
Apparently this didn't exist in PoE1, only had BASE affects to CritMultiplier.