### PR TITLE
Handle corrupted saves and re export on datSource creation

### DIFF
--- a/src/Export/Classes/GGPKSourceListControl.lua
+++ b/src/Export/Classes/GGPKSourceListControl.lua
@@ -43,7 +43,7 @@ function GGPKSourceListClass:EditDATSource(datSource, newSource)
 		controls.save.enabled = (controls.dat.buf:match("%S") or controls.ggpk.buf:match("%S")) and controls.label.buf:match("%S") and buf:match("%S")
 	end)
 	controls.save = new("ButtonControl", {"TOP",controls.spec,"TOP"}, {-45, 22, 80, 20}, "Save", function()
-		local reload = datSource.label == main.datSource.label
+		local reload = datSource.label == (main.datSource and main.datSource.label)
 		datSource.label = controls.label.buf
 		datSource.ggpkPath = controls.ggpk.buf or ""
 		datSource.datFilePath = controls.dat.buf or ""

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -337,11 +337,13 @@ end
 
 function main:LoadDatSource(value)
 	self.leagueLabel = nil
+	local reExportState = self.reExportGGPKData
+	self.reExportGGPKData = true
+	self.datSource = value
 	local out = io.open(self.datSource.spec..(self.datSource.spec:match("%.lua$") and "" or ".lua"), "w")
 	out:write('return ')
 	writeLuaTable(out, self.datSpecs, 1)
 	out:close()
-	self.datSource = value
 	self.datSpecs = LoadModule(self.datSource.spec)
 	self:InitGGPK()
 	if USE_DAT64 then
@@ -352,6 +354,7 @@ function main:LoadDatSource(value)
 	if self.datFileByName["leaguenames"] then
 		self.leagueLabel = self.datFileByName["leaguenames"]:ReadValueText({ type = "String" }, self.datFileByName["leaguenames"].rows[2] + 8)
 	end
+	self.reExportGGPKData = reExportState
 end
 
 function main:OpenPathPopup()
@@ -523,7 +526,7 @@ function main:LoadSettings()
 	end
 	for _, node in ipairs(setXML[1]) do
 		if type(node) == "table" then
-			if node.elem == "DatSource" then
+			if node.elem == "DatSource" and (node.attrib.ggpkPath or node.attrib.path) and node.attrib.datFilePath then
 				self.datSource = self.datSource or { }
 				self.datSource.ggpkPath = node.attrib.ggpkPath or node.attrib.path
 				self.datSource.datFilePath = node.attrib.datFilePath
@@ -533,18 +536,19 @@ function main:LoadSettings()
 			if node.elem == "DatSources" then
 				self.datSources = self.datSources or { }
 				for _, child in ipairs(node) do
-					t_insert(self.datSources, { ggpkPath = child.attrib.ggpkPath, datFilePath = child.attrib.datFilePath, label = child.attrib.label, spec = child.attrib.spec })
+					if (child.attrib.ggpkPath or child.attrib.path) and child.attrib.datFilePath then
+						t_insert(self.datSources, { ggpkPath = child.attrib.ggpkPath, datFilePath = child.attrib.datFilePath, label = child.attrib.label, spec = child.attrib.spec })
+					end
 				end
 			end
 		end
 	end
-	if type(self.datSources) ~= "table" then
-		self.datSources = { }
-	end
-	if not next(self.datSources) then
+	if self.datSources and not next(self.datSources) and self.datSource then
 		t_insert(self.datSources, self.datSource)
 	end
-	self.datSource = self.datSource or self.datSources[1]
+	if not self.datSoruce and self.datSources then
+		self.datSource = self.datSources[1]
+	end
 end
 
 function main:SaveSettings()


### PR DESCRIPTION
### Description of the problem being solved:
When creating a new save file and not having one datSource an error is thrown at 
```lua
	local reload = datSource.label == main.datSource.label
```
As main.datSource is nil due to there being no value. This leads to Setting corruption. This fixes that, adds proper checks for corrupted settings incase someone is already running into these issues and will automatically run rexport on LoadDatSource() called for when source is updated.

Documentation should be added or at least clearly conveyed for https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/50 as I wasn't aware of this and was confused why it wasn't exporting which was confounded by the issue fixed here.