### PR TITLE
Add support for Accuracy Penalty at Distance

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -3055,7 +3055,7 @@ c["You gain 2% Life when one of your Minions is Revived"]={{[1]={flags=0,keyword
 c["You gain Onslaught for 4 seconds on Kill"]={{[1]={[1]={type="Condition",var="KilledRecently"},flags=0,keywordFlags=0,name="Condition:Onslaught",type="FLAG",value=true}},nil}
 c["You have Arcane Surge"]={{[1]={flags=0,keywordFlags=0,name="Condition:ArcaneSurge",type="FLAG",value=true}},nil}
 c["You have a Smoke Cloud around you while stationary"]={nil,"a Smoke Cloud around you  "}
-c["You have no Accuracy Penalty at Distance"]={nil,"no Accuracy Penalty at Distance "}
+c["You have no Accuracy Penalty at Distance"]={{[1]={flags=0,keywordFlags=0,name="NoAccuracyPenaltyAtDistance",type="FLAG",value=true}},nil}
 c["You have no Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="OVERRIDE",value=0},[2]={flags=0,keywordFlags=0,name="ColdResist",type="OVERRIDE",value=0},[3]={flags=0,keywordFlags=0,name="LightningResist",type="OVERRIDE",value=0}},nil}
 c["You have no Life Regeneration"]={{[1]={flags=0,keywordFlags=0,name="NoLifeRegen",type="FLAG",value=true}},nil}
 c["You have no Spirit"]={{[1]={flags=0,keywordFlags=0,name="NoSpirit",type="FLAG",value=true}},nil}

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2097,7 +2097,17 @@ function calcs.offence(env, actor, activeSkill)
 		local moreVsEnemy = skillModList:More("MORE", cfg, "Accuracy", "AccuracyVsEnemy")
 
 		output.Accuracy = m_max(0, m_floor(base * (1 + inc / 100) * more))
-		local accuracyVsEnemy = m_max(0, m_floor(baseVsEnemy * (1 + incVsEnemy / 100) * moreVsEnemy))
+
+		local enemyDistance = env.configInput.enemyDistance or 0
+		local effectiveEnemyDistance = m_min(m_max(2, enemyDistance), 12)
+		local accuracyPenalty = 1 - (effectiveEnemyDistance - 2) * 0.09
+
+		if skillModList:Flag(cfg, "NoAccuracyPenaltyAtDistance") then
+			accuracyPenalty = 1
+		end
+
+		local accuracyVsEnemy = m_max(0, m_floor(baseVsEnemy * (1 + incVsEnemy / 100) * moreVsEnemy)) * accuracyPenalty
+
 		if breakdown then
 			breakdown.Accuracy = { }
 			breakdown.multiChain(breakdown.Accuracy, {
@@ -2113,6 +2123,7 @@ function calcs.offence(env, actor, activeSkill)
 					base = { "%g ^8(base)", baseVsEnemy },
 					{ "%.2f ^8(increased/reduced)", 1 + incVsEnemy / 100 },
 					{ "%.2f ^8(more/less)", moreVsEnemy },
+					{ "%.2f ^8(penalty at %dm distance)", accuracyPenalty, enemyDistance},
 					total = s_format("= %g", accuracyVsEnemy)
 				})
 			end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1404,7 +1404,7 @@ Huge sets the radius to 11.
 	{ var = "skillPierceCount", type = "count", label = "# of times Skill has Pierced:", ifStat = "PiercedCount", ifFlag = "piercing", apply = function(val, modList, enemyModList)
 		modList:NewMod("PiercedCount", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },
-	{ var = "enemyDistance", type = "count", label = "Distance to enemy:", ifTagType = "DistanceRamp" },
+	{ var = "enemyDistance", type = "count", label = "Distance to enemy:" },
 	{ var = "conditionAtCloseRange", type = "check", label = "Is the enemy at Close Range?", ifCond = "AtCloseRange", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AtCloseRange", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4281,6 +4281,7 @@ local specialModList = {
 	["chaos resistance is zero"] = {
 		mod("ChaosResist", "OVERRIDE", 0),
 	},
+	["you have no accuracy penalty at distance"] = { flag("NoAccuracyPenaltyAtDistance") },
 	["nearby enemies' chaos resistance is (%d+)"] = function(num) return {
 		mod("EnemyModifier", "LIST", { mod = mod("ChaosResist", "OVERRIDE", num) }),
 	} end,


### PR DESCRIPTION
Fixes #187 .

### Description of the problem being solved:
Accuracy Penalty at Distance is currently not supported.

### Steps taken to verify a working solution:
A from mechanics testers is required.