### PR TITLE
Change default boss resistance

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1701,11 +1701,11 @@ Huge sets the radius to 11.
 			modList:NewMod("WarcryPower", "BASE", 20, "Boss")
 			modList:NewMod("Multiplier:EnemyPower", "BASE", 20, "Boss")
 
-			local defaultEleResist = 40
+			local defaultEleResist = 30
 			build.configTab.varControls['enemyLightningResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyColdResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultEleResist, true)
-			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(25, true)
+			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(0, true)
 
 			local defaultLevel = 83
 			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
@@ -1740,7 +1740,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyLightningResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyColdResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultEleResist, true)
-			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(30, true)
+			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(0, true)
 
 			local defaultLevel = 84
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
@@ -1774,7 +1774,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyLightningResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyColdResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultEleResist, true)
-			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(30, true)
+			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(0, true)
 
 			local defaultLevel = 85
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -737,14 +737,12 @@ This is divided by 4.40 to represent 4 damage types + some (40% as much) ^xD0209
 Bosses' armour and evasion multiplier are calculated using the average of the boss type
 
 Standard Boss adds the following modifiers:
-	+40% to enemy Elemental Resistances
-	+25% to enemy ^xD02090Chaos Resistance
+	+30% to enemy Elemental Resistances
 	^7]]..tostring(m_floor(data.misc.stdBossDPSMult * 100))..[[% of monster Damage of each type
 	]]..tostring(m_floor(data.misc.stdBossDPSMult * 4.4 * 100))..[[% of monster Damage total
 
 Guardian / Pinnacle Boss adds the following modifiers:
 	+50% to enemy Elemental Resistances
-	+30% to enemy ^xD02090Chaos Resistance
 	^7]]..tostring(m_floor(data.bossStats.PinnacleArmourMean))..[[% of monster Armour
 	]]..tostring(m_floor(data.bossStats.PinnacleEvasionMean))..[[% of monster ^x33FF77Evasion
 	^7]]..tostring(m_floor(data.misc.pinnacleBossDPSMult * 100))..[[% of monster Damage of each type
@@ -753,7 +751,6 @@ Guardian / Pinnacle Boss adds the following modifiers:
 
 Uber Pinnacle Boss adds the following modifiers:
 	+50% to enemy Elemental Resistances
-	+30% to enemy ^xD02090Chaos Resistance
 	^7]]..tostring(m_floor(data.bossStats.UberArmourMean))..[[% of monster Armour
 	]]..tostring(m_floor(data.bossStats.UberEvasionMean))..[[% of monster ^x33FF77Evasion
 	^770% less to enemy Damage taken


### PR DESCRIPTION
Most stuff in poe2 now has 0 chaos resist by default, see:

https://poe2db.tw/us/The_Arbiter_of_Ash#TheArbiterofAshDemonClawBoss https://poe2db.tw/us/Xesht%2C_We_That_Are_One#XeshtWeThatAreOneItThatReturned