### PR TITLE
Fix Gamblesprint missing movement speed mod 

### DIFF
--- a/src/Data/Uniques/boots.lua
+++ b/src/Data/Uniques/boots.lua
@@ -84,7 +84,6 @@ Variant: Current
 +(10-15) to Dexterity
 {variant:1}+(5-15)% to Lightning Resistance
 {variant:2}+(15-25)% to Lightning Resistance
-+(15-25)% to Lightning Resistance
 Gain 0% to 40% increased Movement Speed at random when Hit, until Hit again
 ]],[[
 Thunderstep

--- a/src/Export/Uniques/boots.lua
+++ b/src/Export/Uniques/boots.lua
@@ -84,7 +84,6 @@ UniqueLocalIncreasedEvasionRatingPercent13
 UniqueDexterity20
 {variant:1}UniqueLightningResist11[5,15]
 {variant:2}UniqueLightningResist11
-UniqueLightningResist11
 UniqueRandomMovementVelocityOnHit1
 ]],[[
 Thunderstep

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -320,7 +320,7 @@ end
 
 function itemLib.formatModLine(modLine, dbMode)
 	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar, modLine.corruptedRange)) or modLine.line
-	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
+	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]") and not line:match("0%% to %d+%%")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
 		return
 	end
 	local colorCode


### PR DESCRIPTION
Fixes #112 .

### Description of the problem being solved:
Extra lightning removed (already included in _current_ variant).
Unique movement speed mod now shows correctly after improving the regex to hide 0-value modifiers.

### Steps taken to verify a working solution:
- Tested on POB2
- All tests successful
- Checked on [trade](https://www.pathofexile.com/trade2/search/poe2/Standard/EDQkZ3RT5)

### Link to a build that showcases this PR:
https://pobb.in/EBYaDilf3RIp

### Before screenshot:
![before](https://github.com/user-attachments/assets/f1850bca-af15-4cd9-b388-d9b19709b7b5)

### After screenshot:
![after](https://github.com/user-attachments/assets/3b4e8436-265d-4e04-bc5b-e015a846beb3)

