### PR TITLE
Add Lightning Conduit Shock Mod

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -10723,6 +10723,11 @@ skills["LightningConduitPlayer"] = {
 			incrementalEffectiveness = 0.14000000059605,
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "lightning_conduit",
+			statMap = {
+				["consume_enemy_shock_to_gain_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
+					mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "Multiplier", var = "ShockEffect", div = 5, actor = "enemy" }),
+				},
+			},
 			baseFlags = {
 				spell = true,
 			},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -708,6 +708,11 @@ statMap = {
 #startSets
 #set LightningConduitPlayer
 #flags spell
+statMap = {
+	["consume_enemy_shock_to_gain_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
+		mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "Multiplier", var = "ShockEffect", div = 5, actor = "enemy" }),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Port the Lightning Conduit Mod from POB for POE1

### Link to a build that showcases this PR:
https://pobb.in/8gNhxMRJ7QWU

### Before screenshot:
![before](https://github.com/user-attachments/assets/19f65e62-c148-4b0d-a4ef-a6796187b423)
![before2](https://github.com/user-attachments/assets/756890b4-c659-44b3-aae4-d94f51ddcf29)

### After screenshot:
![after](https://github.com/user-attachments/assets/de52070d-c35e-4c7d-840e-9aae36377cf4)
![after2](https://github.com/user-attachments/assets/dd399b3c-fe2b-419a-82b2-31324f8eeb01)

