### PR TITLE
Add Emotion filtering to Anoint popup

### DIFF
--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -11,6 +11,7 @@ local CheckBoxClass = newClass("CheckBoxControl", "Control", "TooltipHost", func
 	self.labelWidth = DrawStringWidth(self.width - 4, "VAR", label or "") + 5
 	self.changeFunc = changeFunc
 	self.state = initialState
+	self.checkImage = nil
 end)
 
 function CheckBoxClass:IsMouseOver()
@@ -42,6 +43,8 @@ function CheckBoxClass:Draw(viewPort, noTooltip)
 	elseif self.borderFunc then
 		local r, g, b = self.borderFunc()
 		SetDrawColor(r, g, b)
+	elseif self.checkImage and self.state then
+		SetDrawColor(0.75, 0.75, 0.75)
 	else
 		SetDrawColor(0.5, 0.5, 0.5)
 	end
@@ -56,15 +59,30 @@ function CheckBoxClass:Draw(viewPort, noTooltip)
 		SetDrawColor(0, 0, 0)
 	end
 	DrawImage(nil, x + 1, y + 1, size - 2, size - 2)
-	if self.state then
-		if not enabled then
-			SetDrawColor(0.33, 0.33, 0.33)
-		elseif mOver then
-			SetDrawColor(1, 1, 1)
+	if self.checkImage then
+		if self.state then
+			if not enabled then
+				SetDrawColor(0.33, 0.33, 0.33)
+			elseif mOver then
+				SetDrawColor(2, 2, 2)
+			else
+				SetDrawColor(1, 1, 1)
+			end
 		else
-			SetDrawColor(0.75, 0.75, 0.75)
+			SetDrawColor(0.5, 0.5, 0.5)
 		end
-		main:DrawCheckMark(x + size/2, y + size/2, size * 0.8)
+		DrawImage(self.checkImage.handle, x + 1, y + 1, size - 2, size - 2, self.checkImage[1])
+	else
+		if self.state then
+			if not enabled then
+				SetDrawColor(0.33, 0.33, 0.33)
+			elseif mOver then
+				SetDrawColor(1, 1, 1)
+			else
+				SetDrawColor(0.75, 0.75, 0.75)
+			end
+			main:DrawCheckMark(x + size/2, y + size/2, size * 0.8)
+		end
 	end
 	if enabled then
 		SetDrawColor(1, 1, 1)
@@ -105,4 +123,9 @@ function CheckBoxClass:OnKeyUp(key)
 		end
 	end
 	self.clicked = false
+end
+
+---@param image table @The image to display instead of a check.  Expects a `handle` field with an image handle, and the sprite position at index `1`.  All other fields are ignored.  Set to `nil` to draw a normal check.
+function CheckBoxClass:SetCheckImage(image)
+	self.checkImage = image
 end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2110,7 +2110,7 @@ function ItemsTabClass:AnointDisplayItem(enchantSlot)
 	self.anointEnchantSlot = enchantSlot or 1
 
 	local controls = { } 
-	controls.notableDB = new("NotableDBControl", {"TOPLEFT",nil,"TOPLEFT"}, {10, 60, 360, 360}, self, self.build.spec.tree.nodes, "ANOINT")
+	controls.notableDB = new("NotableDBControl", {"TOPLEFT",nil,"TOPLEFT"}, {10, 20, 360, 400}, self, self.build.spec.tree.nodes, "ANOINT")
 
 	local function saveLabel()
 		local node = controls.notableDB.selValue

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -12,6 +12,8 @@ local m_floor = math.floor
 local m_huge = math.huge
 local s_format = string.format
 
+local emotionList = {"Ire", "Guilt", "Greed", "Paranoia", "Envy", "Disgust", "Despair", "Fear", "Isolation", "Suffering"}
+
 ---@param node table
 ---@return boolean
 local function IsAnointableNode(node)
@@ -20,7 +22,9 @@ end
 
 ---@class NotableDBControl : ListControl
 local NotableDBClass = newClass("NotableDBControl", "ListControl", function(self, anchor, rect, itemsTab, db, dbType)
-	self.ListControl(anchor, rect, 16, "VERTICAL", false)
+	local headerHeight = 68
+	local innerRect = {rect[1], rect[2]+headerHeight, rect[3], rect[4]-headerHeight}
+	self.ListControl(anchor, innerRect, 16, "VERTICAL", false)
 	self.itemsTab = itemsTab
 	self.db = db
 	self.dbType = dbType
@@ -32,15 +36,52 @@ local NotableDBClass = newClass("NotableDBControl", "ListControl", function(self
 	self.sortDropList = { }
 	self.sortOrder = { }
 	self.sortMode = "NAME"
-	self.controls.sort = new("DropDownControl", {"BOTTOMLEFT",self,"TOPLEFT"}, {0, -22, 360, 18}, self.sortDropList, function(index, value)
+	self.controls.sort = new("DropDownControl", {"TOPLEFT",self,"TOPLEFT"}, {0, -headerHeight, 360, 18}, self.sortDropList, function(index, value)
 		self:SetSortMode(value.sortMode)
 	end)
-	self.controls.search = new("EditControl", {"BOTTOMLEFT",self,"TOPLEFT"}, {0, -2, 258, 18}, "", "Search", "%c", 100, function()
+	self.controls.search = new("EditControl", {"TOPLEFT",self.controls.sort,"BOTTOMLEFT"}, {0, 2, 258, 18}, "", "Search", "%c", 100, function()
 		self.listBuildFlag = true
 	end, nil, nil, true)
 	self.controls.searchMode = new("DropDownControl", {"LEFT",self.controls.search,"RIGHT"}, {2, 0, 100, 18}, { "Anywhere", "Names", "Modifiers" }, function(index, value)
 		self.listBuildFlag = true
 	end)
+
+	-- Create and set up emotion filters.
+	local function getEmotionImages()
+		local tree = main:LoadTree(latestTreeVersion)
+		local images = {}
+		for _, emotionName in ipairs(emotionList) do
+			images[emotionName] = tree.ddsMap[emotionName]
+		end
+
+		return images
+	end
+	self.emotionImages = getEmotionImages()
+
+	self.controls.emotionLabel = new("LabelControl", {"TOPLEFT", self.controls.search, "BOTTOMLEFT"}, {0, 6, 100, 16}, "Emotions: ")
+	self.emotionsAvailable = { }
+	local function emoCheckOnChange(name)
+		self.emotionsAvailable[name] = true
+		return function(state)
+			self.emotionsAvailable[name] = state
+			self.listBuildFlag = true
+		end
+	end
+	local function emoCheck(name, relTo)
+		local anchor = {"LEFT", relTo, "RIGHT"}
+		local rect = {2, 0, 26, 26}
+		local ctl = new("CheckBoxControl", anchor, rect, "", emoCheckOnChange(name), "Distilled "..name, true)
+		if self.emotionImages then ctl:SetCheckImage(self.emotionImages[name]) end
+		return ctl
+	end
+
+	local emotionCheckBoxes = {}
+	for i,emo in ipairs(emotionList) do
+		local emoCtl = emoCheck(emo, emotionCheckBoxes[i-1] or self.controls.emotionLabel)
+		emotionCheckBoxes[i] = emoCtl
+		self.controls["emotionCheckbox"..emo] = emoCtl
+	end
+
 	self:BuildSortOrder()
 	self.listBuildFlag = true
 end)
@@ -50,6 +91,13 @@ end)
 function NotableDBClass:DoesNotableMatchFilters(node)
 	if not IsAnointableNode(node) then
 		return false
+	end
+
+	-- Exclude notables the player doesn't have the emotions for.
+	for _,emo in ipairs(node.recipe) do
+		if not self.emotionsAvailable[emo] then
+			return false
+		end
 	end
 
 	local searchStr = self.controls.search.buf:lower():gsub("[%-%.%+%[%]%$%^%%%?%*]", "%%%0")

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -12,7 +12,7 @@ local m_floor = math.floor
 local m_huge = math.huge
 local s_format = string.format
 
-local emotionList = {"Ire", "Guilt", "Greed", "Paranoia", "Envy", "Disgust", "Despair", "Fear", "Isolation", "Suffering"}
+local emotionList = {"Ire", "Guilt", "Greed", "Paranoia", "Envy", "Disgust", "Despair", "Fear", "Suffering", "Isolation" }
 
 ---@param node table
 ---@return boolean
@@ -51,7 +51,7 @@ local NotableDBClass = newClass("NotableDBControl", "ListControl", function(self
 		local tree = main:LoadTree(latestTreeVersion)
 		local images = {}
 		for _, emotionName in ipairs(emotionList) do
-			images[emotionName] = tree.ddsMap[emotionName]
+			images[emotionName] = tree:GetAssetByName(emotionName)
 		end
 
 		return images


### PR DESCRIPTION
### Description of the problem being solved:

This lets users select which emotions they have available to restrict the list of anoints.

I'd appreciate if someone could check that I'm getting the emotion icon images the correct way (via `main:LoadTree`, then accessing via `tree.ddsMap` directly).

The images are displayed by modifying the `CheckBoxControl` class to have a `checkImage` field that overrides the display.  I took some liberties with the display, giving enabled controls a white outline to make it clearer when a control is selected/not selected without making it excessively difficult to see the image.

I slightly refactored the `NotableDBControl` class so that the filtering controls are included in the `rect` for the control, as opposed to technically appearing outside of it (which was weird and required offsets in the code that uses the control).

### Steps taken to verify a working solution:
- Toggle each of the emotions on and off, ensuring that listed anoints only have the selected emotions in the recipe.

### Link to a build that showcases this PR:

N/A

### Before screenshot:

![image](https://github.com/user-attachments/assets/e1693beb-5e71-467d-843d-8001c1939926)

### After screenshot:

![image](https://github.com/user-attachments/assets/aefb3018-3e97-4c7d-aa20-853956943c5b)
