### PR TITLE
Fix Corrupted Unique roll ranges formula

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -671,9 +671,9 @@ end
 function alwaysPositiveRound(val, dec)
 	if dec then
 		local factor = 10 ^ dec
-		return m_floor(val * factor + 0.5) / factor
+		return floorSymmetric(val * factor + 0.5) / factor
 	else
-		return m_floor(val + 0.5)
+		return floorSymmetric(val + 0.5)
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Switch formula from m_floor to floorSymmetric for corrupted unique rolls

### Before screenshot:
![image](https://github.com/user-attachments/assets/d70c4564-9a54-4ac8-b11a-a06b999c8b04)


### After screenshot:
![image](https://github.com/user-attachments/assets/12193fce-0bff-4cf9-89cc-a53be88017b5)
