### PR TITLE
GGPK Export CTRL+F5 support

### DIFF
--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -74,7 +74,10 @@ function main:Init()
 	self.datFileByName = { }
 
 	self:LoadSettings()
-
+	self.reExportGGPKData = false
+	if IsKeyDown("CTRL") then
+		self.reExportGGPKData = true
+	end
 	self:InitGGPK()
 	if self.datSource then
 		if USE_DAT64 then
@@ -430,10 +433,10 @@ function main:InitGGPK()
 		local now = GetTime()
 		local ggpkPath = self.datSource.ggpkPath
 		if ggpkPath and ggpkPath ~= "" then
-			self.ggpk = new("GGPKData", ggpkPath)
+			self.ggpk = new("GGPKData", ggpkPath, nil, self.reExportGGPKData)
 			ConPrintf("GGPK: %d ms", GetTime() - now)
 		elseif self.datSource.datFilePath then
-			self.ggpk = new("GGPKData", nil, self.datSource.datFilePath)
+			self.ggpk = new("GGPKData", nil, self.datSource.datFilePath, self.reExportGGPKData)
 			ConPrintf("GGPK: %d ms", GetTime() - now)
 		end
 	end


### PR DESCRIPTION
New Behavior:

Running Export loads data
Running Export with CTRL down (including by hitting F5 key) forces a Contents.ggpk fresh data pull