### PR TITLE
Fix Corrupting cry using reduced effect instead of less

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -367,7 +367,7 @@ skills["SupportCorruptingCryPlayer"] = {
 					mod("CorruptingCryStagesFromWarcry", nil, 0, KeywordFlag.Warcry)
 				},
 				["support_corrupting_cry_area_of_effect_+%_final"] = {
-					mod("AreaOfEffect", "INC", nil, 0, KeywordFlag.Warcry)
+					mod("AreaOfEffect", "MORE", nil, 0, KeywordFlag.Warcry)
 				},
 				["support_corrupting_cry_corrupted_blood_duration_ms"] = {
 					skill("durationSecondary", nil),

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -96,7 +96,7 @@ statMap = {
 		mod("CorruptingCryStagesFromWarcry", nil, 0, KeywordFlag.Warcry)
 	},
 	["support_corrupting_cry_area_of_effect_+%_final"] = {
-		mod("AreaOfEffect", "INC", nil, 0, KeywordFlag.Warcry)
+		mod("AreaOfEffect", "MORE", nil, 0, KeywordFlag.Warcry)
 	},
 	["support_corrupting_cry_corrupted_blood_duration_ms"] = {
 		skill("durationSecondary", nil),


### PR DESCRIPTION
Fixes #532 .

### Description of the problem being solved:
We were using the wrong modifier on the stat
### Steps taken to verify a working solution:
- Tested with the build below

### Link to a build that showcases this PR:
```bash
eNqlW1132jgTvu7-Ch-uafAHYNhDdg-BpKGbNCwk7e570yNsAdrIFrXlJPTXvyPJNoYiY5O9SI01z8xoRjPSjLyDP98CarzgKCYsvGxYF2bDwKHHfBKuLhtPjzcfe40___htMEV8_bC8SggVI_Yfv30YyB8GxS-YXjZsu2F4FMXxFxTgy8Y3FEWERQ0DxR4O_dHeyCICFhgGOYpWmH_NhJvfLWCyRhHyOI7uBONhwtk98wHHowQ3jACRcM68Z8w_RSzZgMIN44XgV0UzuZ8-zB4boNyHwZSiLY7mHHEjhj-XjSFMEq3wLeEAQTQBeqvfveg0WqX0V0kU8zEK4LEabr7B2M9JzQvLbrum07N7bdPtODoUmMWLtiMU80cS4ALc6bhW2-6pv10dfBrh6-USe5y84FFE-GiNQq_ARoerS3ufUE42lAjvpfS2jv72F9aWqWX-yDii4-l8x7Z90THbjmnbPdvslcMYP639N8LXQFhfxIhFUbLhsGSvKGP-HoN-mbQrCguhvjwBnaxCwvF52CkjMQvPN2W1CY4SSsEkRWKt6Wc4xtEL4mRfLf1CY8GChPu26zjVfMWoz17DHNa7MC3tHIYRRg9LFTcz5JMkvsc8wnGOdi60ku5RiEYsLuQSs19GO8URJEK-BzFPAObYY5A796SAGfq2a7l2v9u2rQoSj_PRir4jS1ydstasUkBdbc6bx_W8Kl1txucpNIMNpBrlnCW0IiXfpWHL6ujj70eR0ja1lGP8lpO5OqJJyE8TjfELEwF_ehIy71zfTnPKdtu-cPtmv9d3O2ZXv-WttzHxEL1HbyRIAthtHtEz3gnsuLZ-Wa3WPIT0pcO29cF8QyJ8BmwEiekc2Bqx-KwZLnEVOjiseL8L4kno7ZJmGdenMJLpvHDGOaHHDKJEnKUWFFeF7ISkwVblCKFkrXCYCtxWyy93GHvrT3CunCGOq-XmQjout6wgLlq2lOsRy5bw30fUMJMAHjdT58IpA9U01HxDIlJJI0V5bPrVMTUMcB3iaLWdrwmmfoV8X6DOLDZCmyrzhwVQRFdaCPviai3mIrSmr8TmVFfaC4qL-b3vlBtCkVcLBgwnZwD4uGppMo3Yf6L4ofVgwyhgSVTRlYq40gSyrUmVjTPsJ161vTCv4aDU8J6rTiNHgZ6U1oIOOUfe85j5q8pGk0JqIfb1myebDUStWA1VGYg9F4oIUjgTfWxXoH6ApVwpVsXuXF3AjrqygPzEUV3KAaT6XMSR4UBMFeLKAnJ33kOqCCDpyo7HPSvkba1roGqsVAJKwv1aVB9t7BU0X4teUlyPGg5Wu1pPq0qEw5_byvz3yCsJuA79JBKBUFnGIeKYmKtkuYwND0ppxO_AvZeNhrGAd9mzl0QxTn8ohGg8UQjMMeLI8NPz-1cUERRyW3baYowiby1AN4jSBWQOwWn3Vv6S3bkbQjmOxvBOqCmmcsjRypbJoCUbieJpEmxYxA38Jv6ZoohvLxtLRGOsCOUb4BNzEspuAuQvShvGfM1eh_6LkPTIGI0zkIE2Gxz6ezweI4wNlGUjTyghJy9-GAGKQeutWuCxmE2hfTnxRa_LCBkoAGelnt3vNNuu3XWattXp9ppOz7GdZrvvOu1mu9d1rKbd63TbTcfpWXbT6bTtbtPpO_DHgdKm2W1bltu04Ifb7Fg92wIGrglv2t0OMLAE4zYU-p2mZdntXtPuu127CZJcq2nZQNg1LaFAHwRZHbdnN0VLQLwxgaPV74PkvmuZzXa3awPc7lpd4StRsaJoO9yfWEjAjhxsc9CMzcaVlT4MnmZ38uHDmvNN_Hur9fr6erFBfM2W-A223wtYcK0NgMC-H-NnQulHwbU1hP-uVtejW_zgJJ_7T39__vbz9Rn1-_bHJxJMpv9OHm8-hk_mV2_D6c_7zvTH9ctf36_Mv_8znas775-lG7tT9L-fPxfLzlXvx-I2-vf5280KuF5eSsVamWYD1R6OW-qXyGoRAZcptQew4UVkkXCcDcB6evuifNowSMjz55hHX371tfKscpXyqTK-8r5aCdIzBU8pB6auUu6Vq0Q5X_lH-UotBOWrdAKtvRkMWmKhyqgRK1k8fGFcjYmX2Y_BXNg-hmiM-CccxFdbSKU34mR40F5LQ0FQzzFXUV7EZI13Hy9RQsX7vxNEiYhMs_j2Tl0DhCwK8pIcWEFkiv1ecXzcboQ5h3d3acylUg1SWGHypezzD3eqjRD1YqkcCT2a-FCupltJHusULYQC4vZCVJp-8cagwCkX9GEAGsl8ChpMQlgFaRQo_CfKFojaGZfslsPcH7ey8ReV1ESozDGJA-KNxCFaRsD-S5XMG8aPghlXOBBE95gjH5Jva8LB_C3hg5ZUGp6KXEMUpMkrfWvI1wcT91gSpg4tTDK1pJhp63w7WKfNsGubg3LpGigaRL3Zo6prmnxh7XEp2mc38B4TDZQX0vhLF62MQRVl4lGCJMUk3CRc6nDZCEjsfRe7rrifkilFXqtd39xcjx4nX6_TnbcIkRb6HibBQphC_bs7Uc2xrCSMOFnE6vGy8ZXgV6nIGIxEaCzmRSnaxDjf-mSEpZpTwJVwk1S3JL_yOs5rR6DndP2GI2F6ebVFsFavfPyEUkqgKE_VFdlxbuIySM9I1Tvimk0VxhpLySs8PRdxE6adjhgswcIZB1Gt5HT0hCW4SKSwwMmSeOJYWO5ykXYVVYldPDgPIm9b4u-0WNPzkPddOgZqUA9Wt1Y6dDpaYlV5Yaa1qhrVw8fYQ9q5q0E9OO-1sFBeLh_nklOVcPrCQrnIIWiGhIrSSuvZa4pzEj3DB77GUXqc1XG6hxyVkZQGjjo3afkUKEpsJfvSGguJMT1UNV41cxBjJUGTtiJ10U7KQ3a_YajxR5FGz0qV2lobpmV7iRvSjpXGBWq0ZCZZ004ziXS4JFBkDh6-MOKr1o0mZA7IypIGHNffz0b2o97P5rBB9X6ON1BBPWv9nY7q4U-ciKPQES7qBFOJiQis93EQ8fU-DqJTEZyNnh0eRXbYWfkhJO-pHAVno2Wxn7ZazuagGkJnw2W_6my03ADGeIlhBqU7QE5TEhw8CcdgDF4SGBVZSbWOZ5Hd7GrxUnvh0ZnW5qiiO71rLUsAiuQEI9jMb0uOi9U45T3XW4yo-MaH0fcx_OVO-T3MxK1RskGhn7F7OHZI3_mhovUYj4Gn7A6OxeXUe20Y4mB7hJFer0ErK-tk31AUWmm3c86hKPOgjDBi9bnfT8aCf0WDwLno96x237KtvttR79PeiGWmDRE4i48JODSSCzFTQFD-c9lwrc6F6_Zcq98xu5b6vmIgq960VyOe81aNnl0SY_V5yjeMNiyUCGUyVXIqLiVk-10ZyrgBZ-hgunia3Yk2i6pWof5_EeEmhkSdbmYlsw6gxBhWDYjcHWohhkFCMa8BkLuT4RxDyG7ixAdy2foVg7KBm0E_41dMjfRVkXUlkfXtYNc3dh3IFab8DHca81dxdVTJfLK3vW--9FUN881ET6fWxJi_NbLjc20LaudXpp5VewXWmdAthi2P17IA47-G6qCVpgJ1BxQhHxKCSHHfsLiAjFUelAlI9rlYuCSrNBWpH2kykvj8jcEJp1gUz7JDvJ9NphR5eM2oj6NUNyxyc_rldNbzcs18ShrA3lVnBjsFyu9Vsw5X3mMzbfuUwMLn0hmscwJTvLzOMSdnBm_O0E_IOgMmN6gdotfW0wf5B-DiW2PYc_y57KiJTuoc02VBbqfCHGsbJvfeVBxaMphTFVXfEWKJHZo0_2Cv1BFVNZyvIUlKK8a_NHxLV6L4xAQS1HMIxeoh3q6ywmrZMP2YBc5NMxQWreGWiJp7TJ6W6k_u0ObOqQlluT0XYvf6JZiYrAh9WMryCvSTNWJV_fa_76kVankHJg-2smgbrUXL_rj14HCaJVt1VJW__vht0Prl_9X5Pzc8sWw=
```
### Before screenshot:
![image](https://github.com/user-attachments/assets/79949a2c-55ae-4442-a8c1-41a27b791e1d)

### After screenshot:
![image](https://github.com/user-attachments/assets/6c9df598-9e6a-432f-9038-f654b54bb248)
