### PR TITLE
Fix decimal antonym

### DIFF
--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -78,7 +78,7 @@ function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 		if sign == "-" then value = value * -1 end
 		return (sign == "+" and value > 0 ) and sign..tostring(value) or tostring(value)
 	end)
-	:gsub("%-(%d+%%) (%a+)", antonymFunc)
+	:gsub("%-(%d+%.?%d*%%) (%a+)", antonymFunc)
 	:gsub("(%-?%d+%.?%d*)", function(value)
 		t_insert(values, value)
 		return "#"


### PR DESCRIPTION
### Description of the problem being solved:
If the range value was computed such that it had a decimal it would break.

### Link to a build that showcases this PR:

### Before screenshot:
![image](https://github.com/user-attachments/assets/7607e027-b801-4a5f-b68e-225ebed890a7)

### After screenshot:
![image](https://github.com/user-attachments/assets/4d0b3ad6-3703-4b07-974d-96ef4dbcef66)
