### PR TITLE
Add support for Oasis keystone

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2252,8 +2252,7 @@ c["Cannot be Poisoned"]={{[1]={flags=0,keywordFlags=0,name="PoisonImmune",type="
 c["Cannot be Shocked"]={{[1]={flags=0,keywordFlags=0,name="ShockImmune",type="FLAG",value=true}},nil}
 c["Cannot gain Spirit from Equipment"]={{[1]={flags=0,keywordFlags=0,name="CannotGainSpiritFromEquipment",type="FLAG",value=true}},nil}
 c["Cannot have Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="CannotHaveES",type="FLAG",value=true}},nil}
-c["Cannot use Charms"]={nil,"Cannot use Charms "}
-c["Cannot use Charms 30% more Recovery from Flasks"]={nil,"Cannot use Charms 30% more Recovery from Flasks "}
+c["Cannot use Charms"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="OVERRIDE",value=0}},nil}
 c["Cannot use Life Flasks"]={nil,"Cannot use Life Flasks "}
 c["Cannot use Shield Skills"]={nil,"Cannot use Shield Skills "}
 c["Carry a Chest which adds 20 Inventory Slots"]={nil,"Carry a Chest which adds 20 Inventory Slots "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1293,7 +1293,7 @@ function calcs.perform(env, skipEHP)
 
 	local effectInc = modDB:Sum("INC", {actor = "player"}, "CharmEffect")
 	local effectIncMagic = modDB:Sum("INC", {actor = "player"}, "MagicCharmEffect")
-	local charmLimit = modDB:Sum("BASE", nil, "CharmLimit")
+	local charmLimit = modDB:Override(nil, "CharmLimit") or modDB:Sum("BASE", nil, "CharmLimit")
 
 	-- charm breakdown
 	if breakdown then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4687,6 +4687,7 @@ local specialModList = {
 	["can't use other rings"] = { mod("CanNotUseRightRing", "Flag", 1, { type = "DisablesItem", slotName = "Ring 2" }, { type = "SlotNumber", num = 1 }), mod("CanNotUseLeftRing", "Flag", 1, { type = "DisablesItem", slotName = "Ring 1" }, { type = "SlotNumber", num = 2 }) },
 	["uses both hand slots"] = { mod("CanNotUseRightWeapon", "Flag", 1, { type = "DisablesItem", slotName = "Weapon 2" }, { type = "SlotNumber", num = 1 }), mod("CanNotUseLeftWeapon", "Flag", 1, { type = "DisablesItem", slotName = "Weapon 1" }, { type = "SlotNumber", num = 2 }) },
 	["can't use flask in fifth slot"] = { mod("CanNotUseFifthFlask", "Flag", 1, { type = "DisablesItem", slotName = "Flask 5"}) },
+	["cannot use charms"] = { mod("CharmLimit", "OVERRIDE", 0) },
 	["boneshatter has (%d+)%% chance to grant %+1 trauma"] = function(num) return { mod("ExtraTrauma", "BASE", num, { type = "SkillName", skillName = "Boneshatter", includeTransfigured = true }) } end,
 	["your minimum frenzy, endurance and power charges are equal to your maximum while you are stationary"] = {
 		flag("MinimumFrenzyChargesIsMaximumFrenzyCharges", {type = "Condition", var = "Stationary" }),


### PR DESCRIPTION
### Description of the problem being solved:
Cannot use charms modifier is currently not supported

### Steps taken to verify a working solution:
- Equip A belt with +2 Charm Slots; Amethyst Charm; Ruby Charm; Sapphire Charm
- Allocate Oasis keystone
- Verify that bonuses from charms no longer affect the player

### Link to a build that showcases this PR:

```
eNq9W1tz4joSfp78ChevmwnmGpIic4oAmaQ2Fw4kMztPU4otQBthsbachLO1_327JdsYgoxMtnYeZmzcX9-kbnW3Pd0_3hfceaVhxERwUamduBWHBp7wWTC7qDw9Xn3tVP74dtQdETl_mF7GjOOT-rejL11143D6SjkA6xXH4ySK7smCXlTGJJjRsOKQyKOB318_uBcBrTiShDMqf6RS3d81QM9JSDxJw1vk2IuluBM-IGQYA2JBWDAR3guV30MRL0FgxXll9E3T3NyNHsaPFdDqS3fEyYqGE0mkE8FfF5UeWEdmdEAW8DegCI8B4p647WalWgi5jMNIlsFNlpT6GWntpG4iHIV0OJ1ST7JX2g-Z7M9J4OWEmHBlae9iLtmSM1yLhN6o0_UH1rW2ifZRSMIHo0neLaftTjG5kPuV_snk_JKDF-2ZI-RmFjBJy2FGgkUiKG_EBsLo_JhzCBQr2jGNaPhKJNvSxshbLJ5ZUMZFdyQgfRFZ-B8pRzSEqJWlABPqCQj0sjJKIm_ZlNpTlrIjAZTV5jA7hhNbutKMD1NoDCnOjnIiYm5JKddJp2XMOgP6vs43LRPVTbAWeGpm9SowiParpkJ5eD1aJ8XG6Um7Veu4p81Gu1Yzpu35KmIe4XfknS3iBWTMR_JC1wIb7ql5s8zmMoCUYMLWa2cm7BUL6QGwvuD-IbA5EdEBFt7BEX1NAr_neTGc5Kv1srqdohCy4Q0Hq3eOxDeBl9EXcn0KQpVWc-dx4epM6RjiBc_9Z05tIWshSdjlbHaLZc1okAhc2WWaW0q9-Xfw8ZhIapdkM6qzeqFjkTbv2EKmOxxrZr8JKOEkBO52UuPktAhU0k2TJYMyyUYjTbnD-hKYEg4YBjScrSZzRrlvkfdz1KnH-mRpYz-sfx5ttQ82xZXaynloybXCQ6qstFcS5U-E07NiR2hyu1igUKYCwKe2BfkoFP_Ekp-Xg_XChYhDy6XUxFYGpIeZbnDG1I89u9Mz61wuOXRktmZkKNCT81LQnpTEexkIf2btNCWkFGJTv0m8XELU4m6wZYCnNJTyLFcbfW1aUD_AVraKVTzP7QWsqa0FZDWKvZQtiL0tWGRsibEhthaQLecdpIoFJF3Vm9-JXN42Lg30blaNmCK0bAhH4g00n-PgIypHDaXY-vAzqhLS4K-VNf8NcisBw8CHqg4CwVrGNmKXmMt4Oo0cDxpaIm9heS8qFecZfkuvoZKMaHKjEY9sAYk3igZEEsdPKv4fJGQkkHU1FoooCb05gq4I58-QOZDT-le82wLW0t3QraqpFl7dLJYilA59x39GJJSri8qU8IhqQvUL8IkkC1TrDmmK84ozmYu3nv-Kdj8KwaMU5JDlkgb-Bo_HkFKHpEnHQyWUjXjjLEgk4YzT-zhCpXPDtBsfHe8EAhS4qDQ7Tbd2XHPP3LPjlttsnR3X26ed9nGtDU-O6y0oM9T12XGt0al3jmu1pnvc7LTacNlquafHzXq95aKPsGMk4aq3KSlgYJgEZbcmdmtNUO0v3afxrbr4MpdyGZ1Xq29vbydLIudiSt_h2DuBha4uAQQGf41eGOdfkWu1B38uZ71e_9Qd_31ZE-Ll8uXX7L1HHn8NL68nZ_Fg9bj8UwDVxYUSVE0ldfVMMKrqO8wOIQOfaDW6cHCE7DmWNH0AC_Z-r51WcVggs-tIhvcfnam9k3emdmPiO-VG5bpEfnVDgW4VF1LtKlxpvLgXUj_DH9Ob7gRdETkRbLTvdBFdriCjXGGBtDXrSbYKUk-o1Js9j0mHpT6dkpjj73_GhDPcuW7-11s9sw1EuMh6WWAFOxePPc3xcbVEb_Rub5M9mUh1mL8OFq04XvYJ97TRN8Eylk6gpr0LFnm_MZ5xTKucrMbKw6urYf_x5scwiek8RG2L30G8eMaZpf53nasnVNUoThQ_R_ryovKD0TelyIBKwjhkJk9wTpYRzaJNKZ1YwAFXwE1RQdubjn1381oTmDkN32kIyWH2ExJPyKhRr-z5HqW0QCx8MQeauOGU1cxIV1J9SC265DZ4So2xzVxwsmw0Bx8WYCGtEm6UnDzd4wmJexNCi02ZhwdO8ZLjTtZUBX7JZhbG9U7KQDMPNbY2MdAPzWA9jDahk6cFXlXzb6NX9VMzfEA9YrRdPzSDsy5OBNfYSu_mklEVcLoXgdrkEDQ9xrFoM67skNOMxMzwQc5pmJygJk53kKNSksLA0SeJkU-OosBXat5l8BA-M0P1QMdgAz4rCJpkyGGKdlYcspujCMN65GnMrHQRb_Rh0hAULEPSCxuWQD8tsCQdBxiMSB4XBIrKwb1XwXzdFBpCZousKGlAAfN5NqrT_Tyb7db38xyvoEZ8Ma538tQMf5IM65cdXHSlY8UEA-tzHDC-PscBe6DFwejxdimyxo6Li5CsW9sJTp8WxX7SxB3MQbeaB8NVJ3wwWh0AAzqlYEHhCZDRFASHjIMBOEMWBIYlK6XW7iyytq4UL30W7rS0NEcd3cl7n6IEoEn2MILD_LqgXLTjlE1zrinh-Ope8M8x_PB-6zPMcB4dL0ngp-wedhXp63Ww9J6QEfBUA4kBjr0_68OALlY7GJn16lbTtk6NKrDRSuYoExli1_yXEItfOB9sNU7qzUajrX9K-stO0lNC7T1gsICh2nipQCT8B2Dbnc6J2-mc6W9NujcSutmk08XrrNE1c4ojqt91_6RkKQKFwJGF7i2BR9Kzqh59TKDYWZ074954eHQPBiHB0RX02M4l5fJIJWpnwsH5507jqB-SqaT-uYOijkYhnbL3cwe_Yiq4mUDH--Hm3yF-E3Ve-0_P9xmuCOFKVn2TXPluTP917rTrR9AOceYxVKV2pE8JZwY1tOOe1E7VF1OQ_pwlDR3tgKO_1Z2cAWomAa23-hrLUfLxS5FWJdfEF1Gkr_Wq6KNNb9Y3vXnX-37TP-otqJyvIql1KPLdhsnJkOLccXPWN91N659grzpvcxo4KxE7Evaoo8bCjq82rTMNxcIhDkSgQePGLo3H8fPqf6Fta6-yOO-31rW5S9cJWS7nyOX_oi--PrDRF0dCpgDMx10Xd6QDbehi9Pw0vsXsoQc-37l4xRMLH-lhYrUYoIU4tRIQFTqlEL1FzKm0AuhclSYjDddB2Fjjm4fgcwrX7Uysl_djGQhmyDV5zXalnMkbvrKxFjOGmqGcXsJfOWlvWNoBB6lX--TeyJnX2CfwmkJ1J0v5Q8iPIaUjF6JTHe3qoFWjWxFM2SxRVd8kh64CZb9sRPOIE4_OIUfA2aNlUiwvkg9g07HtqZupagBsvAdMYftA2UvHdEibjYnden2fwNwXtCmstQeTf7ObYfZaBr8coB_KOgCmUvsa0Wma6RfZN8H4FSzUUv5EDYVFHMgJ5dOc3JaFjaUdk63eCOvuFNawRZVfCNxi2y5tumd7YNmsKPNpkVMnc-G9KD9GH95aFO5F_AIDEtFLQKNoG1_fZ9rmJxzl4gB-sV2AiSdUzV_OuuS7Emg0VHWZzwp7kGkmzyTVO2cFmIjNGH-YqkkBKKnGHWWWYNt7DdciRm1915_jW6fdroP-Kk2uuttSd9-OutUP_93iv2B9Cb4=
```