### PR TITLE
Clean up Against the Darkness variant names

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -19,7 +19,7 @@ do
 			table.insert(againstMods, { mod = mod, name = name:gsub("([a-z])([A-Z])", "%1 %2"):gsub("Strenth", "Strength") })
 		end
 	end
-	table.sort(againstMods, function(a, b) return a.mod.statOrder[1] > b.mod.statOrder[1] end)
+	table.sort(againstMods, function(a, b) return a.name < b.name end)
 	local against = {
 		"Against the Darkness",
 		"Time-Lost Diamond",


### PR DESCRIPTION
### Description of the problem being solved:
Space out Variant text for Against the Darkness mods, remove unnecessary gsub as the match() already ignores "UniqueJewelRadius"

### Before screenshot:
![image](https://github.com/user-attachments/assets/830b79a0-6070-470e-892c-dd6b447673d9)

### After screenshot:
![image](https://github.com/user-attachments/assets/53bffe6f-5e4c-4a5a-bfeb-5b705ada25ec)



name sort
![image](https://github.com/user-attachments/assets/17b48c7b-04dd-4db1-827e-962293f57cc8)
