### PR TITLE
Make Ice Bite work as intended

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -947,9 +947,6 @@ return {
 ["non_skill_base_all_damage_%_to_gain_as_fire_with_attacks_vs_burning_enemies"] = {
 	mod("DamageGainAsFire", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Burning" }),
 },
-["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
-	mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" } ),
-},
 ["base_physical_damage_%_to_convert_to_lightning"] = {
 	mod("PhysicalDamageConvertToLightning", "BASE", nil),
 },
@@ -2293,7 +2290,7 @@ return {
 	mod("AdditionalCooldownUses", "BASE", nil)
 },
 ["kill_enemy_on_hit_if_under_10%_life"] = {
-	mod("CullPercent", "MAX", nil), 
+	mod("CullPercent", "MAX", nil),
 	value = 10
 },
 ["spell_cast_time_added_to_cooldown_if_triggered"] = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -851,8 +851,12 @@ skills["SupportInnervatePlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
-				["support_innervate_buff_base_duration_ms"] = {
-					-- Display only
+				["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
+					mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
+				},
+				["support_innervate_base_buff_duration"] = {
+					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),
+					div = 1000,
 				},
 			},
 			baseFlags = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1892,10 +1892,10 @@ skills["SupportIceBitePlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-					mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+					mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 				},
 				["support_ice_bite_base_buff_duration"] = {
-					mod("Duration", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),
 					div = 1000,
 				},
 			},

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -230,8 +230,12 @@ statMap = {
 #startSets
 #set SupportInnervatePlayer
 statMap = {
-	["support_innervate_buff_base_duration_ms"] = {
-		-- Display only
+	["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
+		mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
+	},
+	["support_innervate_base_buff_duration"] = {
+		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),
+		div = 1000,
 	},
 },
 #mods

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -498,10 +498,10 @@ statMap = {
 #set SupportIceBitePlayer
 statMap = {
 	["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-		mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 	},
 	["support_ice_bite_base_buff_duration"] = {
-		mod("Duration", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),
 		div = 1000,
 	},
 },


### PR DESCRIPTION
This commit also makes Innervate work similarly to Ice Bite in terms of how the stat map is written.

Fixes #507 .

### Description of the problem being solved:

When adding the support gem `Ice Bite` to one skill, the 35% Cold Damage Gained is applied regardless of whether an enemy has been frozen recently or not.

### Steps taken to verify a working solution:
- Check mod and damage gained

### Link to a build that showcases this PR:

https://maxroll.gg/poe2/pob/uvfcq0y9

### Before screenshot:

![image](https://github.com/user-attachments/assets/84104ae6-61d8-4cc1-8fb2-ede28a1e8fcf)
![image](https://github.com/user-attachments/assets/003febc7-1ca1-4e2b-90d4-1a119ae0f837)

### After screenshot:

![image](https://github.com/user-attachments/assets/5363424e-424e-48b0-8b21-a6f63efe5298)
![image](https://github.com/user-attachments/assets/1da11597-613c-4c32-8087-3bbe895246f9)
