### PR TITLE
Fix shock min-max limits

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -300,7 +300,7 @@ data.nonElementalAilmentTypeList = { "Bleed", "Poison" }
 data.nonDamagingAilment = {
 	["Chill"] = { associatedType = "Cold", alt = false, default = 10, min = 5, max = data.gameConstants["ChillMaxEffect"], precision = 0, duration = data.gameConstants["BaseChillDuration"] },
 	["Freeze"] = { associatedType = "Cold", alt = false, default = nil, min = 0.3, max = 3, precision = 2, duration = data.gameConstants["FreezeDuration"] },
-	["Shock"] = { associatedType = "Lightning", alt = false, default = 20, min = 20, max = 20, precision = 0, duration = data.gameConstants["BaseShockDuration"] },
+	["Shock"] = { associatedType = "Lightning", alt = false, default = 15, min = 5, max = 50, precision = 0, duration = data.gameConstants["BaseShockDuration"] },
 }
 
 -- Used in ModStoreClass:ScaleAddMod(...) to identify high precision modifiers


### PR DESCRIPTION
Fixes #426.

### Description of the problem being solved:

Shock min-max limits were changed in commit 0b90f10 causing any shock applied to be applied at a magnitude of 20%, this pull request reverts the changes to those limits.

EDIT 1/19:
> When manually configuring the Effect of Shock in the Configuration panel, that number is processed and subject to the maximum and minimum % amounts for the shock ailment, so 35% will be processed and turned into 20% for damage calculation, which isn't correct.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/4h8t50yo

### Configuration screenshot
![image](https://github.com/user-attachments/assets/d45a52b5-8874-459c-aafe-06b4f45e0716)


### Before screenshot:
![image](https://github.com/user-attachments/assets/0cf18c8e-1e68-4a57-8bf1-24b10869d407)


### After screenshot:
![image](https://github.com/user-attachments/assets/9169324f-3900-4356-9d9f-0bcd73b321f6)

