### PR TITLE
Fix fallout from SimpleGraphic upgrade with wider Unicode support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN --mount=type=cache,from=luarocks,source=/opt,target=/opt make -C /opt/luaroc
 # Install here to install lua rocks pkgs in pararell with compilation of emmylua and luajit
 RUN luarocks install busted 2.2.0-1;\
 	luarocks install cluacov 0.1.2-1;\
-	luarocks install luacov-coveralls 0.2.3-1
+	luarocks install luacov-coveralls 0.2.3-1;\
+	luarocks install luautf8 0.1.6-1
 
 RUN --mount=type=cache,from=emmyluadebugger,source=/opt,target=/opt make -C /opt/EmmyLuaDebugger/build/ install
 RUN --mount=type=cache,from=luajit,source=/opt,target=/opt make -C /opt/LuaJIT/ install

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -26,6 +26,7 @@ common.curl = require("lcurl.safe")
 common.xml = require("xml")
 common.base64 = require("base64")
 common.sha1 = require("sha1")
+local utf8 = require('lua-utf8')
 
 -- Try to load a library return nil if failed. https://stackoverflow.com/questions/34965863/lua-require-fallback-error-handling
 function prerequire(...)
@@ -723,20 +724,21 @@ function formatNumSep(str)
 		end
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
 		if main.showThousandsSeparators then
-			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()
+			rev1kSep = utf8.reverse(main.thousandsSeparator)
+			integer = utf8.reverse(utf8.gsub(utf8.reverse(integer), "(%d%d%d)", "%1"..rev1kSep))
 			-- There will be leading separators if the number of digits are divisible by 3
 			-- This checks for their presence and removes them
 			-- Don't use patterns here because thousandsSeparator can be a pattern control character, and will crash if used
 			if main.thousandsSeparator ~= "" then
-				local thousandsSeparator = string.find(integer, main.thousandsSeparator, 1, 2)
+				local thousandsSeparator = utf8.find(integer, rev1kSep, 1, 2)
 				if thousandsSeparator and thousandsSeparator == 1 then
-					integer = integer:sub(2)
+					integer = utf8.sub(integer, 2)
 				end
 			end
 		else
-			integer = integer:reverse():gsub("(%d%d%d)", "%1"):reverse()
+			integer = utf8.reverse(utf8.gsub(utf8.reverse(integer), "(%d%d%d)", "%1"))
 		end
-		return colour..minus..integer..fraction:gsub("%.", main.decimalSeparator)
+		return colour..minus..integer..utf8.gsub(fraction, "%.", main.decimalSeparator)
 	end)
 end
 

--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -78,8 +78,8 @@ end
 
 ConPrintf("Checking for update...")
 
-local scriptPath = GetScriptPath()
-local runtimePath = GetRuntimePath()
+local scriptPath = "."
+local runtimePath = "."
 
 -- Load and process local manifest
 local localVer


### PR DESCRIPTION
### Description of the problem being solved:

In https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/59 there were significant foundational improvements for users installing Path of Building into paths with characters that cannot be expressed in their codepage.

There is also a companion PR for the Launcher in https://github.com/PathOfBuildingCommunity/PathOfBuilding-Launcher/pull/6.

In short:
* the LuaJIT runtime is patched to understand paths in UTF-8,
* API functionality like FileSearch yields paths encoded in UTF-8,
* `GetScriptPath`/`GetUserPath` yields paths in UTF-8,
* text rendering draws glyphs that don't exist in the fonts as `[U+1234]` "tofu" in a smaller font size,
* mouse selection understands codepoint boundaries,
* a compiled extension `lua-utf8` is exposed to the Lua side.

This means that Lua code that touches things like the full build path or the script path may need to adapt to process UTF-8 correctly with string operations.

In order to help with that, the SimpleGraphic update also features [luautf8](https://github.com/starwing/luautf8), a Lua extension that provides UTF-8 analogues of many string operations like `gsub`, `match`, etc.

This change leverages that extension via `local utf8 = require('lua-utf8')` to correctly move the text caret with the cursor keys in edit controls, and also showcases its use to handle (hypothetical) Unicode decimal and thousands separators.

The runtime also lost the vestigial ability to process GIF and BLP image formats, some existing assets were stealth GIFs with PNG extensions and have here been converted lossless to PNG.

The update check logic has been adapted to generate relative paths in the op-files to make its limited interpreter work correctly in exotic install locations.

### Steps taken to verify a working solution:
Install location:
- install PoB into a location with traditionally unrepresentable Japanese characters in an English locale,
- note how it can both start and update itself

Build path:
- set the build path to such a location,
- note how builds with ASCII characters can still be saved and otherwise modified there.

Build name:
- manually create a build XML file with exotic characters outside of PoB,
- exercise the build rename, copy and removal UI to see that they still work,
- move the text caret around in the build rename UI without splitting any codepoints,

Numeric separators:
- artificially set the numeric separators to Unicode codepoints in `Settings.xml`,
- observe how the sidebar and calcs UI draws them correctly.

### Link to a build that showcases this PR:

n/a

### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/260218/d1091121-9ab4-4639-806b-e83ea1780648)
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/260218/c58f9f1b-77a6-4d20-8438-92d30a3b484d)
