### PR TITLE
Update resources and defences conversions

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2252,8 +2252,8 @@ c["Charms use no Charges"]={{[1]={flags=0,keywordFlags=0,name="CharmsUseNoCharge
 c["Cold Damage from Hits Contributes to Ignite Chance and Magnitude instead of Chill Magnitude"]={nil,"Cold Damage from Hits Contributes to Ignite Chance and Magnitude instead of Chill Magnitude "}
 c["Cold Damage from Hits Contributes to Ignite Chance and Magnitude instead of Chill Magnitude Lightning Damage from Hits Contributes to Freeze Buildup instead of Shock Chance"]={nil,"Cold Damage from Hits Contributes to Ignite Chance and Magnitude instead of Chill Magnitude Lightning Damage from Hits Contributes to Freeze Buildup instead of Shock Chance "}
 c["Cold Exposure you inflict lowers Total Cold Resistance by an extra 5%"]={nil,"Cold Exposure you inflict lowers Total Cold Resistance by an extra 5% "}
-c["Converts all Energy Shield to Mana"]={nil,"Converts all Energy Shield to Mana "}
-c["Converts all Evasion Rating to Armour"]={nil,"Converts all Evasion Rating to Armour "}
+c["Converts all Energy Shield to Mana"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldConvertToMana",type="BASE",value=100}},nil}
+c["Converts all Evasion Rating to Armour"]={{[1]={flags=0,keywordFlags=0,name="IronReflexes",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="EvasionConvertToArmour",type="BASE",value=100}},nil}
 c["Corpses in your Presence Explode when you Warcry,"]={nil,"Corpses in your Presence Explode when you Warcry, "}
 c["Corpses in your Presence Explode when you Warcry, dealing 10% of their Life as Physical Damage"]={nil,"Corpses in your Presence Explode when you Warcry, dealing 10% of their Life as Physical Damage "}
 c["Corpses in your Presence Explode when you Warcry, dealing 25% of their Life as Physical Damage"]={nil,"Corpses in your Presence Explode when you Warcry, dealing 25% of their Life as Physical Damage "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -78,70 +78,6 @@ local function mergeKeystones(env)
 	end
 end
 
-function doActorLifeManaSpirit(actor)
-	local modDB = actor.modDB
-	local output = actor.output
-	local breakdown = actor.breakdown
-	local condList = modDB.conditions
-
-	local lowLifePerc = modDB:Sum("BASE", nil, "LowLifePercentage")
-	output.LowLifePercentage = 100.0 * (lowLifePerc > 0 and lowLifePerc or data.misc.LowPoolThreshold)
-	local fullLifePerc = modDB:Sum("BASE", nil, "FullLifePercentage")
-	output.FullLifePercentage = 100.0 * (fullLifePerc > 0 and fullLifePerc or 1.0)
-
-	output.ChaosInoculation = modDB:Flag(nil, "ChaosInoculation")
-	-- Life/mana pools
-	if output.ChaosInoculation then
-		output.Life = 1
-		condList["FullLife"] = true
-	else
-		local base = modDB:Sum("BASE", nil, "Life")
-		local inc = modDB:Sum("INC", nil, "Life")
-		local more = modDB:More(nil, "Life")
-		local conv = modDB:Sum("BASE", nil, "LifeConvertToEnergyShield")
-		output.Life = m_max(round(base * (1 + inc/100) * more * (1 - conv/100)), 1)
-		if breakdown then
-			if inc ~= 0 or more ~= 1 or conv ~= 0 then
-				breakdown.Life = { }
-				breakdown.Life[1] = s_format("%g ^8(base)", base)
-				if inc ~= 0 then
-					t_insert(breakdown.Life, s_format("x %.2f ^8(increased/reduced)", 1 + inc/100))
-				end
-				if more ~= 1 then
-					t_insert(breakdown.Life, s_format("x %.2f ^8(more/less)", more))
-				end
-				if conv ~= 0 then
-					t_insert(breakdown.Life, s_format("x %.2f ^8(converted to Energy Shield)", 1 - conv/100))
-				end
-				t_insert(breakdown.Life, s_format("= %g", output.Life))
-			end
-		end
-	end
-	local manaConv = modDB:Sum("BASE", nil, "ManaConvertToArmour")
-	output.Mana = round(calcLib.val(modDB, "Mana") * (1 - manaConv / 100))
-	local base = modDB:Sum("BASE", nil, "Mana")
-	local inc = modDB:Sum("INC", nil, "Mana")
-	local more = modDB:More(nil, "Mana")
-	if breakdown then
-		if inc ~= 0 or more ~= 1 or manaConv ~= 0 then
-			breakdown.Mana = { }
-			breakdown.Mana[1] = s_format("%g ^8(base)", base)
-			if inc ~= 0 then
-				t_insert(breakdown.Mana, s_format("x %.2f ^8(increased/reduced)", 1 + inc/100))
-			end
-			if more ~= 1 then
-				t_insert(breakdown.Mana, s_format("x %.2f ^8(more/less)", more))
-			end
-			if manaConv ~= 0 then
-				t_insert(breakdown.Mana, s_format("x %.2f ^8(converted to Armour)", 1 - manaConv/100))
-			end
-			t_insert(breakdown.Mana, s_format("= %g", output.Mana))
-		end
-	end
-	output.LowestOfMaximumLifeAndMaximumMana = m_min(output.Life, output.Mana)
-	output.Spirit = modDB:Sum("BASE", nil, "Spirit")
-end
-
 -- Calculate attributes, and set conditions
 ---@param env table
 ---@param actor table
@@ -376,42 +312,6 @@ local function doActorAttribsConditions(env, actor)
 			end
 		end
 	end
-
-	doActorLifeManaSpirit(actor)
-end
-
--- Calculate life/mana reservation
----@param actor table
-function doActorLifeManaSpiritReservation(actor)
-	local modDB = actor.modDB
-	local output = actor.output
-	local condList = modDB.conditions
-
-	for _, pool in pairs({"Life", "Mana", "Spirit"}) do
-		local max = output[pool]
-		local reserved
-		if max > 0 then
-			local lowPerc = modDB:Sum("BASE", nil, "Low" .. pool .. "Percentage")
-			reserved = (actor["reserved_"..pool.."Base"] or 0) + m_ceil(max * (actor["reserved_"..pool.."Percent"] or 0) / 100)
-			uncancellableReservation = actor["uncancellable_"..pool.."Reservation"] or 0
-			output[pool.."Reserved"] = m_min(reserved, max)
-			output[pool.."ReservedPercent"] = m_min(reserved / max * 100, 100)
-			output[pool.."Unreserved"] = max - reserved
-			output[pool.."UnreservedPercent"] = (max - reserved) / max * 100
-			output[pool.."UncancellableReservation"] = m_min(uncancellableReservation, 0)
-			output[pool.."CancellableReservation"] = 100 - uncancellableReservation
-			if (max - reserved) / max <= (lowPerc > 0 and lowPerc or data.misc.LowPoolThreshold) then
-				condList["Low"..pool] = true
-			end
-		else
-			reserved = 0
-		end
-		for _, value in ipairs(modDB:List(nil, "GrantReserved"..pool.."AsAura")) do
-			local auraMod = copyTable(value.mod)
-			auraMod.value = m_floor(auraMod.value * m_min(reserved, max))
-			modDB:NewMod("ExtraAura", "LIST", { mod = auraMod })
-		end
-	end
 end
 
 -- Helper function to determine curse priority when processing curses beyond the curse limit
@@ -518,14 +418,6 @@ local function doActorMisc(env, actor)
 			modDB:NewMod("Speed", "INC", effect, "Onslaught", ModFlag.Attack)
 			modDB:NewMod("Speed", "INC", effect, "Onslaught", ModFlag.Cast)
 			modDB:NewMod("MovementSpeed", "INC", effect, "Onslaught")
-		end
-		if modDB.conditions["AffectedByArcaneSurge"] or modDB:Flag(nil, "Condition:ArcaneSurge") then
-			modDB.conditions["AffectedByArcaneSurge"] = true
-			local effect = 1 + modDB:Sum("INC", nil, "ArcaneSurgeEffect", "BuffEffectOnSelf") / 100
-			modDB:NewMod("ManaRegen", "MORE", (modDB:Max(nil, "ArcaneSurgeManaRegen") or 20) * effect, "Arcane Surge")
-			modDB:NewMod("Speed", "MORE", (modDB:Max(nil, "ArcaneSurgeCastSpeed") or 10) * effect, "Arcane Surge", ModFlag.Cast)
-			local arcaneSurgeDamage = modDB:Max(nil, "ArcaneSurgeDamage") or 0
-			if arcaneSurgeDamage ~= 0 then modDB:NewMod("Damage", "MORE", arcaneSurgeDamage * effect, "Arcane Surge", ModFlag.Spell) end
 		end
 		if modDB:Flag(nil, "Fanaticism") and actor.mainSkill and actor.mainSkill.skillFlags.selfCast then
 			local effect = m_floor(75 * (1 + modDB:Sum("INC", nil, "BuffEffectOnSelf") / 100))
@@ -864,12 +756,9 @@ end
 -- 3. Initialises the main skill's minion, if present
 -- 4. Merges flask effects
 -- 5. Sets conditions and calculates attributes (doActorAttribsConditions)
--- 6. Calculates life and mana (doActorLifeManaSpirit)
--- 6. Calculates reservations
--- 7. Sets life/mana reservation (doActorLifeManaSpiritReservation)
--- 8. Processes buffs and debuffs
--- 9. Processes charges and misc buffs (doActorCharges, doActorMisc)
--- 10. Calculates defence and offence stats (calcs.defence, calcs.offence)
+-- 6. Processes buffs and debuffs
+-- 7. Processes charges and misc buffs (doActorCharges, doActorMisc)
+-- 8. Calculates defence and offence stats (calcs.defence, calcs.offence)
 function calcs.perform(env, skipEHP)
 	local modDB = env.modDB
 	local enemyDB = env.enemyDB
@@ -1433,9 +1322,8 @@ function calcs.perform(env, skipEHP)
 		mergeKeystones(env)
 	end
 
-	-- Calculate attributes and life/mana pools
+	-- Calculate attributes
 	doActorAttribsConditions(env, env.player)
-	doActorLifeManaSpirit(env.player)
 	if env.minion then
 		for _, value in ipairs(env.player.mainSkill.skillModList:List(env.player.mainSkill.skillCfg, "MinionModifier")) do
 			if not value.type or env.minion.type == value.type then
@@ -1449,117 +1337,6 @@ function calcs.perform(env, skipEHP)
 		end
 		doActorAttribsConditions(env, env.minion)
 	end
-
-	-- Calculate skill life and mana reservations
-	env.player.reserved_LifeBase = 0
-	env.player.reserved_LifePercent = modDB:Sum("BASE", nil, "ExtraLifeReserved")
-	env.player.reserved_ManaBase = 0
-	env.player.reserved_ManaPercent = 0
-	env.player.uncancellable_LifeReservation = modDB:Sum("BASE", nil, "ExtraLifeReserved")
-	env.player.uncancellable_ManaReservation = modDB:Sum("BASE", nil, "ExtraManaReserved")
-	if breakdown then
-		breakdown.LifeReserved = { reservations = { } }
-		breakdown.ManaReserved = { reservations = { } }
-	end
-	for _, activeSkill in ipairs(env.player.activeSkillList) do
-		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
-			local skillModList = activeSkill.skillModList
-			local skillCfg = activeSkill.skillCfg
-			local mult = floor(skillModList:More(skillCfg, "SupportManaMultiplier"), 4)
-			local pool = { ["Mana"] = { }, ["Life"] = { } }
-			pool.Mana.baseFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
-			if skillModList:Flag(skillCfg, "ManaCostGainAsReservation") and activeSkill.activeEffect.grantedEffectLevel.cost then
-				pool.Mana.baseFlat = skillModList:Sum("BASE", skillCfg, "ManaCostBase") + (activeSkill.activeEffect.grantedEffectLevel.cost.Mana or 0)
-			end
-			pool.Mana.basePercent = activeSkill.skillData.manaReservationPercent or activeSkill.activeEffect.grantedEffectLevel.manaReservationPercent or 0
-			pool.Life.baseFlat = activeSkill.skillData.lifeReservationFlat or activeSkill.activeEffect.grantedEffectLevel.lifeReservationFlat or 0
-			if skillModList:Flag(skillCfg, "LifeCostGainAsReservation") and activeSkill.activeEffect.grantedEffectLevel.cost then
-				pool.Life.baseFlat = skillModList:Sum("BASE", skillCfg, "LifeCostBase") + (activeSkill.activeEffect.grantedEffectLevel.cost.Life or 0)
-			end
-			pool.Life.basePercent = activeSkill.skillData.lifeReservationPercent or activeSkill.activeEffect.grantedEffectLevel.lifeReservationPercent or 0
-			if skillModList:Flag(skillCfg, "BloodMagicReserved") then
-				pool.Life.baseFlat = pool.Life.baseFlat + pool.Mana.baseFlat
-				pool.Mana.baseFlat = 0
-				activeSkill.skillData["LifeReservationFlatForced"] = activeSkill.skillData["ManaReservationFlatForced"]
-				activeSkill.skillData["ManaReservationFlatForced"] = nil
-				pool.Life.basePercent = pool.Life.basePercent + pool.Mana.basePercent
-				pool.Mana.basePercent = 0
-				activeSkill.skillData["LifeReservationPercentForced"] = activeSkill.skillData["ManaReservationPercentForced"]
-				activeSkill.skillData["ManaReservationPercentForced"] = nil
-			end
-			for name, values in pairs(pool) do
-				values.more = skillModList:More(skillCfg, name.."Reserved", "Reserved")
-				values.inc = skillModList:Sum("INC", skillCfg, name.."Reserved", "Reserved")
-				values.efficiency = m_max(skillModList:Sum("INC", skillCfg, name.."ReservationEfficiency", "ReservationEfficiency"), -100)
-				-- used for Arcane Cloak calculations in ModStore.GetStat
-				env.player[name.."Efficiency"] = values.efficiency
-				if activeSkill.skillData[name.."ReservationFlatForced"] then
-					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
-				else
-					local baseFlatVal = m_floor(values.baseFlat * mult)
-					values.reservedFlat = 0
-					if values.more > 0 and values.inc > -100 and baseFlatVal ~= 0 then
-						values.reservedFlat = m_max(round(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
-					end
-				end
-				if activeSkill.skillData[name.."ReservationPercentForced"] then
-					values.reservedPercent = activeSkill.skillData[name.."ReservationPercentForced"]
-				else
-					local basePercentVal = values.basePercent * mult
-					values.reservedPercent = 0
-					if values.more > 0 and values.inc > -100 and basePercentVal ~= 0 then
-						values.reservedPercent = m_max(round(basePercentVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 2), 0)
-					end
-				end
-				if activeSkill.activeMineCount then
-					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount
-					values.reservedPercent = values.reservedPercent * activeSkill.activeMineCount
-				end
-				-- Blood Sacrament increases reservation per stage channelled
-				if activeSkill.skillCfg.skillName == "Blood Sacrament" and activeSkill.activeStageCount then
-					values.reservedFlat = values.reservedFlat * (activeSkill.activeStageCount + 1)
-					values.reservedPercent = values.reservedPercent * (activeSkill.activeStageCount + 1)
-				end
-				if values.reservedFlat ~= 0 then
-					activeSkill.skillData[name.."ReservedBase"] = values.reservedFlat
-					env.player["reserved_"..name.."Base"] = env.player["reserved_"..name.."Base"] + values.reservedFlat
-					if breakdown then
-						t_insert(breakdown[name.."Reserved"].reservations, {
-							skillName = activeSkill.activeEffect.grantedEffect.name,
-							base = values.baseFlat,
-							mult = mult ~= 1 and ("x "..mult),
-							more = values.more ~= 1 and ("x "..values.more),
-							inc = values.inc ~= 0 and ("x "..(1 + values.inc / 100)),
-							efficiency = values.efficiency ~= 0 and ("x " .. round(100 / (100 + values.efficiency), 4)),
-							total = values.reservedFlat,
-						})
-					end
-				end
-				if values.reservedPercent ~= 0 then
-					activeSkill.skillData[name.."ReservedPercent"] = values.reservedPercent
-					activeSkill.skillData[name.."ReservedBase"] = (values.reservedFlat or 0) + m_ceil(output[name] * values.reservedPercent / 100)
-					env.player["reserved_"..name.."Percent"] = env.player["reserved_"..name.."Percent"] + values.reservedPercent
-					if breakdown then
-						t_insert(breakdown[name.."Reserved"].reservations, {
-							skillName = activeSkill.activeEffect.grantedEffect.name,
-							base = values.basePercent .. "%",
-							mult = mult ~= 1 and ("x "..mult),
-							more = values.more ~= 1 and ("x "..values.more),
-							inc = values.inc ~= 0 and ("x "..(1 + values.inc / 100)),
-							efficiency = values.efficiency ~= 0 and ("x " .. round(100 / (100 + values.efficiency), 4)),
-							total = values.reservedPercent .. "%",
-						})
-					end
-				end
-				if skillModList:Flag(skillCfg, "HasUncancellableReservation") then
-					env.player["uncancellable_"..name.."Reservation"] = env.player["uncancellable_"..name.."Reservation"] + values.reservedPercent
-				end
-			end
-		end
-	end
-
-	-- Set the life/mana reservations
-	doActorLifeManaSpiritReservation(env.player)
 
 	-- Process attribute requirements
 	do
@@ -3152,10 +2929,6 @@ function calcs.perform(env, skipEHP)
 			end
 		end
 	end
-
-	-- We need to recalculate Spirit, Some Passive tree work with defences stats (Evasion, Energy Shield) from items
-	doActorLifeManaSpirit(env.player)
-	doActorLifeManaSpiritReservation(env.player)
 
 	cacheData(cacheSkillUUID(env.player.mainSkill, env), env)
 end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2013,7 +2013,7 @@ local specialModList = {
 	["cannot deal critical hits with attacks"] = { flag("NeverCrit", nil, ModFlag.Attack), flag("Condition:NeverCrit", nil, ModFlag.Attack) },
 	["no critical damage bonus"] = { flag("NoCritMultiplier") },
 	["ailments never count as being from critical hits"] = { flag("AilmentsAreNeverFromCrit") },
-	["converts all evasion rating to armour%. dexterity provides no bonus to evasion rating"] = { flag("NoDexBonusToEvasion"), flag("IronReflexes") },
+	["converts all evasion rating to armour"] = { flag("IronReflexes"), mod("EvasionConvertToArmour", "BASE", 100) },
 	["30%% chance to dodge attack hits%. 50%% less armour, 30%% less energy shield, 30%% less chance to block spell and attack damage"] = {
 		mod("AttackDodgeChance", "BASE", 30),
 		mod("Armour", "MORE", -50),
@@ -2058,6 +2058,7 @@ local specialModList = {
 	["removes all mana%. spend life instead of mana for skills"] = { mod("Mana", "MORE", -100), flag("CostLifeInsteadOfMana") },
 	["removes all mana"] = { mod("Mana", "MORE", -100) },
 	["removes all energy shield"] = { mod("EnergyShield", "MORE", -100) },
+	["converts all energy shield to mana"] = { mod("EnergyShieldConvertToMana", "BASE", 100) },
 	["skills cost life instead of mana"] = { flag("CostLifeInsteadOfMana") },
 	["skills reserve life instead of mana"] = { flag("BloodMagicReserved") },
 	["non%-aura skills cost no mana or life while focus?sed"] = {
@@ -2182,9 +2183,6 @@ local specialModList = {
 	["gain additional elemental damage reduction equal to half your chaos resistance"] = {
 		mod("ElementalDamageReduction", "BASE", 1, { type = "PerStat", stat = "ChaosResist", div = 2 })
 	},
-	["(%d+)%% of maximum mana is converted to twice that much armour"] = function(num) return {
-		mod("ManaConvertToArmour", "BASE", num),
-	} end,
 	["life recovery from flasks also applies to energy shield"] = { flag("LifeFlaskAppliesToEnergyShield") },
 	["life recovery from flasks applies to energy shield instead"] = { flag("LifeFlaskAppliesToEnergyShield"), flag("LifeFlaskDoesNotApply") },
 	["non%-instant mana recovery from flasks is also recovered as life"] = { flag("ManaFlaskAppliesToLife") },


### PR DESCRIPTION
I ended up moving most of the related calculations to `CalcDefence`. This seems to work better and makes a few recalculations unnecessary.
I'm not sure if resources (life/mana) and defences should have tighter relationship and common calculations.
I joined them for the purpose of conversions but in the future it might be necessary to separate some parts and run them in different order.
Or maybe the better approach would be to do everything at the same time but in stages e.g. `base pools > conversions > multipliers and finalization`. It wasn't really possible before because life/mana and defences were done in separate files.

Possibly problematic:
- Ward - We don't have info if and how it's going to come back so I tried not to mess with it too much.
- "Gain x per y reserved" types of effects won't work. I believe we don't have any currently and I don't know how they interact with conversions.
- Breakdowns are not ideal. Life/mana and defences use different styles and they display sources with no indication of conversion _from_ even when 100% is converted. This may be desired but is not very clear.
