### PR TITLE
Update Help Section with Attribute Hotkeys

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -46,6 +46,21 @@ Ctrl	While scrolling on a slider makes it 5* times slower
 * default of 5, some scroll bars have more or less extreme modifiers to scroll speed
   and scroll bars in help section and version history will jump to the previous/next section
 
+Attribute Shortcuts:
+
+LMB + 1 / I	Allocate Intelligence for an unallocated Attribute node or
+	    Hotswap an allocated attribute node to Intelligence*
+LMB + 2 / S	Allocate Strength for an unallocated Attribute node or
+	    Hotswap an allocated attribute node to Strength*
+LMB + 3 / D	Allocate Dexterity for an unallocated Attribute node or
+	    Hotswap an allocated attribute node to Dexterity*
+* if allocating a line/path of attribute nodes, all will be set to the selected attribute
+
+If allocating a non-attribute node, either the last used hotkey (if no hotkey is pressed) or one of the hotkeys above
+    will allocate any attribute nodes in the path to the selected attribute
+
+---
+
 When creating an item either through item creator or adding an item pressing ctrl will add it to the first slot
     and ctrl+shift will add it to the second slot e.g. offhand for a weapon.
 

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -683,6 +683,7 @@ function PassiveSpecClass:ResetNodes()
 		end
 	end
 	wipeTable(self.masterySelections)
+	wipeTable(self.hashOverrides) -- reset attribute nodes to "Attribute"
 end
 
 -- Allocate the given node, if possible, and all nodes along the path to the node


### PR DESCRIPTION
### Description of the problem being solved:
Add hotkeys and some additional information on attribute allocation in the Help Section

Also a small fix when Resetting Tree, wipe the hashOverrides so the nodes reset back to "Attribute" as opposed to unallocated Str/Int/Dex

### After screenshot:
![image](https://github.com/user-attachments/assets/c209fa0a-cff2-407c-8c9c-12393fe99612)
