### PR TITLE
Fix passive nodes being permanently attached to a Weapon Set

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -53,6 +53,8 @@ function PassiveSpecClass:Init(treeVersion, convert)
 		end
 	end
 	for id, node in pairs(self.nodes) do
+		-- init all nodes as normal allocationMode
+		node.allocMode = 0
 		-- if the node is allocated and between the old and new tree has the same ID but does not share the same name, add to list of nodes to be ignored
 		if convert and previousTreeNodes[id] and self.build.spec.allocNodes[id] and node.name ~= previousTreeNodes[id].name then
 			self.ignoredNodes[id] = previousTreeNodes[id]
@@ -304,6 +306,7 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, secondaryAs
 		local node = self.nodes[id]
 		if node then
 			node.alloc = true
+			node.allocMode = weaponSets[id] or 0
 			self.allocNodes[id] = node
 		end
 	end
@@ -728,7 +731,7 @@ end
 
 function PassiveSpecClass:DeallocSingleNode(node)
 	node.alloc = false
-	node.allocMode = nil
+	node.allocMode = 0
 	self.allocNodes[node.id] = nil
 	if node.type == "Mastery" then
 		self:AddMasteryEffectOptionsToNode(node)
@@ -771,9 +774,9 @@ function PassiveSpecClass:CountAllocNodes()
 			end
 		end
 
-		if node.allocMode and node.allocMode == 1 then
+		if node.allocMode == 1 then
 			weaponSet1Used = weaponSet1Used + 1
-		elseif node.allocMode and node.allocMode == 2 then
+		elseif node.allocMode == 2 then
 			weaponSet2Used = weaponSet2Used + 1
 		end
 	end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1126,7 +1126,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		tooltip:AddLine(16, string.format("Angle: %f", node.angle))
 		tooltip:AddLine(16, string.format("Orbit: %d, Orbit Index: %d", node.orbit, node.orbitIndex))
 		tooltip:AddLine(16, string.format("Group: %d", node.g))
-		tooltip:AddLine(16, string.format("AllocMode: %d", node.allocMode or 0))
+		tooltip:AddLine(16, string.format("AllocMode: %d", node.allocMode))
 		tooltip:AddSeparator(14)
 
 		-- add connection info for debugging

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -253,8 +253,8 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 	if node.allocMode then
 		for i, mod in ipairs(modList) do
 			local added = false
-			for j, extra in ipairs(mod) do
-				if extra.type == "Condition" and extra.var and extra.var:match("^WeaponSet") then
+			for j = #mod, 1, -1 do
+				if mod[j].type == "Condition" and mod[j].var and mod[j].var:match("^WeaponSet") then
 					if node.allocMode ~= 0 then -- only update the conditional for WS1/WS2
 						mod[j].var = "WeaponSet".. node.allocMode
 						added = true

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -249,25 +249,22 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 	if modList:Flag(nil, "CanExplode") then
 		t_insert(env.explodeSources, node)
 	end
-
-	if node.allocMode then
-		for i, mod in ipairs(modList) do
-			local added = false
-			for j = #mod, 1, -1 do
-				if mod[j].type == "Condition" and mod[j].var and mod[j].var:match("^WeaponSet") then
-					if node.allocMode ~= 0 then -- only update the conditional for WS1/WS2
-						mod[j].var = "WeaponSet".. node.allocMode
-						added = true
-					else -- if normal and conditional exists, remove it
-						t_remove(mod, j)
-					end
-					break
+	
+	for i, mod in ipairs(modList) do
+		local added = false
+		for j = #mod, 1, -1 do
+			if mod[j].type == "Condition" and mod[j].var and mod[j].var:match("^WeaponSet") then
+				added = true
+				if node.allocMode ~= 0 then -- only update the conditional for WS1/WS2
+					mod[j].var = "WeaponSet".. node.allocMode
+				else -- if normal and conditional exists, remove it
+					t_remove(mod, j)
 				end
 			end
-			-- only add the conditional for WS1/WS2
-			if not added and node.allocMode ~= 0 then
-				table.insert(mod, { type = "Condition", var = "WeaponSet".. node.allocMode })
-			end
+		end
+		-- only add the conditional for WS1/WS2
+		if not added and node.allocMode ~= 0 then
+			table.insert(mod, { type = "Condition", var = "WeaponSet".. node.allocMode })
 		end
 	end
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -250,18 +250,22 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 		t_insert(env.explodeSources, node)
 	end
 
-	if node.allocMode and node.allocMode ~= 0 then
+	if node.allocMode then
 		for i, mod in ipairs(modList) do
 			local added = false
 			for j, extra in ipairs(mod) do
-				-- if type conditional and start with WeaponSet then update the var to the current weapon set
 				if extra.type == "Condition" and extra.var and extra.var:match("^WeaponSet") then
-					mod[j].var = "WeaponSet".. node.allocMode
-					added = true
+					if node.allocMode ~= 0 then -- only update the conditional for WS1/WS2
+						mod[j].var = "WeaponSet".. node.allocMode
+						added = true
+					else -- if normal and conditional exists, remove it
+						t_remove(mod, j)
+					end
 					break
 				end
 			end
-			if not added then
+			-- only add the conditional for WS1/WS2
+			if not added and node.allocMode ~= 0 then
 				table.insert(mod, { type = "Condition", var = "WeaponSet".. node.allocMode })
 			end
 		end


### PR DESCRIPTION
Fixes #402 

### Description of the problem being solved:
When you allocate a node in a weaponSet, a conditional mod is added so we can calculate the correct nodes based on which Set is active. The problem is this mod is only ever added or updated and never removed for instances of Normal/Non-WS allocation.  So once allocated in either set, it will permanently have the mod which excludes it from being a Normal node that should apply regardless of WS. In other words, that node is permanently either a WS1 or WS2 node in the background, even if allocated as Normal.

So yeah we're fixing that.

### Steps taken to verify a working solution:
- Import build
- Allocate Ingenuity as WS2
- Deallocate and allocate as Normal
- Verify Intelligence increases while in WS1
---
- Import build
- Allocate Ingenuity as WS1
- Activate WP2
- Deallocate and allocate as Normal
- Verify Intelligence increases while in WS2
---
- Same two above on refresh while on TreeTab
---
- Same kinds of tests for a fresh build


### Link to a build that showcases this PR:
<pre>eNrtPGtz2kqynw-_QkXVuXW3Qmxp9PY6Zwvb-JH4Cbbz-JIawwBKhEQkYRtv7X_f7hkJJNAI4ezuzd46-eCAph8z3T39mhH7f3ue-Moji2IvDN41tR21qbCgHw68YPSueXd7_NZp_u2Pxv41TcZXw4OZ5-MI-aPx2z7_ovjskfnvmq7WVPo-jeNLOmHvmr0w6rOIxXFToXGfBYPD3FgSRpMnRoFpU0loNGLJfcZf_Yp0xjSi_YRF50i7PUvCi3AAiEPqx6ypTKgX9ML-d5acROFsCpNuKo8eexJAZxfXV93bJkzwt_1rn85Z1EtoosTw512zDTzpiB3RCfwFLOrPAMXcsXTLaO5W4hzMojjZCrE3ZWywgNV2CJGCXkesMxyyfuI9ssPISw7HNOgv-agyvG1hL2Z-4k19DyWfwhMZ_OkaaUuTwd6GCfWPrntL0B3HdVxTt6oxwmTzvD96yfjAB1FuRR-xzkaBl7Ct0a5DLw6DV60mjyRXxMz3YQ_Vgu2ymEWPNPGKE5LTDicPXrClrC5oQA_DuIYuEPKawdYOkq0Qeqwfgg_YlseWmOfekNWH3GodKcK2s3ndOjq9unBbE37dhLrg9OpB9sKZXxMyWfogw5Tb_488oG7LAI_Y89KlSaHOguXMdFOv4JqH1HRXzvYxxM25eb3cRXROr3NUTZXsqLbjmI6uO9LQMJ7HXp_6F_TZm8wm4JVv6Xe2ZGgbuiE3wdE4CcDXyJA1zZTHr2MvYjJEYhuaJndC_uB1iGMaxjJMLxjKXYYXnNJg0O73Z5A5zJcB2nWqtudSDhUxvL-HoGdBPye1KqJ3QcSddj72V8F3YSNiivHgs3oISwbpbl6iqWo1pxELUnZLGemkCuecsf74BOTbpclyfvqOrcvx0IMv9zax3ErpInReutV0S6RbxaGIsoW8ELFcXpZr7ehVaOUikzvCqQeZ2XJOllYNWWZf9XG2EEEnYNFo3ht7zF-y0jVdq4OQie2QTmvhclPIE8ibBJE7qSLPMn3VWt-WOsOAuC23RxrnA4VuGtWyEPB5MciNlUF-DAgDVrcYuI7Cb1hu-NuhtaNJOMuFY3k85msQ4LWWkIU5UWF12WDWL8RV6Y5b1E0HPtSEKwsh5kY0mKjvl-HKhZAktP_9KByMasuNM9kKozi_3mw6xWoaJFKXAEZvqB68XC5mW5uBr8Ca83vWrQrytekvgVfp6xtzlxUm8lxsBWOVk1qZdaxwqQNcm8FClxfgKybgfXln4CLMNwc0V56HQb1Yq_jjgDWL0OvwCWY_xu5LvB005GebtXccseBlXpt-AbwWg04wgFQPdkJtHqsYZWwOZsNhrPShiKbJOaj4XbOpPMCz7DOklzFLvwiMW28CzjeOj2hClUFaDdzTyKNBQnhrKmY06o8R6Zj6_gO4DqS0fIrfVhC1LAPc3-VNNvx0NpmGUaKwZ_zvmkbJPGuIcUD-BOjEiRfwdgH4Kd9vKr1x-NQePOK6b8PQjxddNDqdsmBQoHEbMabQzOv0cRJ8jfhFmdA4gUAnbDnGSecae2cDvtQghAmANB1bJy3iEkNtGaauuS3TMAy7RTSiOi1NhTQAPruO0bIN1WxZmqHqLSiHdAAhxNZahq3ZdssmhtUyLV23WpqrGkZLt4irtyxDheeWphIbPtuO29KI4TgtxyFay1KJriJFYGpoxAK6FjGBjGkDa2LoAKOrOhJWNdVoOablIjsLBi1bh8-6Azx0S7fhs2ubMHcX-LZgFTAl3bIARteIDvAODAOMBjMgmm04CGOq8NyA56Zta2pLN01cmmOZWkszLMvC57bVMghxYZTgY9N2CPxVHR0XawB5w0HBOSb-UWE5mmbZpGXZGpCFf0YLpAbzslzdBGBVtUDWGvC3YAl2yyTERFk5DnCwXRsW6Vg2cLCI07JdSwUioAMQuK7aLcNyQFTEBlzQkk1MEJjhwhMLFNIiwA6krILKYF3wUXdVHWkZKE0NJ0AMzQIxaDpMUXcJyFRXgQrRYczUAIOoKqxJhxm2XMuAdegOqIXYtgNohgPqNg0T1OJYGghGtVFDIH94rGt8HfDXtE2YgUVQuYaFIgA1GTA9leDikQMUAWBLYEkGLMHQ9RYIGoThqEAVlgsC05C-CeV2i0vIMEF1QA3FYhjERX0bJpAA-7BAcyAzotsWsHLxs6bZ8NhwABp0haR0gsaMkzQdNEMQtquh3kyCzx2CuxybLDSat4t7JfBgayaw3VYa39m4wTfeb_t33XP-4bdxkkzjvd3dp6ennSlNxuGQPUPytgOuancKSLBl38bfPd9_i1R32_DvYHRzMH4_uOh_854PtPPP783Le-PgJbHdWDXuH77OOt_7t8nTTW_Su3wehjN7cu0e3x6dnQWfou7saxT2nK-jy0n_09Mx8eIr4-zTxLg5Gb_80D9enTjvh-bb94712Rmy0Zfnc6ft3193nZeJYxsfrQ-R-u3h6i4axx_u5kfnF-70WxTpB-Ts5OB8PjONZHIQ2uTm7Jq4ZjC-_PKsX9_evxxYN5333Y9nPy7cowPns_aivry1H77Rt9H9893By5fx4JvGpsnhfPJ5ePv0dE9d9oWe9Ce9m3P15vuwPbp3Dz93rfc0Mgdk_j5Sh3dveyfhSHPunsKvV8aH4OU4-kSPgNJTcNyl3clgcvPxy-nk1AsP2WP7tPdyffPtKgaP8f6Dev7UexuetvXHT5c9-m2uf-4kLyejg6PwQyfyp1-6wSMdhd9G7TZX1G6mqf2PjE7DoMcSLXOHwqcJ58WdVOqMuP9IfYPY_nxz5_eHMGpueiLe5OiTBX3uVoWjFA5KuCPhZIQ7yG_tdEfyjSX2C7fcjIE4WomF3aXfOCs0TPQfTcVL2IS7_AxpDY47wRygLgXEOJADJDJA7tNzgJYMkLv9HKApA-ReJgdoZBLYzYtgH9O8yANJp1Qg_Y-8h1nCsgGIus-XQhXC63NPxuMLUA-SdEx4ceFAc2GH-3LhNLjjFE5cxEQRB7kvSZ0k94mpBxTRhjs_4daEL-fOLxdahIcTEUKEFhG_8lFaBEYR6UR85tEFHFgSpdMXfl4EBHR9C2EV5AOyg2SBZy6YTeCHyzARY_gw-7LfQ2cVKzEkMydsEh_MIWs9xkp85QwjTUcQGmxeJFR5nHfNJJoxzKCGdObj85sZ9T3MjtT803NxTBmE0WTRSwVSkB1hbSUo3s6nuNL2-Xma96RcFW-wTMjExPHjIfX7YtFnwXQGdsVPNyde3P-KOSMeR3IB8pPUzvFx5_D27L6T5o15FO64vwazyQOey4n_lz3AHuOVsBLPHmLx8V3z3mNPfCJHLKGeD9lvP_R9Oo3ZIqPjk05X4ANeBTUOdeotTjfLaS0B5JQ6zyyCBHT0EZLbyGPSeS3GN0xKMMQOC-bZMmp4jCgnJMr1Q0hfRW9HIil-WCungqen0uXgYAUupO7Ul3JORzdIIkHbhK3lDb0-FjXVKkdLFlAVclk0y6X6TnsNchr8XFZGQAzKkcU5qww7Ha2QKj_dlUpVjMrRj1ifStcuBuXIi3ZhGJxi77acygKqgtJlGHAjh03T9nxsDkg12_HZAkRO8CoZsyit0mSULsBHZSCVG0cEOimdHESFrPhBi0RCOCZHFQcJkjXgWMWmSbvqst3uVW_ZYu9boo88jJyUaBZJZZg2nirUkPZcJSoQoxUryfrOkkWkwxUbhfvg9mPoDUTnUbJlVsCqnAakVz9PhrdTf57Man_15ykeQxX3XarvdFSOfpd4mL-UUBGZTi0iuLF-jgLur5-jgH22yauxu6upyBK3W52ELDqCpcjZaNXeTxuFr6Yg2pmvRufd1ldj8wBwxIYMVlAZARYwFZsjmQVHIIykYmPUJMWnVe5FlqvbipaIhaUr3Zqi2N3phYMqByBANhCCYH5akS7Wo7Q4NThl1MdbaaH_cwTXLlb8DDE8-JxNaTDIyF2VJelLPdSUXpjEQJM3vY_wfPVnZRiwybyEkHxe-7tZWcfb4Vhopb36XhJh1_slDCef8WTR0Xd0R1Ud28BjUP48LTI1I60sIQM_8kCNETe_jC1CfnrXfOtq5o7uQoluGZad3lnaP0ugsk2rXvy8KHrl9GYxE5e5Fq0h0WAUdSbQSOtXXq93KSQ-8z2l2-52GidQeCgHNGANyORmUHIrH0H6DY7D17KnWGojLaj3FKI2-NMu-7GnmE4DKhff64Oh7ylqg9i_K17QjxgFCSs8qipCuA3DyQ8tjumy4TeurSShMhHmqWDgabwx8BHnpoRDhQKxJZ4gLgrxhqbniWMlhsfIhQkoB2EwixtvNAeJngUJDHkjlCHvYECh3qUBgEX4911T3TGbuZK_CoJshNA3QhgbIcyNENnB6y6qrqh3UtT73eXZzV2ncUHHs-cw8f8HLCb-awxC74_Tg6PGFbhVECSLE0Uktw2RZO4pYOgNkfWmI3uKRpyCvTikYC9pJ21P6Sm9RhdMDD6FM185DCOGim2_9OmUVowsDU638gZHGn8HBUJ9mvzj7xFg_4OoeTsQy0U6YkMNwxkY9gLFKBjr7TiMglgZpNZqkfygWLsC-0IpLL1hugUijLtr5CjWjJsgW0_cgL_RbAoPfyGLK7MWvcRLXPt0NGMKeJ-o0XmesihRjhnFEIyy82hE14zCXDEKVWIUZYr_Qn2a-DnF22Ze8dqa4vNaKDgRvWASRe290bS808F8ufGGqOqaJyLOZrt6Q9zfERGvUSiioMMkB5gQ_hyvP-Sf___yOhUQttzSjLJ4FHkT5QNj00Z6ZD2Ab8kYpO5hqrdqZsStaWYLQzuLIEHAj2vfc4Gt2twMdd07tJS0jC5xEw6pMEKLG6HoRqAVrcWnN0QrtSydcJNV-CU0JhJ0BbZmeuLY0Hj81Fwlu1e14uT-tEAkXxYZb8cMtMkiqE-xk62c0BdIj15mIP_2ZOazpGBytiYJSm3fD_s0YbFy7bGoz9OWcZisuBP0MEUdYo86s2Llf_k4rM0bApH4L3sKuKjfwWzW3ZSl1qCLvUgFEzXwXxc5bIXGSuc5iejiadFO_-3W8m_OgayyqIayOMB09y6IWaJ0QUWr3mTpFCyt6BROgHsSK5pCBwMPBUzThFTp-aDlDQpsDwaxoqMOLREbxK7EB-K0ApNV112PRVatWFTiRUQcWqbQOVfyK6Ym_3dOwS4xlY8hAzV5fuM2nNKXEksheUtZCR9vcL_JZL9po2sut5LsqAZ3MTIHfVprxqGZdYxDXTcO3SgNMdxZ6LaIMxhaeDGtfAAj_3lb-cUsoQLCkduKU2Ir_OVW5d6LWZYrg7AjD0OBcuKHj1ALrFVQ2lbJclnOsilF_hfmLNx3ieQ5n14clXgwi6zX9aXeySrNkrkBmqv2d-olypMHSWHG50-vhbe0S5Jpfz4dK-c0HjeuogDt74D5SYN35XmU4pZSSGacioiHpUyE1_Kxy8JppK1o7D-BZ3GM9XpKs9djmGYU-jWckmh1KlmnOevU9JKIBaNkDC7KKq-vdPfP-kpiEppaZhOhD8MnIR1k3qnn-d_BGrwpfFtzTa5dtA9jg2cKYqhk0nxzxUGplc2bYuySZK8LHM2WuydSpJReuFf49Q6sx0uMlGglbkoviZN2qbG9QZZ_Jlf_mpCqlbWpjyH_6vWx-zQBg_BXGtSrfehCqOMxItU-mk2f32hBdfGyjEHwE3GlccpJp11lZcAgpmmFdDvtVttFS8VrJrMBb1yJGyvKPJwBxBBmlPzizT6NlAgbsgNY5mAAKwG3AIVwo0en0zF43oLYiVUUe7ELT-Nsy114AWzgTKBqiUCLDzs-37CLjKJxwRKaaWWEGUExgIjd_x8TdKkYy5qmHTrymXLEfC_yZpNSyy0mbWrRstZOSba2XuwcrQn7P--PSiVmVBveie9NJjLLs93XWB4pszxTupezi1aF3fxfYIpmiWCvHmAfexv2s6MWpepIT_OIRN4FYXYWpyFzPD05xPem4v8GAZa1ig5pFKH83ofz8o284gu1gvCyMiut3av3sZvHpFCnBYlo1kFGxK8TYhwr8aKiJMJLBwpFyYJWYAmM13Z3gfdjxjgDj8W_bkzCm9ays-z8EfY-Fi_82v71w133HA_lxT1qUV8vb_Qv7qjLEAQTJf8SwCYUfm8pj6FuwhBd4yWCuQlB1ET6FiwERumkeI5-NgDw1XczBOp79sQgVixf18hI15IDqctSvOVRYLl88aMmy1RbOZ6kimf6wkieZ-4dkpo8sWRe8nPrGpTSe8IXg2vJJn1fJT_P3CssNeeJPcm8ZOwqjuIlnjzD5Ws9deUSDuZKdjM1Y2rU1aBUPFWry5m3VW9D1LXO9EWgvEBy7wbVlMgpg4whZyv6ZhGGSc5ZaWreKYLj45eRePOWv2wSBkNvlF4MEl_Sq0EcafGk4CjzL5mgU-UnFb0ximDA402X4Y-B-POm8hCGPqNBeqdodx0fQkictPsJOQQA_576PuPt5WTMlFsPqt14-bJLMbFKDyrFD2UowyicKPnbn0U2-OZMO-rTgPVmEd4A3TixxcKg2AfuWyxFv-RvA-GJ3z0LYFqH0Xya5NZBarQlyhhwEfd4e3L5Pg-pnDxHEVnTEsUwKjUhpr-NKtIl1FPFQkxc43IpvTF52xcyxNX3ASRr5aaXmqFEXdc-7bNx6A9YlGIzjiR-UjGTj62qGxAKv-2QoW1CWtRe2QtRi1eyVEI2Mcz9ImOGZm7Ayf9UxwJn48rgySvmh7xegcYz3SWGY8jhJ4vfmMQfU8RLQnwnHGIu22P-MMfXrLHGrQWz0N413nHN0PS6WNsrAk1sVaSG6m5AW7yXsZBplVBLPYq2gUXxN3W2M2N4Uld-vX7Ir8duN7n0h35C3-c1Qn5Tb8DM0o4FJ-K4FTixN_L8qyG_VA-T5G8G1J0k7uZV6elqjS1WV3aHY3xBs1x0-7uLqC4uJvNvfzT2d9d-jPeflVwA9A==</pre>

### After screenshot:
![issue402](https://github.com/user-attachments/assets/48ca8a3b-104a-4e5d-a0ed-fe3cba41976a)
