### PR TITLE
Fix Minion Spell skills doing 0 damage

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -148,7 +148,7 @@ function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet)
 			if statSetLevel.statInterpolation[index] == 3 then
 				-- Effectiveness interpolation
 				if not availableEffectiveness then
-					actorLevel = statSetLevel.actorLevel
+					actorLevel = #statSet.levels == 1 and skillInstance.actorLevel or statSetLevel.actorLevel
 					availableEffectiveness =
 						data.gameConstants["SkillDamageBaseEffectiveness"] * (statSet.baseEffectiveness or 1)
 							* (1 + (statSet.incrementalEffectiveness or 0) * (actorLevel - 1)) 


### PR DESCRIPTION
The minion skills take the actor level of the minion when there is only 1 entry in the levels table with a stat interpolation value
