### PR TITLE
add support for Buff Expiry Rate

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2239,7 +2239,7 @@ c["Break Armour on Critical Hit with Spells equal to 10% of Physical Damage deal
 c["Break Armour on Critical Hit with Spells equal to 5% of Physical Damage dealt"]={nil,"Break Armour on Critical Hit with Spells equal to 5% of Physical Damage dealt "}
 c["Break enemy Concentration on Hit equal to 100% of Damage Dealt"]={nil,"Break enemy Concentration on Hit equal to 100% of Damage Dealt "}
 c["Break enemy Concentration on Hit equal to 100% of Damage Dealt Enemies regain 10% of Concentration every second if they haven't lost Concentration in the past 5 seconds"]={nil,"Break enemy Concentration on Hit equal to 100% of Damage Dealt Enemies regain 10% of Concentration every second if they haven't lost Concentration in the past 5 seconds "}
-c["Buffs on you expire 10% slower"]={nil,"Buffs on you expire 10% slower "}
+c["Buffs on you expire 10% slower"]={{[1]={[1]={skillType=5,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=10}},nil}
 c["Burning Enemies you kill have a 5% chance to Explode, dealing a tenth of their maximum Life as Fire Damage"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Burning"},flags=0,keywordFlags=0,name="ExplodeMod",type="LIST",value={amount=5,chance=1,keyOfScaledMod="chance",type="Tenth"}},[2]={flags=0,keywordFlags=0,name="CanExplode",type="FLAG",value=true}},nil}
 c["Can Block Damage from all Hits while Shield is not Raised"]={nil,"Can Block Damage from all Hits while Shield is not Raised "}
 c["Can Block damage from all Hits"]={nil,"Can Block damage from all Hits "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3790,6 +3790,7 @@ local specialModList = {
 	["enemies near targets you shatter have (%d+)%% chance to be covered in frost for (%d+) seconds"] = { mod("CoveredInFrostEffect", "BASE", 20, { type = "Condition", var = "ShatteredEnemyRecently" }) },
 	["([%a%s]+) has (%d+)%% increased effect"] = function(_, skill, num) return { mod("BuffEffect", "INC", num, { type = "SkillId", skillId = gemIdLookup[skill]}) } end,
 	["debuffs on you expire (%d+)%% faster"] = function(num) return { mod("SelfDebuffExpirationRate", "BASE", num) } end,
+	["buffs on you expire (%d+)%% slower"] = function(num) return { mod("Duration", "INC", num, { type = "SkillType", skillType = SkillType.Buff }) } end,
 	["warcries debilitate enemies for (%d+) seconds?"] = { mod("DebilitateChance", "BASE", 100) },
 	["debilitate enemies for (%d+) seconds? when you suppress their spell damage"] = { mod("DebilitateChance", "BASE", 100) },
 	["debilitate nearby enemies for (%d+) seconds? when f?l?a?s?k? ?effect ends"] = { mod("DebilitateChance", "BASE", 100) },


### PR DESCRIPTION
Partially Fixes #180 .

### Description of the problem being solved:

Support for Buff Expiry Rate to Chronomancer

### Steps taken to verify a working solution:

- In-Game tree with the same nodes , correctly shows 10 seconds
![Captura de tela 2025-01-20 124644](https://github.com/user-attachments/assets/7e843b05-b3e5-4535-b1a3-b2a43552005f)


### Link to a build that showcases this PR:

```
eNrdHGtT40by8_pXTLnqrnJ1BvS0JQ6SMgYWElhYG3az-UIN0thWkDWONOKRVP77dc9IsmwsWWY3d1e3VIGs6e7p90xPj_fgh-dZSB5ZnAQ8Omzru1qbsMjjfhBNDtu3N6c7TvuH71sH11RMr8ZHaRDiiPF9692B_EBC9shCQNQA0QtpknygM3bYHvHYYzFLkjahiccif7AYG0xjHvEZjQCiTQSNJ0x8yjnQ7nQgNKUx9QSLL5B6PxX8kvuAOaZhwtpkRoNoxL0HJt7HPJ0fts02eQzYkwI6v7y-Gt60gcV3B9chfWHxSFBBEvh12O6DqHTCzgIBKDRMAd60dw2nvVcLf5TGiTimM3hshjeaM-YXoPqu6fTsKtjrmJ2Mx8wTwSMbxIEYTFE1C2SjCnFr4Ms0FME8DFDvGUIl_Nlr2mDjCuAbLmh4fD0qYC1n17X1enC-sEEl4c-BmB6FoMvmxM8nUSBYGd7YNd1et26K1zg22MxyapGueZDwaHupm7M2SMMQwq2MUKmpIUtY_EhFsMxSJfyAz-6DaFmxG4S-pBEd8ESUPKIO9JpBDojEEsYmhBHzOCSLpUnM3ZrgKU20Hr1yxotgzJpDbiVMhrAtN2-T42TUFG5rwm9jaAhZshnkiKdhQ0ixSFm9ypx1zJ4XUJX5IRJNUtqQ_bYE6erVsz5yDLvNUsgMcHJ2vaBqOc5ut-u6ttYzHbdyhZi-JIFHw0v6HMzSGaTmG_rAFhPqtq5XO9ZkKiLIIpXIWq9y4tMgZm_BG_DQfxPelPKkWkpNrwufklZdrWZh9vYR-jzyCgSnjuxtFMvUWl7PayZAlCFEC24c7kPWGGcxTRZ1TZxUTTZhUTbjS7NEc8GYN30Pu6ghFaxZbi6guma9bhG4rNtaqmt0W0N_GWMLNSHiejUZsImrw9pSU6N5EAeNWFKQ63yrOc4WGjiJWDx5GU0DFi6mMvQm4LnOBnTeAFP6QBm9kS8sz7eVP5dRt7QWLlTbzvZIk3KqN41evSYUfLOAYLDRBQSfrWy8terKgf-KdUO4HVo_nvE0buLNIIECbiRAvkypQmnI_NRrti4W5c9RCGVdUzEKLOAzDLdC7QtBvYdj7k8aK01OshXGMn-jdD7HghgU0pQArr6wrQ9KG6QdqwH0FfhyOVq1umW6-QQL6MYTFJuP5rOsoDSXBbcOK9M0AW48QWHOS8gVM8i7ssa_5KXUXWkaqOO2qLMkeE2dmJEbPQRhSBL8fU1jwGuTBELVY_JJUYphd33PQ7G-RN1MqERAUTxiiSCqXCbNC9lr_gRanuJRT9Igj5SgYTO4SLaVCotZ9PtLY_pL4I0mOIn8NMagbTzHKsa6aY7S8TghHhTiVFyAK6Li7-GdesbiiFyB08UQDG3ipXHCMiiFfhPMYMVIkmMqKPGzIuQTjQMaCQO9kSSMxt4UkU5pGN5DypO2Ld4qS-NB2mkQChYfwzvkGeVapajn_n2wJ0_-8Ol8NuexIOwZ_6DrvORndBJQvgE6iQgieTABiTcM22Q05U99_xFnuuE8TIqDPTqfs8hfonETM0ZonkY9ZEIKjx_IjCbA9YuKzASlKR02nvt4ukUiDgwAmuPqZkc3Ddfq2F2ta3Ycu-t2jK5p6h3bsqxeB8ZsvWP0XFfrmJrbczu6psOoobuO1TFsG1BNzbCBSte0Ol3d0syOZdndju4Y3Y7V1eCt1dN7PSDoaHbH0Hq6A0RMx4BR03Y6lq4ZQBam63Zgo6sZHROIaB3d0LtIpttzOqarmb2OYejAkmX0TKBsOT1gw-iBBKaL7Fma7XbsXk_XOrZr9gDE1Sy3A3I5Nkzl6C4gQV3ZcS14YRogl92FOYCgJmk4IK5rOBoooGs6yAVwp7sajBqWaegort1D4l0Dfmu2KafodpwuUNENS85gd010JzwaoPFLf1n3UQCmFmC-lbPdfNyShnx3cDu8kA_vpkLMk_29vaenp905FVM-Zs-wtdmFANmbAxK4wI5MUjtIda8P_44mHwdXt9H0cqdH715O7V9E2heG_pl9vIwe9J8nX-74hXbzadBzkyHte0Hi_mSN_C-fbq8s_mt8-5mf3Fr3j1_o9Mp6nD78aszOjJnzk3v2-WLmfZjc3Vufe5FzsfNL76NhWF3b_fGjdpm46ZeT96l3aYdPtN89HTzw3s9Pp7_qbBzYvxl3YfCeX55fpSdP_b4UcC-X8EAdWid76hOuPHEA3qnEP4BNSRzcp4LlAxA6zx-U-7ZJEInsWTmRchPpxMoyZXeQZs-8YcVBlakzd0RvyB0DPU26Pab6OJtLuYF0N-XZKiSUi8lgUGGgHEU6mvJu5UXK99Fn2pnQe0tSH-xhHMukgoGODx-4UGP4Mv9wIJeoBJJVLN6zWXL0AmvPKW75Vw4ys0yB0CMmVBIs4xy2RZwyTG5jmob4_mNKwwATl1Z-e6HaGhGPZ8WxC5CCxIX7OEXx5mWOKupfXGQpKZuVBH6eprKXsmPRX7A2oKGXSOaCyAtTn51H2VJcpMKQ3iMD2I3BYwR_qflRIlXM9O4AWJKLD7BwHoHrZCGoCLwP-T0NjVz-rG1jaMvjej7-qJI-xmmxIevHMX9qq33C6wG1ArbJbyV9TtgMAS-ZoD4sUnvnAuywh8bYk8yjoleoR3SWJfpihGRDhSYUix5Po8zCJaEz1aLkSi1gAjUsRyQMmcDKLJiv1o0qQQKlw2yvhL4K7L5d1fpmTX9mdM6jk1DuLvMyKvO3kt6zN2uht7VC4czXcQCeDsUenckjhYUd1AhZDG1rhzzypcm_dVQoHr5pUOgNTHXDcOtDQ9jdBVFSMs7ywBuDYpX6whj5CMmH3maMv8qDB7hJVWFV6bclmDd76xnDkGWQ9SW1soYWQyQb-2_4a6a4_4S72pvNIqu4I1XF5dYoKrs3-mipMlwov_Ty_z5LuJv1jiXcooJbBELp9VbaL5S_THih_5Wa8X_BBvlJAu7v9mW18c3tkk9Zn6ZepehhMF7r_GuyLYJ-A3VmjwAqt7xqU4uPEklCnEfzVEgWDtuzIPHu8EAAL7bIXbm8lXN0e3p6cpwdApThpYR3UTq7R5HUX6yzFOSIydNYkqT3iXo8bH8K2JPk4hh8LQgTFCoM6TwpbThxN5uxHQJeDTUJdRYUF2XW01oAVFM6eWaxAGE_09iLA1bJVzG-gSk1IZ7x46FJFTW8kVJNSJ0ZD2giVHehQlPy4k81FbyGUykODtbgns_mNKycORvdoAmBRQs4dzAOPNwY15scSxwFVaMXz0tj6r3U2Ds78K6mIa_4VBFQgzVyhVgdVEiBY9Wo6gpPFXI2WmMQeQ5aaRA1Wo1-zDxaqTY1WI1c9Lp4JG-zradSQNVQ-sAjGR9YAAUh7vErnQKqjQKkmuCVmLI4O5SronQJuS0HqY05dSRSSacEUaMreTugQkM4Vo2qet8VMuBYjV9mzeCqRBHUR_tyy7bCHmWYalKq01Gpw6xrUmOGrGFYQldLoLSAGqwRJO-ZrkXPR2vCRCbv_iMPfNU3W0tnFaou2XDvoTLsGpORvcCvJ7PaHPx6iqchTR6SCjVlg9XYtyLAndDXEcGg-joKGFtfRwEbL7M3Yw9XdzAL3GH93qVoEVWs8dlwXeBnraOK-TdTUA2uN6PL_tvb-Zfp_5iNGYhQm_8LmJroEGl0DNoQNZHRkJRka30WeSsxtRR-I1FVgGdX3upygALZQAgW87OanWYzSkXL-4zREC888_DrCL662vc1xPDWTjqnkZ-Tu1q3v19dITZqj4sEaMoe5zFeDvpaHUZs9rKGUDVfB3t5OSi7n1ijZT3bkYixpP6d89kXvFGoO7u249qmZtu6pd5njQs3a1bA3v04wPMA6X35rAj482F7xzat3W7P6elQlxvZBdcDedqQNVLwueijVNNLE6YuCKszaYmhFKVqVKCSH4vInmypQTKE1-Jln9x-OP94e9K6hq2qYPHfgUzyr4SM8Ep7JFo3PI4I1POPLGmpPQ9Rm559ouutrEO9T65jRrRdfbf0apDGwKtoqeKV-aQYMVpZ6wcetRZUT2HgQcQAxdYfIB2ULOLPPyAPT9i-_ucxu5fN-heekiAaA6ggU_rIyHeGtmNq__gbnoTEjIJpCdYc5JLi7j_1WeuPTHKgkpHTdu0___mdvaMjnuAEb-4QtQnD1NQAA6_ibIex6KasQzPKaFgukByVj0nRYiDKUwlNyMmziKliQ718K61VklIX35bkQvSMrmmuRxzwCDIIOkmu4m0Qypw3QnjF14DHcTqHUXlsdMn9IQpNpOjqtM1f9KNejYNuFISxEcLcCGFthLA3QnQ3QvQ2QjgbIdyNEMW3VORB6iIjKV0tZaFhf3jS-gD5FgFaJ89zMBY5hjShzt7IEX9qDWI6BhvtE8x9LUg54-B5nxSZ4oJ7NOz7PvPRg5Rlde3uroCEcpstfxhBamnwoZyuspsE-2SEP61hGrEMav2jXBaG7Ld90nNWcp2gk2SfysOtP0E-os65EjJGf6YRob4f4FIme4AxKACES0jXRBd27aU4qTdDU8ddZyeziZ14isez5D1NIxGCdlqqNN0nbreVlZn7xHEqLPjaLt_SSJvtYv-Fa9A2mWVF_XihoXp9X77rEHJBAsC5vr8dXuBORZ1Lq4W7LYfOy55QhaCmIfoCRduEIgu6rTD6sxScZAsEWVASc2uM7cUw1mFIZzr3AVzeaZPX2_BmWo76I3tiIclelUk3U7axBZdHLNxGcbk5yegJL9o2xhtiyt2KL-6_kPywalv2jDexp2_tDtsIdMagwhRbaYCL5BW8CmnVdsKigvoQz1hQfJbN8kRVHXLjL7tRPBoHk6wEUB-yIkDiF2-ICCDP4lG1vDa1nAzKjSlMHXINkcWQOq-_h2KS0SgrIfZeIzGEPU-OOH6JPO99YdLMga9D6rEpLD8sLqNkX73O2189TduAUP4adY5lV-OMphCJI7lGLuD1BnPkbbEcx6xhLAkmQXg1licxMJc8T2ow18jjskzcjrns-xpQm8ploay7asxZ8V1y_C40FIS-nHaATVEotsal6e0N8y9_b6RkhJ6zATOP9RzD1ZxNkxWn0YWQhlWNMphi43O9PqFOzyNBVe3y0_etg71X_1vCvwGrJARt
```

### Before screenshot:

![Captura de tela 2025-01-20 125514](https://github.com/user-attachments/assets/3f404726-81d5-49e7-a984-c070ea0cdb59)

### After screenshot:

![Captura de tela 2025-01-20 125402](https://github.com/user-attachments/assets/a092f9d0-9ee4-48b1-b2dd-331a5a0781f6)

