### PR TITLE
Add Stormweaver Scouring Winds mod Support

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2483,6 +2483,7 @@ local specialModList = {
 	},
 	["(%d+)%% increased area of effect while you don't have convergence"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "Condition", neg = true, var = "Convergence" }) } end,
 	["exposure you inflict applies an extra (%-?%d+)%% to the affected resistance"] = function(num) return { mod("ExtraExposure", "BASE", num) } end,
+	["exposure you inflict lowers the affected resistance by an additional (%-?%d+)%%"] = function(num) return { mod("ExtraExposure", "BASE", -num) } end,
 	["cannot take reflected elemental damage"] = { mod("ElementalReflectedDamageTaken", "MORE", -100, { type = "GlobalEffect", effectType = "Global", unscalable = true }) },
 	["every %d+ seconds:"] = { },
 	["gain chilling conflux for %d seconds"] = {


### PR DESCRIPTION
### Description of the problem being solved:
Adds Scouring Wind mod support for Stormweaver (called it Elementalist in my commit... Oops.)

### Link to a build that showcases this PR:
https://pobb.in/8gNhxMRJ7QWU

### Before screenshot:

![before](https://github.com/user-attachments/assets/327d92dd-cd49-4bc0-80e6-97e69ae6b0e8)

### After screenshot:

![after](https://github.com/user-attachments/assets/4ceacf88-3583-4cad-a7fc-a87d9dc965dd)

