### PR TITLE
Improve UI for corrupted implicit rolls

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2356,9 +2356,9 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		end
 		controls.source.shown = true
 		controls.sourceLabel.shown = true
-		main.popups[1].height = 103 + 18 * enchantNum
-		controls.close.y = 73 + 18 * enchantNum
-		controls.save.y = 73 + 18 * enchantNum
+		main.popups[1].height = 103 + 20 * enchantNum
+		controls.close.y = 73 + 20 * enchantNum
+		controls.save.y = 73 + 20 * enchantNum
 	end)
 	controls.enchants.shown = function ()
 		return self.displayItem.rarity == "UNIQUE"
@@ -2413,9 +2413,9 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 			end
 			controls["enchant"..i]:SetSel(1)
 		end
-		main.popups[1].height = 103 + 18 * enchantNum
-		controls.close.y = 73 + 18 * enchantNum
-		controls.save.y = 73 + 18 * enchantNum
+		main.popups[1].height = 103 + 20 * enchantNum
+		controls.close.y = 73 + 20 * enchantNum
+		controls.save.y = 73 + 20 * enchantNum
 	end)
 	for i = 1, 8 do
 		if i == 1 then
@@ -2478,7 +2478,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 	controls.close = new("ButtonControl", nil, {45, 69 + enchantNum * 20, 80, 20}, "Cancel", function()
 		main:ClosePopup()
 	end)
-	main:OpenPopup(620, 99 + enchantNum * 20, "Corrupted Item", controls)
+	main:OpenPopup(620, 103 + enchantNum * 20, "Corrupted Item", controls)
 end
 
 -- Opens the custom modifier popup


### PR DESCRIPTION
Hide variants
Increase width
Right Aligned
Fixed incorrect offset (ranges and enchants)

### Before screenshot:
![image](https://github.com/user-attachments/assets/a878ad9b-f1f7-42a1-8912-8e3615642a33)
![image](https://github.com/user-attachments/assets/3aa11b44-831b-476c-aa84-559a1c049197)
![image](https://github.com/user-attachments/assets/abc15226-33c2-44ce-a6a8-9136ebf1bb95)
![image](https://github.com/user-attachments/assets/5f47e6b6-eb8a-4fd8-93fe-ec44433b237e)

### After screenshot:
![image](https://github.com/user-attachments/assets/ae0ffcf0-6f54-4212-b7c1-b2fbfffb4596)
![image](https://github.com/user-attachments/assets/c1dade5d-7663-47e0-9059-fd04392214ba)
![image](https://github.com/user-attachments/assets/629063a2-a7f6-47b3-8847-72c6961da112)
![image](https://github.com/user-attachments/assets/3cc6039e-f9b8-4af4-9e9e-939bddd58818)
