### PR TITLE
Fix penetration calculations

### DIFF
--- a/src/Modules/CalcBreakdown.lua
+++ b/src/Modules/CalcBreakdown.lua
@@ -132,6 +132,8 @@ function breakdown.effMult(damageType, resist, pen, taken, mult, takenMore, sour
 		if not useRes then
 			t_insert(out, s_format("x %d%% ^8(resistance ignored)", 0))
 			t_insert(out, s_format("= %d%%", (0)))
+		elseif resist <= 0 then
+			t_insert(out, s_format("= %d%% ^8(negative resistance unaffected by penetration)", resist))
 		elseif (resist - pen) < 0 then
 			t_insert(out, s_format("= %d%% ^8(penetration cannot bring resistances below 0)", 0))
 		else

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1972,7 +1972,7 @@ function calcs.buildDefenceEstimations(env, actor)
 		local impaleArmourReduct = 0
 		local percentOfArmourApplies = m_min((not modDB:Flag(nil, "ArmourDoesNotApplyTo"..damageType.."DamageTaken") and modDB:Sum("BASE", nil, "ArmourAppliesTo"..damageType.."DamageTaken") or 0), 100)
 		local effectiveAppliedArmour = (output.Armour * percentOfArmourApplies / 100) * (1 + output.ArmourDefense)
-		local resMult = 1 - (resist - enemyPen) / 100
+		local resMult = 1 - (resist > 0 and m_max(resist - enemyPen, 0) or resist) / 100
 		local reductMult = 1
 		local takenFlat = modDB:Sum("BASE", nil, "DamageTaken", damageType.."DamageTaken", "DamageTakenWhenHit", damageType.."DamageTakenWhenHit")
 		if damageCategoryConfig == "Melee" or damageCategoryConfig == "Projectile" then
@@ -2068,7 +2068,11 @@ function calcs.buildDefenceEstimations(env, actor)
 			if enemyPen ~= 0 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("+ Enemy Pen: %.2f", enemyPen / 100))
 			end
-			if resist ~= 0 and enemyPen ~= 0 then
+			if resist <= 0 and enemyPen ~=0 then
+				t_insert(breakdown[damageType.."TakenHitMult"], s_format("= %.2f ^8(Negative resistance unaffected by penetration)", resMult))
+			elseif (resist - enemyPen) < 0 then
+				t_insert(breakdown[damageType.."TakenHitMult"], s_format("= %.2f ^8(Penetration cannot bring resistances below 0)", resMult))
+			elseif resist ~= 0 then
 				t_insert(breakdown[damageType.."TakenHitMult"], s_format("= %.2f", resMult))
 			end
 			if resMult ~= 1 and reductMult ~= 1 then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3183,7 +3183,7 @@ function calcs.offence(env, actor, activeSkill)
 								resist = resist > 0 and resist * (1 - (skillModList:Sum("BASE", nil, "PartialIgnoreEnemyPhysicalDamageReduction") / 100 + ChanceToIgnoreEnemyPhysicalDamageReduction / 100)) or resist
 							end
 						else
-							resist = calcResistForType(damageType, dotCfg)
+							resist = calcResistForType(damageType, cfg)
 							if ((skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") or skillModList:Flag(cfg, "ChaosDamageUsesHighestResistance")) and damageType == "Chaos") or
 							   (skillModList:Flag(cfg, "ElementalDamageUsesLowestResistance") and isElemental[damageType]) then
 								-- Default to using the current damage type
@@ -3194,7 +3194,7 @@ function calcs.offence(env, actor, activeSkill)
 								-- Find the lowest resist of all the elements and use that if it's lower
 								for _, eleDamageType in ipairs(dmgTypeList) do
 									if isElemental[eleDamageType] and useThisResist(eleDamageType) and damageType ~= eleDamageType then
-										local currentElementResist = calcResistForType(eleDamageType, dotCfg)
+										local currentElementResist = calcResistForType(eleDamageType, cfg)
 										-- If it's explicitly lower, then use the resist and update which element we're using to account for penetration
 										if skillModList:Flag(cfg, "ChaosDamageUsesHighestResistance") then
 											if resist < currentElementResist then
@@ -3244,7 +3244,7 @@ function calcs.offence(env, actor, activeSkill)
 						if skillModList:Flag(cfg, isElemental[damageType] and "CannotElePenIgnore" or nil) then
 							effMult = effMult * (1 - resist / 100)
 						elseif useRes then
-							effMult = effMult * (1 - (m_max(resist - pen, 0)) / 100)
+							effMult = effMult * (1 - (resist > 0 and m_max(resist - pen, 0) or resist) / 100)
 						end
 						damageTypeHitMin = damageTypeHitMin * effMult
 						damageTypeHitMax = damageTypeHitMax * effMult


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/378

### Description of the problem being solved:
Offensive penetration wasn't properly handling cases when resistance was less than 0 before penetration.
Also updated defensive penetration calculations.
### Steps taken to verify a working solution:
- Load the provided build
- Observe correct damage multipliers for damage taken and damage dealt

### Link to a build that showcases this PR:
https://pobb.in/YMNosS6UIvf3
### Before screenshot:
![image](https://github.com/user-attachments/assets/37253c8f-7140-4197-a415-506062ed42a0)
![image](https://github.com/user-attachments/assets/b60dba5c-26a1-4347-8e58-ebb5291c7999)

### After screenshot:
![image](https://github.com/user-attachments/assets/937ae809-5231-4735-ad28-cd3dd03fd98d)
![image](https://github.com/user-attachments/assets/103e68a6-674d-4730-9554-af77c785bd68)

