### PR TITLE
Add support for Charge consumed recently tree nodes

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1256,6 +1256,7 @@ local modTagList = {
 	["during empowered attacks"] = { tag = { type = "Condition", var = "SkillEmpowered" } },
 	-- Multipliers
 	["per power charge"] = { tag = { type = "Multiplier", var = "PowerCharge" } },
+	["if you've consumed an? (%D+) charge recently"] = function(charge) return { tag = { type = "Multiplier", var = "Removable" .. firstToUpper(charge) .. "Charge", limit = 1 }} end,
 	["per frenzy charge"] = { tag = { type = "Multiplier", var = "FrenzyCharge" } },
 	["per endurance charge"] = { tag = { type = "Multiplier", var = "EnduranceCharge" } },
 	["per siphoning charge"] = { tag = { type = "Multiplier", var = "SiphoningCharge" } },


### PR DESCRIPTION
- 20% increased Armour if you've consumed an Endurance Charge Recently
- 20% increased Critical Damage Bonus if you've consumed a Power Charge Recently
- 20% increased Energy Shield if you've consumed a Power Charge Recently
- 20% increased Evasion Rating if you've consumed a Frenzy Charge Recently
- 50% increased Evasion Rating if you've consumed a Frenzy Charge Recently