### PR TITLE
Add support for additional empowering effects

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -759,7 +759,7 @@ c["100% increased Magnitude of Ignite you inflict"]={{[1]={flags=0,keywordFlags=
 c["100% increased Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=100}},nil}
 c["100% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=100}},nil}
 c["100% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=100}},nil}
-c["100% increased Stun Threshold during Empowered Attacks"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},flags=0,keywordFlags=0,name="StunThreshold",type="INC",value=100}},nil}
+c["100% increased Stun Threshold during Empowered Attacks"]={{[1]={[1]={type="Condition",var="Empowered"},flags=0,keywordFlags=0,name="StunThreshold",type="INC",value=100}},nil}
 c["100% increased Thorns damage"]={{[1]={flags=0,keywordFlags=0,name="Damage",type="INC",value=100}}," Thorns  "}
 c["100% increased amount of Life Leeched"]={{[1]={flags=0,keywordFlags=0,name="LifeLeech",type="INC",value=100}},nil}
 c["100% increased chance to Ignite"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteChance",type="INC",value=100}},nil}
@@ -1076,7 +1076,7 @@ c["20% chance for Lightning Skills to Chain an additional time"]={{}," for Light
 c["20% chance for Slam Skills you use yourself to cause Aftershocks"]={{}," for Slam Skills you use yourself to cause Aftershocks "}
 c["20% chance to Aggravate Bleeding on targets you Critically Hit with Attacks"]={{}," to Aggravate Bleeding on targets you Critically Hit  "}
 c["20% chance to Aggravate Bleeding on targets you Hit with Empowered Attacks"]={{}," to Aggravate Bleeding on targets you Hit  "}
-c["20% chance to Aggravate Bleeding on targets you Hit with Empowered Attacks Empowered Attacks deal 30% increased Damage"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},flags=0,keywordFlags=0,name="Damage",type="BASE",value=20}}," to Aggravate Bleeding on targets you Hit  Empowered Attacks deal 30% increased  "}
+c["20% chance to Aggravate Bleeding on targets you Hit with Empowered Attacks Empowered Attacks deal 30% increased Damage"]={{[1]={[1]={type="Condition",var="Empowered"},flags=0,keywordFlags=0,name="Damage",type="BASE",value=20}}," to Aggravate Bleeding on targets you Hit  Empowered Attacks deal 30% increased  "}
 c["20% chance to Knock Enemies Back with Hits at Close Range"]={{}," to Knock Enemies Back   "}
 c["20% chance to Poison on Hit"]={{[1]={flags=0,keywordFlags=0,name="PoisonChance",type="BASE",value=20}},nil}
 c["20% chance to gain a Power Charge on Hit"]={nil,"a Power Charge on Hit "}
@@ -2369,11 +2369,11 @@ c["Elemental Ailment Threshold is increased by Overcapped Chaos Resistance"]={ni
 c["Elemental Ailment Threshold is increased by Overcapped Chaos Resistance Armour is increased by Overcapped Fire Resistance"]={nil,"Elemental Ailment Threshold is increased by Overcapped Chaos Resistance Armour is increased by Overcapped Fire Resistance "}
 c["Elemental Damage also Contributes to Bleeding Magnitude"]={{[1]={flags=0,keywordFlags=0,name="FireCanBleed",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ColdCanBleed",type="FLAG",value=true},[3]={flags=0,keywordFlags=0,name="LightningCanBleed",type="FLAG",value=true}},nil}
 c["Elemental Storm has 150% more Cooldown Recovery Rate"]={{[1]={[1]={includeTransfigured=true,skillName="Elemental Storm",type="SkillName"},flags=0,keywordFlags=0,name="CooldownRecovery",type="MORE",value=150}},nil}
-c["Empowered Attacks deal 10% increased Damage"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
-c["Empowered Attacks deal 16% increased Damage"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=16}},nil}
-c["Empowered Attacks deal 30% increased Damage"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=30}},nil}
+c["Empowered Attacks deal 10% increased Damage"]={{[1]={[1]={type="Condition",var="Empowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
+c["Empowered Attacks deal 16% increased Damage"]={{[1]={[1]={type="Condition",var="Empowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=16}},nil}
+c["Empowered Attacks deal 30% increased Damage"]={{[1]={[1]={type="Condition",var="Empowered"},flags=1,keywordFlags=0,name="Damage",type="INC",value=30}},nil}
 c["Empowered Attacks have 50% increased Stun Buildup"]={{}," Stun Buildup "}
-c["Empowered Attacks have 50% increased Stun Buildup 100% increased Stun Threshold during Empowered Attacks"]={{[1]={[1]={type="Condition",var="SkillEmpowered"},[2]={type="Condition",var="SkillEmpowered"},flags=1,keywordFlags=0,name="StunThreshold",type="INC",value=50}}," Stun Buildup 100% increased   "}
+c["Empowered Attacks have 50% increased Stun Buildup 100% increased Stun Threshold during Empowered Attacks"]={{[1]={[1]={type="Condition",var="Empowered"},[2]={type="Condition",var="Empowered"},flags=1,keywordFlags=0,name="StunThreshold",type="INC",value=50}}," Stun Buildup 100% increased   "}
 c["Enemies Chilled by your Hits can be Shattered as though Frozen"]={nil,"your Hits can be Shattered as though Frozen "}
 c["Enemies Chilled by your Hits increase damage taken by Chill Magnitude"]={nil,"your Hits increase damage taken by Chill Magnitude "}
 c["Enemies Chilled by your Hits increase damage taken by Chill Magnitude Attacks Gain 10% of Damage as Extra Cold Damage"]={nil,"your Hits increase damage taken by Chill Magnitude Attacks Gain 10% of Damage as Extra Cold Damage "}

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11657,6 +11657,9 @@ skills["ManaTempestPlayer"] = {
 			statDescriptionScope = "mana_tempest",
 			baseFlags = {
 			},
+			baseMods = {
+				mod("Empowered", "FLAG", true, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "StatThreshold", stat = "ManaCost", threshold = 1 }),
+			},
 			constantStats = {
 				{ "mana_tempest_mana_cost_%_to_add_to_cost_per_second", 30 },
 				{ "active_skill_base_area_of_effect_radius", 26 },
@@ -16788,6 +16791,9 @@ skills["StaffUnleashNextSpellPlayer"] = {
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
+			},
+			baseMods = {
+				mod("Empowered", "FLAG", true, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" }),
 			},
 			constantStats = {
 				{ "base_skill_effect_duration", 4000 },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -1329,6 +1329,12 @@ skills["SupportEmpoweredCullPlayer"] = {
 			label = "Murderous Intent",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_empowered_culling_strike"] = {
+					mod("ExtraEmpowerMod", "LIST", { mod = mod("CullPercent", "MAX", nil), unscalable = true }),
+					value = 10,
+				}
+			},
 			baseFlags = {
 			},
 			stats = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1628,6 +1628,11 @@ skills["SupportEmpoweredDamagePlayer"] = {
 			label = "Premeditation",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_empowered_damage_+%_final"] = {
+					mod("ExtraEmpowerMod", "LIST", { mod = mod("Damage", "MORE", nil) }),
+				}
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -772,6 +772,7 @@ statMap = {
 #startSets
 #set ManaTempestPlayer
 #flags
+#baseMod mod("Empowered", "FLAG", true, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "StatThreshold", stat = "ManaCost", threshold = 1 })
 #mods
 #skillEnd
 
@@ -1115,6 +1116,7 @@ statMap = {
 #startSets
 #set StaffUnleashNextSpellPlayer
 #flags
+#baseMod mod("Empowered", "FLAG", true, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" })
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -350,6 +350,12 @@ statMap = {
 #skill SupportEmpoweredCullPlayer
 #startSets
 #set SupportEmpoweredCullPlayer
+statMap = {
+	["support_empowered_culling_strike"] = {
+		mod("ExtraEmpowerMod", "LIST", { mod = mod("CullPercent", "MAX", nil), unscalable = true }),
+		value = 10,
+	}
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -466,6 +466,11 @@ statMap = {
 #skill SupportEmpoweredDamagePlayer
 #startSets
 #set SupportEmpoweredDamagePlayer
+statMap = {
+	["support_empowered_damage_+%_final"] = {
+		mod("ExtraEmpowerMod", "LIST", { mod = mod("Damage", "MORE", nil) }),
+	}
+},
 #mods
 #skillEnd
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -604,8 +604,8 @@ local configSettings = {
 	{ var = "windDancerStacks", type = "count", label = "# of Wind Dancer Stacks:", ifSkill = "Wind Dancer", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:WindDancerStacks", "BASE", val, "Config")
 	end },
-	{ var = "conditionSkillEmpowered", type = "check", label = "Is the skill Empowered?", ifCond = "SkillEmpowered", tooltip = "Skills can be temporarily Empowered by certain buff skills.", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:SkillEmpowered", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	{ var = "conditionEmpowered", type = "check", label = "Is the skill Empowered?", ifCond = "Empowered", tooltip = "Skills can be temporarily Empowered by certain buff skills.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:Empowered", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "multiplierWoCExpiredDuration", type = "count", label = "% Wave of Conviction duration expired:", ifMod = "WaveOfConvictionDurationDotMulti", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:WoCDurationExpired", "BASE", m_min(val, 100), "Config", { type = "Condition", var = "Effective" })

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1240,7 +1240,7 @@ local preFlagList = {
 	["^for each nearby corpse, "] = { tag = { type = "Multiplier", var = "NearbyCorpse" } },
 	["^enemies in your link beams have "] = { tag = { type = "Condition", var = "BetweenYouAndLinkedTarget" }, applyToEnemy = true },
 	["^consecrated ground you create also grants "] = { tag = { type = "Condition", var = "OnConsecratedGround" } },
-	["^empowered attacks [hgd][ae][via][enl] "] = { flags = ModFlag.Attack, tag = { type = "Condition", var = "SkillEmpowered" } },
+	["^empowered attacks [hgd][ae][via][enl] "] = { flags = ModFlag.Attack, tag = { type = "Condition", var = "Empowered" } },
 	-- While in the presence of...
 	["^while a unique enemy is in your presence, "] = { tag = { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" } },
 	["^while a pinnacle atlas boss is in your presence, "] = { tag = { type = "ActorCondition", actor = "enemy", var = "PinnacleBoss" } },
@@ -1257,8 +1257,8 @@ local modTagList = {
 	["with critical hits"] = { tag = { type = "Condition", var = "CriticalStrike" } },
 	["while affected by auras you cast"] = { tag = { type = "Condition", var = "AffectedByAura" } },
 	["for you and nearby allies"] = { newAura = true },
-	["with empowered attacks"] = { tag = { type = "Condition", var = "SkillEmpowered" } },
-	["during empowered attacks"] = { tag = { type = "Condition", var = "SkillEmpowered" } },
+	["with empowered attacks"] = { tag = { type = "Condition", var = "Empowered" } },
+	["during empowered attacks"] = { tag = { type = "Condition", var = "Empowered" } },
 	-- Multipliers
 	["per power charge"] = { tag = { type = "Multiplier", var = "PowerCharge" } },
 	["if you've consumed an? (%D+) charge recently"] = function(charge) return { tag = { type = "Multiplier", var = "Removable" .. firstToUpper(charge) .. "Charge", limit = 1 }} end,


### PR DESCRIPTION
### Description of the problem being solved:
This allow supports (or possibly other sources) to add mods to empowering skills.
This is different from normal mod transfer from support to active skill because the support doesn't know the conditions and flags of the active skill's "GlobalEffect".
Copying tags from the "Empowered" flag on an active skill to support skill mods enables them to be merged into one buff.
I'm not sure if this hacky solution is the best. We may come up with better system when implementing warcries. We may even be able to get rid of the config switch when all empowering effects are properly accounted for.

### Link to a build that showcases this PR:
https://pobb.in/jKr8dJPlXHOI

### After screenshot:
![image](https://github.com/user-attachments/assets/dc6ca632-6245-4a25-b48b-acc69c9f9f15)
