### PR TITLE
Enabled Switchable nodes and fix save & load builds

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -158,7 +158,7 @@ function PassiveSpecClass:Load(xml, dbFileName)
 				end
 			end
 		end
-		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), tonumber(xml.attrib.secondaryAscendClassId or 0), hashList, self.hashOverrides, masteryEffects)
+		self:ImportFromNodeList(tonumber(xml.attrib.classId), tonumber(xml.attrib.ascendClassId), tonumber(xml.attrib.secondaryAscendClassId or 0), hashList,	copyTable(self.hashOverrides, true), masteryEffects)
 	elseif url then
 		self:DecodeURL(url)
 	end
@@ -2028,13 +2028,7 @@ function PassiveSpecClass:SwitchAttributeNode(nodeId, attributeIndex)
 	if not newNode.isAttribute then return end -- safety check
 	
 	local option = newNode.options[attributeIndex]
-	local attribute = option.name
-	
-	newNode.dn = attribute
-	newNode.icon = "Art/2DArt/SkillIcons/passives/plus"..string.lower(attribute)..".dds"
-	newNode.sprites = self.tree.spriteMap[newNode.icon]
-	newNode.activeEffectImage = self.tree.spriteMap[newNode.icon]
-	self:NodeAdditionOrReplacementFromString(newNode, option.stats[1], true)
+	self:ReplaceNode(newNode, option)
 	
 	self.hashOverrides[nodeId] = newNode
 end

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -608,6 +608,10 @@ function PassiveTreeClass:ProcessNode(node)
 	-- if this node isSwtichable then parse also subnodes
 	if node.isSwitchable or node.isAttribute then
 		for class, switchNode in pairs(node.options) do
+			setmetatable(switchNode, { __index = node })
+			if node.isAttribute then
+				switchNode.id = node.id
+			end
 			switchNode.dn = switchNode.name
 			switchNode.sd = switchNode.stats
 			switchNode.sprites = self.spriteMap[switchNode.icon]


### PR DESCRIPTION
this PR Enabled Switchable nodes base on class selected.

Also fix a bug when you create a new Tree, select some attributes node, save and then reload, the nodes wasnt selected from xml

![image](https://github.com/user-attachments/assets/f79553a9-39da-4803-962b-4fda3d8becbe)
![image](https://github.com/user-attachments/assets/be5aa8c8-4c1f-4191-b6f7-f850149bf7d3)
![image](https://github.com/user-attachments/assets/eac2f36f-c250-4dbc-b127-9566a896aafa)
