### PR TITLE
Increase Shock Maximum per Stack to 100%

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -300,7 +300,7 @@ data.nonElementalAilmentTypeList = { "Bleed", "Poison" }
 data.nonDamagingAilment = {
 	["Chill"] = { associatedType = "Cold", alt = false, default = 10, min = 5, max = data.gameConstants["ChillMaxEffect"], precision = 0, duration = data.gameConstants["BaseChillDuration"] },
 	["Freeze"] = { associatedType = "Cold", alt = false, default = nil, min = 0.3, max = 3, precision = 2, duration = data.gameConstants["FreezeDuration"] },
-	["Shock"] = { associatedType = "Lightning", alt = false, default = 20, min = 20, max = 20, precision = 0, duration = data.gameConstants["BaseShockDuration"] },
+	["Shock"] = { associatedType = "Lightning", alt = false, default = 20, min = 20, max = 100, precision = 0, duration = data.gameConstants["BaseShockDuration"] },
 }
 
 -- Used in ModStoreClass:ScaleAddMod(...) to identify high precision modifiers


### PR DESCRIPTION
### Description of the problem being solved:
Increases Maximum Shock per stack to 100%, as you cannot set it above 20% currently in POB.

### Link to a build that showcases this PR:
https://pobb.in/8gNhxMRJ7QWU

### Before screenshot:
![before](https://github.com/user-attachments/assets/8020d216-52d7-44d8-b555-947dfbf40304)

### After screenshot:
![after](https://github.com/user-attachments/assets/340a8267-9ca9-49ea-9b6c-147e2900d38a)
