### PR TITLE
improve implementation of Kaom's Heart 'You have no spirit' mod.

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -3058,7 +3058,7 @@ c["You have a Smoke Cloud around you while stationary"]={nil,"a Smoke Cloud arou
 c["You have no Accuracy Penalty at Distance"]={nil,"no Accuracy Penalty at Distance "}
 c["You have no Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="OVERRIDE",value=0},[2]={flags=0,keywordFlags=0,name="ColdResist",type="OVERRIDE",value=0},[3]={flags=0,keywordFlags=0,name="LightningResist",type="OVERRIDE",value=0}},nil}
 c["You have no Life Regeneration"]={{[1]={flags=0,keywordFlags=0,name="NoLifeRegen",type="FLAG",value=true}},nil}
-c["You have no Spirit"]={{[1]={flags=0,keywordFlags=0,name="NoSpirit",type="FLAG",value=true}},nil}
+c["You have no Spirit"]={{[1]={flags=0,keywordFlags=0,name="Spirit",type="OVERRIDE",value=0}},nil}
 c["You lose 5% of Energy Shield per second"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldDegenPercent",type="BASE",value=5}},nil}
 c["You take 10% of damage from Blocked Hits"]={{[1]={flags=0,keywordFlags=0,name="BlockEffect",type="BASE",value=10}},nil}
 c["You take 20% of damage from Blocked Hits"]={{[1]={flags=0,keywordFlags=0,name="BlockEffect",type="BASE",value=20}},nil}

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1485,6 +1485,7 @@ return {
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC", modSource = "Tree" }, }, },
 	{ label = "Total Base", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE" }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC" }, }, },
+	{ label = "Override", haveOutput = "SpiritHasOverride", { format = "{0:mod:1}", { modName = "Spirit", modType = "OVERRIDE" }, }, },
 	{ label = "Total", { format = "{0:output:Spirit}", { breakdown = "Spirit" }, }, },
 	{ label = "Reserved", { format = "{0:output:SpiritReserved} ({0:output:SpiritReservedPercent}%)", { breakdown = "SpiritReserved" }, }, },
 	{ label = "Unreserved", { format = "{0:output:SpiritUnreserved} ({0:output:SpiritUnreservedPercent}%)" }, },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4272,7 +4272,9 @@ local specialModList = {
 		mod("ColdResist", "OVERRIDE", 0),
 		mod("LightningResist", "OVERRIDE", 0),
 	},
-	["you have no spirit"] = { flag("NoSpirit") },
+	["you have no spirit"] = {
+		mod("Spirit", "OVERRIDE", 0),
+	},
 	["you have no elemental resistances"] = {
 		mod("FireResist", "OVERRIDE", 0),
 		mod("ColdResist", "OVERRIDE", 0),


### PR DESCRIPTION
These changes allow the calculation and display of negative unreserved spirit and the warning associated with it. it also adds a line in the calcs panel in this scenario that shows where the override is coming from.

The linked build also has negative life and mana custom modifiers to make sure the life/mana reservation code is unnaffected in those cases.

### Link to a build that showcases this PR:

https://pobb.in/kglYQAEZMgvn

### After screenshot:

![image](https://github.com/user-attachments/assets/aacf00c1-93a7-471f-beb4-ca15f1dcde16)
![image](https://github.com/user-attachments/assets/ab060915-bd53-4905-8f34-94c40f20d96f)
![image](https://github.com/user-attachments/assets/a8a149b3-cff4-4832-9f4b-e9406cc6c40e)



