### PR TITLE
Fix crash when hovering over breakdown for Minion skills

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -740,7 +740,7 @@ for skillId, grantedEffect in pairs(data.skills) do
 		statSet.statMap = statSet.statMap or { }
 		setmetatable(statSet.statMap, data.skillStatMapMeta)
 		statSet.statMap._grantedEffect = grantedEffect
-		for _, map in ipairs(statSet.statMap or {}) do
+		for _, map in pairs(statSet.statMap) do
 			-- Some mods need different scalars for different stats, but the same value.  Putting them in a group allows this
 			for _, modOrGroup in ipairs(map) do
 				if modOrGroup.name then


### PR DESCRIPTION
### Description of the problem being solved:
Mods of type "LIST" containing other mods like
```lua
 mod("MinionModifier", "LIST", { mod = mod("DamageTaken", "MORE", nil) }),
 ```
and originating from (support?) gems weren't properly propagating their source to the inner mod which resulted in errors when viewing breakdowns.

### Link to a build that showcases this PR:
https://pobb.in/hmHfkHNk0PP_
### Before screenshot:
![image](https://github.com/user-attachments/assets/edf26d19-d56d-4656-9eda-c33035354056)

### After screenshot:
![image](https://github.com/user-attachments/assets/7ff634db-59af-4c06-80d8-bfb88694a48b)
