### PR TITLE
Add support for Deatonate Dead Corpse explosion calculation

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -281,7 +281,7 @@ return {
 	skill("corpseExplosionLifeMultiplier", nil),
 	div = 100,
 },
-["corpse_explosion_monster_life_permillage_fire"] = {
+["corpse_explosion_monster_life_permillage_physical"] = {
 	skill("corpseExplosionLifeMultiplier", nil),
 	div = 1000,
 },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4808,6 +4808,9 @@ skills["DetonateDeadPlayer"] = {
 				area = true,
 				spell = true,
 			},
+			baseMods = {
+				skill("explodeCorpse", true),
+			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 26 },
 				{ "movement_speed_+%_final_while_performing_action", -70 },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1484,6 +1484,7 @@ skills["SupportFieryDeathPlayer"] = {
 			},
 			baseMods = {
 				skill("explodeCorpse", true),
+				skill("corpseExplosionDamageType", "Fire"),
 			},
 			constantStats = {
 				{ "triggered_by_fiery_death_support_%", 100 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -345,6 +345,7 @@ statMap = {
 #startSets
 #set DetonateDeadPlayer
 #flags area spell
+#baseMod skill("explodeCorpse", true)
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -398,6 +398,7 @@ statMap = {
 #set TriggeredFieryDeathPlayer
 #flags spell area
 #baseMod skill("explodeCorpse", true)
+#baseMod skill("corpseExplosionDamageType", "Fire")
 #mods
 #skillEnd
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1778,7 +1778,7 @@ function calcs.offence(env, actor, activeSkill)
 	-- Handle corpse and enemy explosions
 	local monsterLife = skillData.corpseLife or (env.enemyLevel and data.monsterLifeTable[env.enemyLevel] or 100)
 	if skillData.explodeCorpse and (skillData.corpseLife or env.enemyLevel) then
-		local damageType = skillData.corpseExplosionDamageType or "Fire"
+		local damageType = skillData.corpseExplosionDamageType or "Physical"
 		skillData[damageType.."BonusMin"] = monsterLife * ( skillData.corpseExplosionLifeMultiplier or skillData.selfFireExplosionLifeMultiplier )
 		skillData[damageType.."BonusMax"] = monsterLife * ( skillData.corpseExplosionLifeMultiplier or skillData.selfFireExplosionLifeMultiplier )
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Currently DD's corpse explosion mod is to supported 

### Steps taken to verify a working solution:
![image](https://github.com/user-attachments/assets/9bfa4d66-42ba-4410-b635-baeaae874165)
Double check to make sure physical dmg is being scaled properly by the passive tree
![image](https://github.com/user-attachments/assets/8b224e90-c086-4416-b258-b5e9417f39d2)
