### PR TITLE
Improve EHP accuracy

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -6,29 +6,416 @@ describe("TestDefence", function()
 	teardown(function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
+	
+	local function pob1and2Compat()
+		build.configTab.input.customMods = build.configTab.input.customMods.."\n\z
+		8% reduced maximum life\n\z
+		-2 to life\n\z
+		-20% to elemental resistances\n\z
+		-60% to chaos resistance\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+	end
 
-	--it("no armour max hits", function()
-	--end)
+	it("no armour max hits", function()
+		build.configTab.input.enemyIsBoss = "None"
+		build.configTab.input.customMods = ""
+		pob1and2Compat()
+
+		assert.are.equals(60, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(38, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(38, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(38, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(38, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		200% additional Physical Damage Reduction\n\z
+		"
+		pob1and2Compat()
+		assert.are.equals(600, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(240, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(240, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(240, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(240, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		200% additional Physical Damage Reduction\n\z
+		"
+		build.configTab.input.enemyPhysicalOverwhelm = 15 -- should result 75% DR
+		pob1and2Compat()
+		assert.are.equals(240, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(600, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(600, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(600, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(600, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		"
+		pob1and2Compat()
+		assert.are.equals(120, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(1200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(1200, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(1200, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(1200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		50% less damage taken\n\z
+		"
+		pob1and2Compat()
+		assert.are.equals(240, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(2400, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(2400, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(2400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(2400, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		50% less damage taken\n\z
+		Nearby enemies deal 20% less damage\n\z
+		"
+		pob1and2Compat()
+		assert.are.equals(300, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(3000, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(3000, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(3000, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(3000, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+	end)
 	
 	-- a small helper function to calculate damage taken from limited test parameters
 	local function takenHitFromTypeMaxHit(type, enemyDamageMulti)
 		return build.calcsTab.calcs.takenHitFromDamage(build.calcsTab.calcsOutput[type.."MaximumHitTaken"] * (enemyDamageMulti or 1), type, build.calcsTab.calcsEnv.player)
 	end
 
-	--it("armoured max hits", function()
-	--end)
+	it("armoured max hits", function()
+		build.configTab.input.enemyIsBoss = "None"
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		" -- hit of 2000 on 10000 armour results in 50% DR which reduces the damage to 1000 - total HP
+		pob1and2Compat()
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Physical"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+100000 to armour\n\z
+		" -- hit of 5000 on 100000 armour results in 80% DR which reduces the damage to 1000 - total HP
+		pob1and2Compat()
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Physical"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+1000000000 to armour\n\z
+		" -- 90% DR cap
+		pob1and2Compat()
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Physical"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+1000000000 to armour\n\z
+		" -- 90% DR cap
+		build.configTab.input.enemyPhysicalOverwhelm = 15 -- should result 75% DR
+		pob1and2Compat()
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Physical"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+60% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		" -- with no resistances results should be same as physical
+		pob1and2Compat()
+		assert.are.equals(1000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Fire"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Cold"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Lightning"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		" -- max hit should be 4000
+		-- [max] [res]     [armour] [armour]      [max]  [res]
+		-- 4000 * 0.5 * (1 - 10000 / (10000 + 5 * 4000 * 0.5)) = 1000
+		pob1and2Compat()
+		assert.are.equals(1000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Fire"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Cold"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Lightning"))
+		assert.are.equals(625, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		50% less damage taken\n\z
+		" -- max hit should be 6472
+		-- [max] [res]     [armour] [armour]      [max]  [res]  [less]
+		-- 6472 * 0.5 * (1 - 10000 / (10000 + 5 * 6472 * 0.5)) * 0.5 = 1000
+		pob1and2Compat()
+		assert.are.equals(2000, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Fire"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Cold"))
+		assert.are.equals(1000, takenHitFromTypeMaxHit("Lightning"))
+		assert.are.equals(1250, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+	end)
 	
 	local function withinTenPercent(value, otherValue)
 		local ratio = otherValue / value
 		return 0.9 < ratio and ratio < 1.1
 	end
 
-	--it("damage conversion max hits", function()
-	--end)
-	
-	--it("damage conversion to different size pools", function()
-	--end)
+	it("damage conversion max hits", function()
+		build.configTab.input.enemyIsBoss = "None"
 
-	--it("energy shield bypass tests #pet", function()
-	--end)
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		50% less damage taken\n\z
+		50% of physical damage taken as fire\n\z
+		"
+		pob1and2Compat()
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		50% less damage taken\n\z
+		50% of physical damage taken as fire\n\z
+		50% of cold damage taken as fire\n\z
+		"
+		pob1and2Compat()
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		50% of physical damage taken as fire\n\z
+		50% of cold damage taken as fire\n\z
+		"
+		pob1and2Compat()
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		50% of physical damage taken as fire\n\z
+		50% of cold damage taken as fire\n\z
+		50% less fire damage taken\n\z
+		"
+		pob1and2Compat()
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+10000 to armour\n\z
+		+110% to fire resistance\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of cold damage taken as fire\n\z
+		50% of lightning damage taken as fire\n\z
+		50% less fire damage taken\n\z
+		"
+		pob1and2Compat()
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Physical")))
+		assert.is.not_false(withinTenPercent(1000, takenHitFromTypeMaxHit("Cold")))
+
+		build.configTab.input.customMods = "\z
+		+99 to energy shield\n\z
+		100% less attributes\n\z
+		+60% to all elemental resistances\n\z
+		25% of Elemental Damage from Hits taken as Chaos Damage\n\z
+		Chaos Inoculation\n\z
+		"
+		pob1and2Compat()
+		local _, takenDamages = takenHitFromTypeMaxHit("Cold")
+		local poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Life))
+	end)
+	
+	it("damage conversion to different size pools", function()
+		-- conversion into a smaller pool
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		10% of lightning damage taken as cold damage\n\z
+		"   -- Small amount of conversion into a smaller pool leads to the higher pool damage type (lightning) draining it's own excess pool (mana), and then joining back on the shared pools (life)
+		pob1and2Compat()
+		local _, takenDamages = takenHitFromTypeMaxHit("Lightning")
+		local poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Mana))
+		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
+
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		20% of lightning damage taken as cold damage\n\z
+		"   -- This is a case where cold damage drains the whole life pool and lightning damage drains the entire mana pool, leaving nothing
+		pob1and2Compat()
+		_, takenDamages = takenHitFromTypeMaxHit("Lightning")
+		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Life))
+		assert.are.equals(0, round(poolsRemaining.Mana))
+
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+1950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		20% of lightning damage taken as cold damage\n\z
+		"   -- Any extra mana in this case will not help and be left over after death, since life hits 0 from the cold damage alone
+		pob1and2Compat()
+		_, takenDamages = takenHitFromTypeMaxHit("Lightning")
+		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Life))
+		assert.are.equals(1000, round(poolsRemaining.Mana))
+
+		-- conversion into a bigger pool
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		90% of cold damage taken as lightning damage\n\z
+		"   -- With inverted conversion amounts the behaviour of converting into a bigger pool should be exactly the same as converting into a lower one.
+		pob1and2Compat()
+		_, takenDamages = takenHitFromTypeMaxHit("Cold")
+		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Mana))
+		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
+
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		80% of cold damage taken as lightning damage\n\z
+		"
+		pob1and2Compat()
+		_, takenDamages = takenHitFromTypeMaxHit("Cold")
+		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Life))
+		assert.are.equals(0, round(poolsRemaining.Mana))
+
+		build.configTab.input.customMods = "\z
+		+40 to maximum life\n\z
+		+1950 to mana\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		80% of cold damage taken as lightning damage\n\z
+		"
+		pob1and2Compat()
+		_, takenDamages = takenHitFromTypeMaxHit("Cold")
+		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+		assert.are.equals(0, round(poolsRemaining.Life))
+		assert.are.equals(1000, round(poolsRemaining.Mana))
+	end)
+
+	it("energy shield bypass tests #pet", function()
+		build.configTab.input.enemyIsBoss = "None"
+		-- Mastery
+		build.configTab.input.customMods = [[
+			+40 to maximum life
+			+200 to energy shield
+			50% of chaos damage taken does not bypass energy shield
+			You have no intelligence
+			+60% to all resistances
+		]]
+		pob1and2Compat()
+		assert.are.equals(300, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		-- Negative overrides positive
+		build.configTab.input.customMods = [[
+			+40 to maximum life
+			+100 to energy shield
+			Chaos damage does not bypass energy shield
+			You have no intelligence
+			+60% to all resistances
+		]]
+		pob1and2Compat()
+		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		-- Chaos damage should still bypass
+		build.configTab.input.customMods = build.configTab.input.customMods .. "\nAll damage taken bypasses energy shield"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(100, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(100, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+
+		-- Make sure we can't reach over 100% bypass
+		build.configTab.input.customMods = [[
+			+40 to maximum life
+			+100 to energy shield
+			Chaos damage does not bypass energy shield
+			50% of chaos damage taken does not bypass energy shield
+			You have no intelligence
+			+60% to all resistances
+		]]
+		pob1and2Compat()
+		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		-- Chaos damage should still bypass
+		build.configTab.input.customMods = build.configTab.input.customMods .. "\nAll damage taken bypasses energy shield"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(100, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(100, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+	end)
 end)

--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -13,6 +13,7 @@ describe("TestDefence", function()
 		-2 to life\n\z
 		-20% to elemental resistances\n\z
 		-60% to chaos resistance\n\z
+		+2 to mana\n\z
 		"
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
@@ -291,7 +292,7 @@ describe("TestDefence", function()
 		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
 
 		build.configTab.input.customMods = "\z
-		+40 to maximum life\n\z
+		+140 to maximum life\n\z
 		+950 to mana\n\z
 		+10000 to armour\n\z
 		+110% to all elemental resistances\n\z
@@ -318,7 +319,7 @@ describe("TestDefence", function()
 		_, takenDamages = takenHitFromTypeMaxHit("Lightning")
 		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
 		assert.are.equals(0, round(poolsRemaining.Life))
-		assert.are.equals(1000, round(poolsRemaining.Mana))
+		assert.are.not_false(1000 < round(poolsRemaining.Mana))
 
 		-- conversion into a bigger pool
 		build.configTab.input.customMods = "\z
@@ -337,7 +338,7 @@ describe("TestDefence", function()
 		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
 
 		build.configTab.input.customMods = "\z
-		+40 to maximum life\n\z
+		+140 to maximum life\n\z
 		+950 to mana\n\z
 		+10000 to armour\n\z
 		+110% to all elemental resistances\n\z
@@ -364,53 +365,33 @@ describe("TestDefence", function()
 		_, takenDamages = takenHitFromTypeMaxHit("Cold")
 		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
 		assert.are.equals(0, round(poolsRemaining.Life))
-		assert.are.equals(1000, round(poolsRemaining.Mana))
+		assert.are.not_false(1000 < round(poolsRemaining.Mana))
 	end)
 
 	it("energy shield bypass tests #pet", function()
 		build.configTab.input.enemyIsBoss = "None"
-		-- Mastery
 		build.configTab.input.customMods = [[
 			+40 to maximum life
 			+200 to energy shield
-			50% of chaos damage taken does not bypass energy shield
-			You have no intelligence
-			+60% to all resistances
-		]]
-		pob1and2Compat()
-		assert.are.equals(300, build.calcsTab.calcsOutput.FireMaximumHitTaken)
-		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
-
-		-- Negative overrides positive
-		build.configTab.input.customMods = [[
-			+40 to maximum life
-			+100 to energy shield
-			Chaos damage does not bypass energy shield
+			50% of damage taken bypasses energy shield
 			You have no intelligence
 			+60% to all resistances
 		]]
 		pob1and2Compat()
 		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
 		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
-		-- Chaos damage should still bypass
-		build.configTab.input.customMods = build.configTab.input.customMods .. "\nAll damage taken bypasses energy shield"
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
-		assert.are.equals(100, build.calcsTab.calcsOutput.FireMaximumHitTaken)
-		assert.are.equals(100, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
 
 		-- Make sure we can't reach over 100% bypass
 		build.configTab.input.customMods = [[
 			+40 to maximum life
 			+100 to energy shield
-			Chaos damage does not bypass energy shield
 			50% of chaos damage taken does not bypass energy shield
 			You have no intelligence
 			+60% to all resistances
 		]]
 		pob1and2Compat()
 		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
-		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		assert.are.equals(150, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
 		-- Chaos damage should still bypass
 		build.configTab.input.customMods = build.configTab.input.customMods .. "\nAll damage taken bypasses energy shield"
 		build.configTab:BuildModList()

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -342,6 +342,12 @@ function calcs.takenHitFromDamage(rawDamage, damageType, actor)
 	return receivedDamageSum, damages
 end
 
+local function calcLifeHitPoolWithLossPrevention(life, maxLife, lifeLossPrevented, lifeLossBelowHalfPrevented)
+	local halfLife = maxLife * 0.5
+	local aboveLow = m_max(life - halfLife, 0)
+	return aboveLow / (1 - lifeLossPrevented / 100) + m_min(life, halfLife) / (1 - lifeLossBelowHalfPrevented / 100) / (1 - lifeLossPrevented / 100)
+end
+
 ---Helper function that reduces pools according to damage taken
 ---@param poolTable table special pool values to use. Can be nil. Values from actor output are used if this is not provided or a value for some key in this is nil.
 ---@param damageTable table damage table after all the relevant reductions
@@ -400,9 +406,12 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	local energyShield = poolTbl.EnergyShield or output.EnergyShieldRecoveryCap
 	local mana = poolTbl.Mana or output.ManaUnreserved or 0
 	local life = poolTbl.Life or output.LifeRecoverable or 0
+	local lifeLossBelowHalfPrevented = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented")
 	local LifeLossLostOverTime = poolTbl.LifeLossLostOverTime or 0
 	local LifeBelowHalfLossLostOverTime = poolTbl.LifeBelowHalfLossLostOverTime or 0
 	local overkillDamage = 0
+	local MoMPoolRemaining = m_huge
+	local esPoolRemaining = m_huge
 	
 	local damageRemaindersBeforeES = {}
 	for _, damageType in ipairs(dmgTypeList) do
@@ -457,86 +466,94 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 		local damageType = dmgTypeList[i]
 		local damageRemainder = damageRemaindersBeforeES[damageType]
 		if damageRemainder then
+			local esDamageTypeMultiplier = damageType == "Chaos" and 2 or 1
+			local esBypass = output[damageType.."EnergyShieldBypass"] / 100 or 0
+			local lifeHitPool = calcLifeHitPoolWithLossPrevention(life, output.Life, output.preventedLifeLoss, lifeLossBelowHalfPrevented)
+			if energyShield > 0 and (not modDB:Flag(nil, "EnergyShieldProtectsMana")) and (esBypass) < 1 then
+				local esPool = esBypass > 0 and m_min(lifeHitPool / esBypass - lifeHitPool, energyShield) or energyShield
+				local tempDamage = m_min(damageRemainder * (1 - esBypass), esPool / esDamageTypeMultiplier) * esDamageTypeMultiplier
+				esPoolRemaining = m_min(esPoolRemaining, esPool - tempDamage)
+				energyShield = energyShield - tempDamage
+				damageRemainder = damageRemainder - tempDamage
+			end
+			if (output.sharedMindOverMatter + output[damageType.."MindOverMatter"]) > 0 then
+				local MoMEffect = m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
+				local MoMPool = MoMEffect < 1 and m_min(lifeHitPool / (1 - MoMEffect) - lifeHitPool, mana) or mana
+				local MoMDamage = damageRemainder * MoMEffect
+				if modDB:Flag(nil, "EnergyShieldProtectsMana") and energyShield > 0 and esBypass < 1 then
+					local MoMEBPool = esBypass > 0 and m_min(MoMPool / esBypass - MoMPool, energyShield) or energyShield
+					local tempDamage = m_min(MoMDamage * (1 - esBypass), MoMEBPool / esDamageTypeMultiplier) * esDamageTypeMultiplier
+					esPoolRemaining = m_min(esPoolRemaining, MoMEBPool - tempDamage)
+					energyShield = energyShield - tempDamage
+					MoMDamage = MoMDamage - tempDamage
+					local tempDamage2 = m_min(MoMDamage, MoMPool)
+					MoMPoolRemaining = m_min(MoMPoolRemaining, MoMPool - tempDamage2)
+					mana = mana - tempDamage2
+					damageRemainder = damageRemainder - tempDamage - tempDamage2
+				elseif mana > 0 then
+					local tempDamage = m_min(MoMDamage, MoMPool)
+					MoMPoolRemaining = m_min(MoMPoolRemaining, MoMPool - tempDamage)
+					mana = mana - tempDamage
+					damageRemainder = damageRemainder - tempDamage
+				end
+			else
+				MoMPoolRemaining = 0
+			end
+			if output.preventedLifeLossTotal > 0 then
+				local halfLife = output.Life * 0.5
+				local lifeOverHalfLife = m_max(life - halfLife, 0)
+				local preventPercent = output.preventedLifeLoss / 100
+				local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
+				local preventBelowHalfPercent = lifeLossBelowHalfPrevented / 100
+				local damageThatLifeCanStillTake = poolAboveLow + m_max(m_min(life, halfLife), 0) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
+				if damageThatLifeCanStillTake < damageRemainder  then
+					overkillDamage = overkillDamage + damageRemainder - damageThatLifeCanStillTake
+					damageRemainder = damageThatLifeCanStillTake
+				end
+				if output.preventedLifeLossBelowHalf ~= 0 then
+					local damageToSplit = m_min(damageRemainder, poolAboveLow)
+					local lostLife = damageToSplit * (1 - preventPercent)
+					local preventedLoss = damageToSplit * preventPercent
+					damageRemainder = damageRemainder - damageToSplit
+					LifeLossLostOverTime = LifeLossLostOverTime + preventedLoss
+					life = life - lostLife
+					if life <= halfLife then
+						local unspecificallyLowLifePreventedDamage = damageRemainder * preventPercent
+						LifeLossLostOverTime = LifeLossLostOverTime + unspecificallyLowLifePreventedDamage
+						damageRemainder = damageRemainder - unspecificallyLowLifePreventedDamage
+						local specificallyLowLifePreventedDamage = damageRemainder * preventBelowHalfPercent
+						LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime + specificallyLowLifePreventedDamage
+						damageRemainder = damageRemainder - specificallyLowLifePreventedDamage
+					end
+				else
+					local tempDamage = damageRemainder * output.preventedLifeLoss / 100
+					LifeLossLostOverTime = LifeLossLostOverTime + tempDamage
+					damageRemainder = damageRemainder - tempDamage
+				end
+			end
 			if life > 0 then
-				local esBypass = output[damageType.."EnergyShieldBypass"] or 0
-				if energyShield > 0 and (not modDB:Flag(nil, "EnergyShieldProtectsMana")) and (esBypass) < 100 then
-					local esDamageTypeMultiplier = damageType == "Chaos" and 2 or 1
-					local tempDamage = m_min(damageRemainder * (1 - esBypass / 100), energyShield / esDamageTypeMultiplier)
-					energyShield = energyShield - tempDamage * esDamageTypeMultiplier
-					damageRemainder = damageRemainder - tempDamage
-				end
-				if (output.sharedMindOverMatter + output[damageType.."MindOverMatter"]) > 0 then
-					local MoMEffect = m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
-					local MoMDamage = damageRemainder * MoMEffect
-					if modDB:Flag(nil, "EnergyShieldProtectsMana") and energyShield > 0 and esBypass < 100 then
-						local esDamageTypeMultiplier = damageType == "Chaos" and 2 or 1
-						local tempDamage = m_min(MoMDamage * (1 - esBypass / 100), energyShield / esDamageTypeMultiplier)
-						energyShield = energyShield - tempDamage * esDamageTypeMultiplier
-						MoMDamage = MoMDamage - tempDamage
-						local tempDamage2 = m_min(MoMDamage, mana)
-						mana = mana - tempDamage2
-						damageRemainder = damageRemainder - tempDamage - tempDamage2
-					elseif mana > 0 then
-						local manaPool = MoMEffect < 1 and m_min(life / (1 - MoMEffect) - life, mana) or mana
-						local tempDamage = m_min(MoMDamage, manaPool)
-						mana = mana - tempDamage
-						damageRemainder = damageRemainder - tempDamage
-					end
-				end
-				if output.preventedLifeLossTotal > 0 then
-					local halfLife = output.Life * 0.5
-					local lifeOverHalfLife = m_max(life - halfLife, 0)
-					local preventPercent = output.preventedLifeLoss / 100
-					local poolAboveLow = lifeOverHalfLife / (1 - preventPercent)
-					local preventBelowHalfPercent = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented") / 100
-					local damageThatLifeCanStillTake = poolAboveLow + m_max(m_min(life, halfLife), 0) / (1 - preventBelowHalfPercent) / (1 - output.preventedLifeLoss / 100)
-					if damageThatLifeCanStillTake < damageRemainder  then
-						overkillDamage = overkillDamage + damageRemainder - damageThatLifeCanStillTake
-						damageRemainder = damageThatLifeCanStillTake
-					end
-					if output.preventedLifeLossBelowHalf ~= 0 then
-						local damageToSplit = m_min(damageRemainder, poolAboveLow)
-						local lostLife = damageToSplit * (1 - preventPercent)
-						local preventedLoss = damageToSplit * preventPercent
-						damageRemainder = damageRemainder - damageToSplit
-						LifeLossLostOverTime = LifeLossLostOverTime + preventedLoss
-						life = life - lostLife
-						if life <= halfLife then
-							local unspecificallyLowLifePreventedDamage = damageRemainder * preventPercent
-							LifeLossLostOverTime = LifeLossLostOverTime + unspecificallyLowLifePreventedDamage
-							damageRemainder = damageRemainder - unspecificallyLowLifePreventedDamage
-							local specificallyLowLifePreventedDamage = damageRemainder * preventBelowHalfPercent
-							LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime + specificallyLowLifePreventedDamage
-							damageRemainder = damageRemainder - specificallyLowLifePreventedDamage
-						end
-					else
-						local tempDamage = damageRemainder * output.preventedLifeLoss / 100
-						LifeLossLostOverTime = LifeLossLostOverTime + tempDamage
-						damageRemainder = damageRemainder - tempDamage
-					end
-				end
-				if life > 0 then
-					local tempDamage = m_min(damageRemainder, life)
-					life = life - tempDamage
-					damageRemainder = damageRemainder - tempDamage
-				end
+				local tempDamage = m_min(damageRemainder, life)
+				life = life - tempDamage
+				damageRemainder = damageRemainder - tempDamage
 			end
 			overkillDamage = overkillDamage + damageRemainder
 		end
 	end
+	local hitPoolRemaining = life + (MoMPoolRemaining ~= m_huge and MoMPoolRemaining or 0) + (esPoolRemaining ~= m_huge and esPoolRemaining or 0)
 
 	return {
 		AlliesTakenBeforeYou = alliesTakenBeforeYou,
 		Aegis = aegis,
 		Guard = guard,
-		damageTakenThatCanBeRecouped = damageTakenThatCanBeRecouped,
 		Ward = restoreWard,
 		EnergyShield = energyShield,
 		Mana = mana,
 		Life = life,
+		damageTakenThatCanBeRecouped = damageTakenThatCanBeRecouped,
 		LifeLossLostOverTime = LifeLossLostOverTime,
 		LifeBelowHalfLossLostOverTime = LifeBelowHalfLossLostOverTime,
-		OverkillDamage = overkillDamage
+		OverkillDamage = overkillDamage,
+		hitPoolRemaining = hitPoolRemaining
 	}
 end
 
@@ -2280,9 +2297,7 @@ function calcs.buildDefenceEstimations(env, actor)
 	
 	-- Prevented life loss taken over 4 seconds (and Petrified Blood)
 	do
-		local halfLife = output.Life * 0.5
 		local recoverable = output.LifeRecoverable
-		local aboveLow = m_max(recoverable - halfLife, 0)
 		local preventedLifeLoss = m_min(modDB:Sum("BASE", nil, "LifeLossPrevented"), 100)
 		output["preventedLifeLoss"] = preventedLifeLoss
 		local initialLifeLossBelowHalfPrevented = modDB:Sum("BASE", nil, "LifeLossBelowHalfPrevented")
@@ -2290,12 +2305,12 @@ function calcs.buildDefenceEstimations(env, actor)
 		local portionLife = 1
 		if not env.configInput["conditionLowLife"] then
 			--portion of life that is lowlife
-			portionLife = m_min(halfLife / recoverable, 1)
+			portionLife = m_min(output.Life * 0.5 / recoverable, 1)
 			output["preventedLifeLossTotal"] = output["preventedLifeLoss"] + output["preventedLifeLossBelowHalf"] * portionLife
 		else
 			output["preventedLifeLossTotal"] = output["preventedLifeLoss"] + output["preventedLifeLossBelowHalf"]
 		end
-		output.LifeHitPool = aboveLow / (1 - preventedLifeLoss / 100) + m_min(recoverable, halfLife) / (1 - initialLifeLossBelowHalfPrevented / 100) / (1 - preventedLifeLoss / 100)
+		output.LifeHitPool = calcLifeHitPoolWithLossPrevention(recoverable, output.Life, preventedLifeLoss, initialLifeLossBelowHalfPrevented)
 		
 		if breakdown then
 			breakdown["preventedLifeLossTotal"] = {
@@ -2355,12 +2370,13 @@ function calcs.buildDefenceEstimations(env, actor)
 		local sourcePool = m_max(output.ManaUnreserved or 0, 0)
 		local sourceHitPool = sourcePool
 		local manatext = "unreserved mana"
-		if modDB:Flag(nil, "EnergyShieldProtectsMana") and output.MinimumBypass < 100 then
+		local esBypass = output.MinimumBypass / 100
+		if modDB:Flag(nil, "EnergyShieldProtectsMana") and esBypass < 1 then
 			manatext = manatext.." + non-bypassed energy shield"
-			if output.MinimumBypass > 0 then
-				local manaProtected = output.EnergyShieldRecoveryCap / (1 - output.MinimumBypass / 100) * (output.MinimumBypass / 100)
-				sourcePool = m_max(sourcePool - manaProtected, -output.LifeRecoverable) + m_min(sourcePool + output.LifeRecoverable, manaProtected) / (output.MinimumBypass / 100)
-				sourceHitPool = m_max(sourceHitPool - manaProtected, -output.LifeHitPool) + m_min(sourceHitPool + output.LifeHitPool, manaProtected) / (output.MinimumBypass / 100)
+			if esBypass > 0 then
+				local manaProtected = m_min(sourcePool / esBypass - sourcePool, output.EnergyShieldRecoveryCap)
+				sourcePool = m_max(sourcePool - manaProtected, -output.LifeRecoverable) + m_min(sourcePool + output.LifeRecoverable, manaProtected) / esBypass
+				sourceHitPool = m_max(sourceHitPool - manaProtected, -output.LifeHitPool) + m_min(sourceHitPool + output.LifeHitPool, manaProtected) / esBypass
 			else
 				sourcePool = sourcePool + output.EnergyShieldRecoveryCap
 				sourceHitPool = sourcePool
@@ -2686,8 +2702,9 @@ function calcs.buildDefenceEstimations(env, actor)
 			local VaalArcticArmourMultiplier = VaalArcticArmourHitsLeft > 0 and (( 1 - output["VaalArcticArmourMitigation"] * m_min(VaalArcticArmourHitsLeft / iterationMultiplier, 1))) or 1
 			VaalArcticArmourHitsLeft = VaalArcticArmourHitsLeft - iterationMultiplier
 			for _, damageType in ipairs(dmgTypeList) do
-				Damage[damageType] = DamageIn[damageType] * iterationMultiplier * VaalArcticArmourMultiplier
-				damageTotal = damageTotal + Damage[damageType]
+				local damage = DamageIn[damageType] or 0
+				Damage[damageType] = damage > 0 and damage * iterationMultiplier * VaalArcticArmourMultiplier or nil
+				damageTotal = damageTotal + damage
 			end
 			if DamageIn.GainWhenHit and (iterationMultiplier > 1 or DamageIn["cycles"] > 1) then
 				local gainMult = iterationMultiplier * DamageIn["cycles"]
@@ -3195,7 +3212,6 @@ function calcs.buildDefenceEstimations(env, actor)
 
 		for _, damageType in ipairs(dmgTypeList) do
 			local partMin = m_huge
-			local poolMax = 0
 			local useConversionSmoothing = false
 			for _, damageConvertedType in ipairs(dmgTypeList) do
 				local convertPercent = actor.damageShiftTable[damageType][damageConvertedType]
@@ -3250,7 +3266,6 @@ function calcs.buildDefenceEstimations(env, actor)
 						hitTaken = m_floor(m_max(m_min(RAW, maxDRMaxHit), noDRMaxHit))
 						useConversionSmoothing = useConversionSmoothing or convertPercent ~= 100
 					end
-					poolMax = m_max(poolMax, totalHitPool)
 					partMin = m_min(partMin, hitTaken)
 				end
 			end
@@ -3261,26 +3276,26 @@ function calcs.buildDefenceEstimations(env, actor)
 			if partMin == m_huge then
 				finalMaxHit = m_huge
 			elseif useConversionSmoothing then
-				-- this just reduces deviation from what the result should be
-				local noSmoothing = partMin
-				-- this sqrt pass could be repeated multiple times and each time it would produce a more accurate result.
-				local noSmoothingFullTaken, noSmoothingDamages = calcs.takenHitFromDamage(noSmoothing, damageType, actor)
-				local firstPassRatio = noSmoothingFullTaken / poolMax
-				for partType, partTaken in pairs(noSmoothingDamages) do
-					firstPassRatio = m_max(firstPassRatio, partTaken / output[partType.."TotalHitPool"])
+				local passIncomingDamage = partMin
+				local previousOverkill
+				for n = 1, data.misc.maxHitSmoothingPasses do
+					local _, passDamages = calcs.takenHitFromDamage(passIncomingDamage, damageType, actor)
+					local passPools = calcs.reducePoolsByDamage(nil, passDamages, actor)
+					local passOverkill = passPools.OverkillDamage - passPools.hitPoolRemaining
+					local passRatio = 0
+					for partType, _ in pairs(passDamages) do
+						passRatio = m_max(passRatio, (passOverkill + output[partType.."TotalHitPool"]) / output[partType.."TotalHitPool"])
+					end
+					local stepSize = n > 1 and m_min(math.abs((passOverkill - previousOverkill) / previousOverkill), 2) or 1
+					local stepAdjust = stepSize > 1 and -passOverkill / stepSize or n > 1 and -passOverkill * stepSize or 0
+					previousOverkill = passOverkill
+					passIncomingDamage = (passIncomingDamage + stepAdjust) / m_sqrt(passRatio)
+					if passOverkill < 1 and passOverkill > -1 then
+						break
+					end
 				end
-				local onePass = noSmoothing / m_sqrt(firstPassRatio)
-				-- this finishing pass is special because it:
-				--	1) inverts the behaviour of misreporting - instead of over reporting it under reports, so players don't try to tank something they can't
-				--	2) near the worst case scenarios of previous smoothing ratios this *magically* makes calculations near exact. In average case scenarios it still helps.
-				local onePassFullTaken, onePassDamages = calcs.takenHitFromDamage(onePass, damageType, actor)
-				local finalPassRatio = onePassFullTaken / poolMax
-				for partType, partTaken in pairs(onePassDamages) do
-					finalPassRatio = m_max(finalPassRatio, partTaken / output[partType.."TotalHitPool"])
-				end
-				local finalPass = onePass / finalPassRatio
 				
-				finalMaxHit = round(finalPass / enemyDamageMult)
+				finalMaxHit = round(passIncomingDamage / enemyDamageMult)
 			else
 				finalMaxHit = round(partMin / enemyDamageMult)
 			end
@@ -3385,7 +3400,7 @@ function calcs.buildDefenceEstimations(env, actor)
 					t_insert(breakdown[maxHitCurType], s_format("\t%d "..colorCodes.LIFE.."Life ^7Loss Prevented", poolsRemaining.LifeLossLostOverTime + poolsRemaining.LifeBelowHalfLossLostOverTime))
 				end
 				t_insert(breakdown[maxHitCurType], s_format("\t%d "..colorCodes.LIFE.."Life ^7(%d remaining)", output.LifeRecoverable - poolsRemaining.Life, poolsRemaining.Life))
-				if poolsRemaining.OverkillDamage > 0 then
+				if poolsRemaining.OverkillDamage >= 1 then
 					t_insert(breakdown[maxHitCurType], s_format("\t%d Overkill damage", poolsRemaining.OverkillDamage))
 				end
 			end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -204,6 +204,8 @@ data.misc = { -- magic numbers
 	ehpCalcMaxDamage = 100000000,
 	-- max iterations can be increased for more accuracy this should be perfectly accurate unless it runs out of iterations and so high eHP values will be underestimated.
 	ehpCalcMaxIterationsToCalc = 50,
+	-- more iterations would reduce the cases where max hit would result in overkill damage or leave some life.
+	maxHitSmoothingPasses = 8,
 	-- maximum increase for stat weights, only used in trader for now.
 	maxStatIncrease = 2, -- 100% increased
 	-- PvP scaling used for hogm


### PR DESCRIPTION
Closes #542
Closes #451

### Description of the problem being solved:
A previous fix for MoM EHP calculations was erroneous.

### Steps taken to verify a working solution:
- Check that EHP stops changing when adding mana past MoM limit
- Check that EHP scales linearly when only adding more to the hit pool

### Before screenshot:
![image](https://github.com/user-attachments/assets/581b596d-cd57-444e-a39c-837311707fc9)
![image](https://github.com/user-attachments/assets/3cc57d71-4b5c-4ae6-b67f-27d1de5ae419)
![image](https://github.com/user-attachments/assets/b0500af2-1a1c-4cd9-98dd-cfe835ffc499)


### After screenshot:
![image](https://github.com/user-attachments/assets/59620a54-cf95-441f-a2ba-6c273cddedee)
![image](https://github.com/user-attachments/assets/713e0444-a22b-4cdd-afe8-3038b4dd026a)
