### PR TITLE
Fix gems with more than one GrantEffect

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -394,7 +394,7 @@ end
 
 function CalcsTabClass:CheckFlag(obj)
 	local actor = self.input.showMinion and self.calcsEnv.minion or self.calcsEnv.player
-	local skillFlags = actor.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags
+	local skillFlags = actor.mainSkill.activeEffect.statSetCalcs.skillFlags
 	if obj.flag and not skillFlags[obj.flag] then
 		return
 	end
@@ -405,7 +405,7 @@ function CalcsTabClass:CheckFlag(obj)
 			end
 		end
 	end
-	if obj.playerFlag and not self.calcsEnv.player.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags[obj.playerFlag] then
+	if obj.playerFlag and not self.calcsEnv.player.mainSkill.activeEffect.statSetCalcs.skillFlags[obj.playerFlag] then
 		return
 	end
 	if obj.notFlag and skillFlags[obj.notFlag] then

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -449,7 +449,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				t_insert(shownFuncs, listOrSingleIfOption(varData.ifFlag, function(ifOption)
 					local skillModList = self.build.calcsTab.mainEnv.player.mainSkill.skillModList
 					-- only checking flags of skill in main env. rework may be required
-					local skillFlags = self.build.calcsTab.mainEnv.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags
+					local skillFlags = self.build.calcsTab.mainEnv.player.mainSkill.activeEffect.statSet.skillFlags
 					-- Check both the skill mods for flags and flags that are set via calcPerform
 					return skillFlags[ifOption] or skillModList:Flag(nil, ifOption)
 				end))
@@ -499,7 +499,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				t_insert(shownFuncs, listOrSingleIfOption(varData.ifSkillFlag, function(ifOption)
 					for _, activeSkill in ipairs(self.build.calcsTab.mainEnv.player.activeSkillList) do
 						-- only checking flags of skill in main env. rework may be required
-						if activeSkill.activeEffect.srcInstance.statSet.skillFlags[ifOption] then
+						if activeSkill.activeEffect.statSet.skillFlags[ifOption] then
 							return true
 						end
 					end

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -239,7 +239,7 @@ function ModStoreClass:GetStat(stat, cfg)
 		if totalMana == 0 then return 0 else
 			for _, activeSkill in ipairs(self.actor.activeSkillList) do
 				-- currently only checks main statset for skill flags. rework if required
-				if (activeSkill.skillTypes[SkillType.Aura] and not activeSkill.activeEffect.srcInstance.statSet.skillFlags.disable and activeSkill.buffList and activeSkill.buffList[1] and activeSkill.buffList[1].name == cfg.skillName) then
+				if (activeSkill.skillTypes[SkillType.Aura] and not activeSkill.activeEffect.statSet.skillFlags.disable and activeSkill.buffList and activeSkill.buffList[1] and activeSkill.buffList[1].name == cfg.skillName) then
 					local manaBase = activeSkill.skillData["ManaReservedBase"] or 0
 					reservedPercentMana = manaBase / totalMana * 100
 					break

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -948,7 +948,7 @@ function buildMode:Save(xml)
 	end
 	local addedStatNames = { }
 	for index, statData in ipairs(self.displayStats) do
-		if not statData.flag or self.calcsTab.mainEnv.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags[statData.flag] then
+		if not statData.flag or self.calcsTab.mainEnv.player.mainSkill.activeEffect.statSet.skillFlags[statData.flag] then
 			local statName = statData.stat and statData.stat..(statData.childStat or "")
 			if statName and not addedStatNames[statName] then
 				if statData.stat == "SkillDPS" then
@@ -1406,15 +1406,15 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 					end
 				end
 				
-				if activeSkill.activeEffect.srcInstance.statSet.skillFlags.mine then
+				if activeSkill.activeEffect.statSet.skillFlags.mine then
 					controls.mainSkillMineCount.shown = true
 					controls.mainSkillMineCount.buf = tostring(activeEffect.srcInstance["skillMineCount"..suffix] or "")
 				end
-				if activeSkill.activeEffect.srcInstance.statSet.skillFlags.multiStage and not (activeEffect.grantedEffect.parts and #activeEffect.grantedEffect.parts > 1) then
+				if activeSkill.activeEffect.statSet.skillFlags.multiStage and not (activeEffect.grantedEffect.parts and #activeEffect.grantedEffect.parts > 1) then
 					controls.mainSkillStageCount.shown = true
 					controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeSkill.skillData.stagesMin or 1)
 				end
-				if not activeSkill.activeEffect.srcInstance.statSet.skillFlags.disable and (activeEffect.grantedEffect.minionList or (activeSkill.minionList and activeSkill.minionList[1])) then
+				if not activeSkill.activeEffect.statSet.skillFlags.disable and (activeEffect.grantedEffect.minionList or (activeSkill.minionList and activeSkill.minionList[1])) then
 					wipeTable(controls.mainSkillMinion.list)
 					if activeEffect.grantedEffect.minionHasItemSet then
 						for _, itemSetId in ipairs(self.itemsTab.itemSetOrderList) do
@@ -1488,7 +1488,7 @@ end
 function buildMode:AddDisplayStatList(statList, actor)
 	local statBoxList = self.controls.statBox.list
 	for index, statData in ipairs(statList) do
-		if not statData.flag or actor.mainSkill.activeEffect.srcInstance.statSet.skillFlags[statData.flag] then
+		if not statData.flag or actor.mainSkill.activeEffect.statSet.skillFlags[statData.flag] then
 			local labelColor = "^7"
 			if statData.color then
 				labelColor = statData.color
@@ -1647,7 +1647,7 @@ function buildMode:RefreshStatList()
 		t_insert(statBoxList, { height = 10 })
 		t_insert(statBoxList, { height = 18, "^7Player:" })
 	end
-	if self.calcsTab.mainEnv.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags.disable then
+	if self.calcsTab.mainEnv.player.mainSkill.activeEffect.statSet.skillFlags.disable then
 		t_insert(statBoxList, { height = 16, "^7Skill disabled:" })
 		t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, self.calcsTab.mainEnv.player.mainSkill.disableReason })
 	end
@@ -1658,7 +1658,7 @@ end
 function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compareOutput, header, nodeCount)
 	local count = 0
 	for _, statData in ipairs(statList) do
-		if statData.stat and (not statData.flag or actor.mainSkill.activeEffect.srcInstance.statSet.skillFlags[statData.flag]) and not statData.childStat and statData.stat ~= "SkillDPS" then
+		if statData.stat and (not statData.flag or actor.mainSkill.activeEffect.statSet.skillFlags[statData.flag]) and not statData.childStat and statData.stat ~= "SkillDPS" then
 			local statVal1 = compareOutput[statData.stat] or 0
 			local statVal2 = baseOutput[statData.stat] or 0
 			local diff = statVal1 - statVal2

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -112,13 +112,13 @@ function calcs.createActiveSkill(activeEffect, supportList, env, actor, socketGr
 	if env.mode == "CALCS" then 
 		statSet = activeEffect.grantedEffect.statSets[activeEffect.srcInstance.statSetCalcs.index or 1]
 		skillFlags = statSet and copyTable(statSet.baseFlags) or { disable = true }
-		activeEffect.srcInstance.statSetCalcs.statSet = statSet
-		activeEffect.srcInstance.statSetCalcs.skillFlags = skillFlags
+		activeEffect.statSetCalcs.statSet = statSet
+		activeEffect.statSetCalcs.skillFlags = skillFlags
 	else
 		statSet = activeEffect.grantedEffect.statSets[activeEffect.srcInstance.statSet.index or 1]
 		skillFlags = statSet and copyTable(statSet.baseFlags) or { disable = true }
-		activeEffect.srcInstance.statSet.statSet = statSet
-		activeEffect.srcInstance.statSet.skillFlags = skillFlags
+		activeEffect.statSet.statSet = statSet
+		activeEffect.statSet.skillFlags = skillFlags
 	end
 	skillFlags.hit = skillFlags.hit or activeSkill.skillTypes[SkillType.Attack] or activeSkill.skillTypes[SkillType.Damage] or activeSkill.skillTypes[SkillType.Projectile]
 
@@ -238,11 +238,11 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	local activeGrantedEffect = activeEffect.grantedEffect
 	local activeStatSet, skillFlags
 	if env.mode == "CALCS" then
-		activeStatSet = activeEffect.srcInstance.statSetCalcs.statSet
-		skillFlags = activeEffect.srcInstance.statSetCalcs.skillFlags
+		activeStatSet = activeEffect.statSetCalcs.statSet
+		skillFlags = activeEffect.statSetCalcs.skillFlags
 	else
-		activeStatSet = activeEffect.srcInstance.statSet.statSet
-		skillFlags = activeEffect.srcInstance.statSet.skillFlags
+		activeStatSet = activeEffect.statSet.statSet
+		skillFlags = activeEffect.statSet.skillFlags
 	end
 	local effectiveRange = 0
 
@@ -867,6 +867,8 @@ function calcs.createMinionSkills(env, activeSkill)
 			grantedEffect = env.data.skills[skillId],
 			level = 1,
 			quality = 0,
+			statSet = { },
+			statSetCalcs = { },
 		}
 		local minionSkillIndex = activeSkill.activeEffect.srcInstance.skillMinionSkill
 		local minionSkillIndexCalcs = activeSkill.activeEffect.srcInstance.skillMinionSkillCalcs
@@ -893,9 +895,9 @@ function calcs.createMinionSkills(env, activeSkill)
 		calcs.buildActiveSkillModList(env, minionSkill)
 		local skillFlags
 		if env.mode == "CALCS" then
-			skillFlags = minionSkill.activeEffect.srcInstance.statSetCalcs.skillFlags
+			skillFlags = minionSkill.activeEffect.statSetCalcs.skillFlags
 		else 
-			skillFlags = minionSkill.activeEffect.srcInstance.statSet.skillFlags
+			skillFlags = minionSkill.activeEffect.statSet.skillFlags
 		end
 		skillFlags.minion = true
 		skillFlags.minionSkill = true

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -327,9 +327,9 @@ function calcs.offence(env, actor, activeSkill)
 	local skillData = activeSkill.skillData
 	local skillFlags
 	if env.mode == "CALCS" then
-		skillFlags = activeSkill.activeEffect.srcInstance.statSetCalcs.skillFlags
+		skillFlags = activeSkill.activeEffect.statSetCalcs.skillFlags
 	else 
-		skillFlags = activeSkill.activeEffect.srcInstance.statSet.skillFlags
+		skillFlags = activeSkill.activeEffect.statSet.skillFlags
 	end
 	local skillCfg = activeSkill.skillCfg
 	if skillData.showAverage then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -179,9 +179,9 @@ local function doActorAttribsConditions(env, actor)
 		end
 		local skillFlags
 		if env.mode == "CALCS" then
-			skillFlags = actor.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags 
+			skillFlags = actor.mainSkill.activeEffect.statSetCalcs.skillFlags
 		else 
-			skillFlags = actor.mainSkill.activeEffect.srcInstance.statSet.skillFlags 
+			skillFlags = actor.mainSkill.activeEffect.statSet.skillFlags
 		end
 		if not actor.mainSkill.skillData.triggered and not skillFlags.trap and not skillFlags.mine and not skillFlags.totem then
 			if skillFlags.attack then
@@ -903,9 +903,9 @@ function calcs.perform(env, skipEHP)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		local skillFlags
 		if env.mode == "CALCS" then
-			skillFlags = activeSkill.activeEffect.srcInstance.statSetCalcs.skillFlags 
+			skillFlags = activeSkill.activeEffect.statSetCalcs.skillFlags
 		else 
-			skillFlags = activeSkill.activeEffect.srcInstance.statSet.skillFlags 
+			skillFlags = activeSkill.activeEffect.statSet.skillFlags
 		end
 		if skillFlags.brand then
 			local attachLimit = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "BrandsAttachedLimit")
@@ -1546,9 +1546,9 @@ function calcs.perform(env, skipEHP)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		local disabledFlag
 		if env.mode == "CALCS" then
-			disabledFlag = activeSkill.activeEffect.srcInstance.statSetCalcs.skillFlags.disable 
+			disabledFlag = activeSkill.activeEffect.statSetCalcs.skillFlags.disable
 		else 
-			disabledFlag = activeSkill.activeEffect.srcInstance.statSet.skillFlags.disable 
+			disabledFlag = activeSkill.activeEffect.statSet.skillFlags.disable
 		end
 		if not disabledFlag and not (env.limitedSkills and env.limitedSkills[cacheSkillUUID(activeSkill, env)]) then
 			if (activeSkill.activeEffect.grantedEffect.name == "Blight" or activeSkill.activeEffect.grantedEffect.name == "Blight of Contagion" or activeSkill.activeEffect.grantedEffect.name == "Blight of Atrophy") and activeSkill.skillPart == 2 then
@@ -1581,9 +1581,9 @@ function calcs.perform(env, skipEHP)
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		local skillFlags
 		if env.mode == "CALCS" then
-			skillFlags = activeSkill.activeEffect.srcInstance.statSetCalcs.skillFlags 
+			skillFlags = activeSkill.activeEffect.statSetCalcs.skillFlags
 		else 
-			skillFlags = activeSkill.activeEffect.srcInstance.statSet.skillFlags 
+			skillFlags = activeSkill.activeEffect.statSet.skillFlags
 		end
 		local skillModList = activeSkill.skillModList
 		local skillCfg = activeSkill.skillCfg
@@ -1777,9 +1777,9 @@ function calcs.perform(env, skipEHP)
 					end
 					local totemFlag
 					if env.mode == "CALCS" then
-						totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags.totem 
+						totemFlag = env.player.mainSkill.activeEffect.statSetCalcs.skillFlags.totem
 					else 
-						totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags.totem 
+						totemFlag = env.player.mainSkill.activeEffect.statSet.skillFlags.totem
 					end
 					if totemFlag and not (modDB:Flag(nil, "SelfAurasCannotAffectAllies") or modDB:Flag(nil, "SelfAuraSkillsCannotAffectAllies")) then
 						activeSkill.totemBuffSkill = true
@@ -2139,9 +2139,9 @@ function calcs.perform(env, skipEHP)
 								buffExports["Aura"][buff.name] = { effectMult = mult, modList = newModList }
 								local totemFlag
 								if env.mode == "CALCS" then
-									totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags.totem 
-								else 
-									totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags.totem 
+									totemFlag = env.player.mainSkill.activeEffect.statSetCalcs.skillFlags.totem
+								else
+									totemFlag = env.player.mainSkill.activeEffect.statSet.skillFlags.totem
 								end
 								if totemFlag and not env.player.mainSkill.skillModList.conditions["AffectedBy"..buff.name:gsub(" ","")] then
 									activeMinionSkill.totemBuffSkill = true
@@ -2638,9 +2638,9 @@ function calcs.perform(env, skipEHP)
 			local totemModBlacklist = value.mod.name and (value.mod.name == "Speed" or value.mod.name == "CritMultiplier" or value.mod.name == "CritChance")
 			local totemFlag
 			if env.mode == "CALCS" then
-				totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags.totem 
+				totemFlag = env.player.mainSkill.activeEffect.statSetCalcs.skillFlags.totem
 			else 
-				totemFlag = env.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags.totem 
+				totemFlag = env.player.mainSkill.activeEffect.statSet.skillFlags.totem
 			end
 			if totemFlag and not totemModBlacklist then
 				local totemMod = copyTable(value.mod)
@@ -2732,9 +2732,9 @@ function calcs.perform(env, skipEHP)
 
 	local hitFlag
 	if env.mode == "CALCS" then
-		hitFlag = env.player.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags.hit 
+		hitFlag = env.player.mainSkill.activeEffect.statSetCalcs.skillFlags.hit
 	else 
-		hitFlag = env.player.mainSkill.activeEffect.srcInstance.statSet.skillFlags.hit
+		hitFlag = env.player.mainSkill.activeEffect.statSet.skillFlags.hit
 	end
 	for ailment, val in pairs(ailments) do
 		if (enemyDB:Sum("BASE", nil, ailment.."Val") > 0

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1443,13 +1443,17 @@ function calcs.initEnv(build, mode, override, specEnv)
 									qualityId = gemInstance.qualityId,
 									srcInstance = gemInstance,
 									gemData = gemInstance.gemData,
+									statSet = {skillFlags={}, stateSet ={}},
+									statSetCalcs = {skillFlags={}, stateSet ={}},
 								}
+
 								if not activeEffect.srcInstance.statSet then
-									activeEffect.srcInstance.statSet = { statSet = grantedEffect.statSets[1] }
+									activeEffect.srcInstance.statSet = { }
 								end
 								if not activeEffect.srcInstance.statSetCalcs then
-									activeEffect.srcInstance.statSetCalcs = { statSet = grantedEffect.statSets[1] }
+									activeEffect.srcInstance.statSetCalcs = { }
 								end
+
 								if gemInstance.gemData then
 									local playerItems = env.player.itemList
 									local socketedIn = playerItems[groupCfg.slotName] and playerItems[groupCfg.slotName].sockets and playerItems[groupCfg.slotName].sockets[gemIndex]

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1434,9 +1434,9 @@ end
 function calcs.triggers(env, actor)
 	local skillFlags
 	if env.mode == "CALCS" then
-		skillFlags = actor.mainSkill.activeEffect.srcInstance.statSetCalcs.skillFlags
+		skillFlags = actor.mainSkill.activeEffect.statSetCalcs.skillFlags
 	else
-		skillFlags = actor.mainSkill.activeEffect.srcInstance.statSet.skillFlags
+		skillFlags = actor.mainSkill.activeEffect.statSet.skillFlags
 	end
 	if actor and not skillFlags.disable and not (env.limitedSkills and env.limitedSkills[cacheSkillUUID(actor.mainSkill, env)]) then
 		local skillName = actor.mainSkill.activeEffect.grantedEffect.name

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -272,8 +272,8 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						fullDPS.decayDPS = fullDPS.decayDPS + activeSkill.mirage.output.DecayDPS
 					end
 					-- This will only take skillFlags from main env. Needs rework if trigger section is to be kept.
-					if activeSkill.mirage.output.TotalDot and activeSkill.mirage.output.TotalDot > 0 and (activeSkill.activeEffect.srcInstance.statSet.skillFlags.DotCanStack or (usedEnv.player.output.TotalDot and usedEnv.player.output.TotalDot == 0)) then
-						fullDPS.dotDPS = fullDPS.dotDPS + activeSkill.mirage.output.TotalDot * (activeSkill.activeEffect.srcInstance.statSet.skillFlags.DotCanStack and mirageCount or 1)
+					if activeSkill.mirage.output.TotalDot and activeSkill.mirage.output.TotalDot > 0 and (activeSkill.activeEffect.statSet.skillFlags.DotCanStack or (usedEnv.player.output.TotalDot and usedEnv.player.output.TotalDot == 0)) then
+						fullDPS.dotDPS = fullDPS.dotDPS + activeSkill.mirage.output.TotalDot * (activeSkill.activeEffect.statSet.skillFlags.DotCanStack and mirageCount or 1)
 					end
 					if activeSkill.mirage.output.CullMultiplier and activeSkill.mirage.output.CullMultiplier > 1 and activeSkill.mirage.output.CullMultiplier > fullDPS.cullingMulti then
 						fullDPS.cullingMulti = activeSkill.mirage.output.CullMultiplier
@@ -324,7 +324,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 				end
 					-- This will only take skillFlags from main env. Needs rework.
 				if usedEnv.player.output.TotalDot and usedEnv.player.output.TotalDot > 0 then
-					fullDPS.dotDPS = fullDPS.dotDPS + usedEnv.player.output.TotalDot * (activeSkill.activeEffect.srcInstance.statSet.skillFlags.DotCanStack and activeSkillCount or 1)
+					fullDPS.dotDPS = fullDPS.dotDPS + usedEnv.player.output.TotalDot * (activeSkill.activeEffect.srcInstance.skillFlags.DotCanStack and activeSkillCount or 1)
 				end
 				if usedEnv.player.output.CullMultiplier and usedEnv.player.output.CullMultiplier > 1 and usedEnv.player.output.CullMultiplier > fullDPS.cullingMulti then
 					fullDPS.cullingMulti = usedEnv.player.output.CullMultiplier


### PR DESCRIPTION
Current code is using srcIntance to set statSets for activeEffect, srcInstance is set as reference of GemInstance.

because of that if a Gem have more that one GrantEffect (with global effect), the activeSkill SrcInstance.Stats will have the last GrantEffect StatSet in all activeSkillList that generate taht Gem.

![image](https://github.com/user-attachments/assets/db58d909-f0a3-412d-8f79-fe3aae287ef1)

![image](https://github.com/user-attachments/assets/fbc949f9-d5f0-44d4-9276-66b41dcc7ee7)


Build:
[Link to build](https://pobb.in/1QaGlpawEWO_)
