### PR TITLE
Add Threaded Light Woven Focus spell dmg per 10 spirit

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -552,8 +552,8 @@ c["0% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type=
 c["0% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=0}},"% to  "}
 c["0% to Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=0}},"% to  "}
 c["0.1 Life Regeneration per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=0.1}},nil}
+c["0.5% of Life Regenerated per second per Fragile Regrowth"]={{[1]={[1]={type="Multiplier",var="FragileRegrowthCount"},flags=0,keywordFlags=0,name="Life",type="BASE",value=0.5}},"  Regenerated per second  "}
 c["0.5% of Life Regenerated per second per Fragile Regrowth 10% increased Mana Regeneration Rate per Fragile Regrowth"]={{[1]={[1]={type="Multiplier",var="FragileRegrowthCount"},[2]={type="Multiplier",var="FragileRegrowthCount"},flags=0,keywordFlags=0,name="Life",type="BASE",value=0.5}},"  Regenerated per second  10% increased Mana Regeneration Rate  "}
-c["0.500000% of Life Regenerated per second per Fragile Regrowth"]={{[1]={[1]={type="Multiplier",var="FragileRegrowthCount"},flags=0,keywordFlags=0,name="Life",type="BASE",value=0.5}},"  Regenerated per second  "}
 c["1% increased Attack Damage per 75 Armour or Evasion Rating on Shield"]={{[1]={[1]={div=75,statList={[1]="ArmourOnWeapon 2",[2]="EvasionOnWeapon 2"},type="PerStat"},flags=1,keywordFlags=0,name="Damage",type="INC",value=1}},nil}
 c["1% increased Attack Speed per 15 Dexterity"]={{[1]={[1]={div=15,stat="Dex",type="PerStat"},flags=1,keywordFlags=0,name="Speed",type="INC",value=1}},nil}
 c["1% increased Attack Speed per 250 Accuracy Rating"]={{[1]={[1]={div=250,stat="Accuracy",type="PerStat"},flags=1,keywordFlags=0,name="Speed",type="INC",value=1}},nil}
@@ -681,7 +681,7 @@ c["10% increased Rarity of Items found per Socketed Rune or Soul Core"]={{[1]={[
 c["10% increased Skill Effect Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=10}},nil}
 c["10% increased Skill Speed"]={{[1]={flags=0,keywordFlags=0,name="Speed",type="INC",value=10},[2]={flags=0,keywordFlags=0,name="WarcrySpeed",type="INC",value=10}},nil}
 c["10% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
-c["10% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div="10",stat="Spirit",type="PerStat"},[2]={skillType=2,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
+c["10% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div=10,stat="Spirit",type="PerStat"},flags=2,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
 c["10% increased Strength"]={{[1]={flags=0,keywordFlags=0,name="Str",type="INC",value=10}},nil}
 c["10% increased Stun Buildup"]={{}," Stun Buildup "}
 c["10% increased Stun Buildup 10% increased Damage with Two Handed Weapons"]={{[1]={flags=34359738372,keywordFlags=0,name="Damage",type="INC",value=10}}," Stun Buildup 10% increased   "}
@@ -819,7 +819,7 @@ c["12% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalD
 c["12% increased Spell Area Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},"  Area  "}
 c["12% increased Spell Area Damage Spell Skills have 5% reduced Area of Effect"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},"  Area  Spell Skills have 5% reduced Area of Effect "}
 c["12% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
-c["12% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div="10",stat="Spirit",type="PerStat"},[2]={skillType=2,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
+c["12% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div=10,stat="Spirit",type="PerStat"},flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Spell Damage while on Full Energy Shield"]={{[1]={[1]={type="Condition",var="FullEnergyShield"},flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Spell Damage while wielding a Melee Weapon"]={{[1]={[1]={type="Condition",var="UsingMeleeWeapon"},flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Stun Buildup"]={{}," Stun Buildup "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -681,6 +681,7 @@ c["10% increased Rarity of Items found per Socketed Rune or Soul Core"]={{[1]={[
 c["10% increased Skill Effect Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=10}},nil}
 c["10% increased Skill Speed"]={{[1]={flags=0,keywordFlags=0,name="Speed",type="INC",value=10},[2]={flags=0,keywordFlags=0,name="WarcrySpeed",type="INC",value=10}},nil}
 c["10% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
+c["10% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div="10",stat="Spirit",type="PerStat"},[2]={skillType=2,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=10}},nil}
 c["10% increased Strength"]={{[1]={flags=0,keywordFlags=0,name="Str",type="INC",value=10}},nil}
 c["10% increased Stun Buildup"]={{}," Stun Buildup "}
 c["10% increased Stun Buildup 10% increased Damage with Two Handed Weapons"]={{[1]={flags=34359738372,keywordFlags=0,name="Damage",type="INC",value=10}}," Stun Buildup 10% increased   "}
@@ -818,7 +819,7 @@ c["12% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalD
 c["12% increased Spell Area Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},"  Area  "}
 c["12% increased Spell Area Damage Spell Skills have 5% reduced Area of Effect"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},"  Area  Spell Skills have 5% reduced Area of Effect "}
 c["12% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
-c["12% increased Spell Damage per 10 Spirit"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},"   per 10 Spirit "}
+c["12% increased Spell Damage per 10 Spirit"]={{[1]={[1]={div="10",stat="Spirit",type="PerStat"},[2]={skillType=2,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Spell Damage while on Full Energy Shield"]={{[1]={[1]={type="Condition",var="FullEnergyShield"},flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Spell Damage while wielding a Melee Weapon"]={{[1]={[1]={type="Condition",var="UsingMeleeWeapon"},flags=2,keywordFlags=0,name="Damage",type="INC",value=12}},nil}
 c["12% increased Stun Buildup"]={{}," Stun Buildup "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2773,9 +2773,6 @@ local specialModList = {
 		flag("ShockImmune"),
 	},
 	["you gain (%d+)%% increased damage for each trap"] = function(num) return { mod("Damage", "INC", num, { type = "PerStat", stat = "ActiveTrapLimit" }) } end,
-	["(%d+)%% increased spell damage per (%d+) spirit"] = function(num, _, spirit) return { 
-		mod("Damage", "INC", num, { type = "PerStat", stat = "Spirit", div = spirit }, { type = "SkillType", skillType = SkillType.Spell }) 
-	} end,
 	["you gain (%d+)%% increased area of effect for each mine"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "PerStat", stat = "ActiveMineLimit" }) } end,
 	["triggers level (%d+) summon triggerbots when allocated"] = { flag("HaveTriggerBots") },
 	-- Slayer

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1392,6 +1392,7 @@ local modTagList = {
 	["per (%d+) maximum mana"] = function(num) return { tag = { type = "PerStat", stat = "Mana", div = num } } end,
 	["per (%d+) maximum mana, up to (%d+)%%"] = function(num, _, limit) return { tag = { type = "PerStat", stat = "Mana", div = num, limit = tonumber(limit), limitTotal = true } } end,
 	["per (%d+) maximum mana, up to a maximum of (%d+)%%"] = function(num, _, limit) return { tag = { type = "PerStat", stat = "Mana", div = num, limit = tonumber(limit), limitTotal = true } } end,
+	["per (%d+) spirit"] = function(num) return { tag = { type = "PerStat", stat = "Spirit", div = num } } end,
 	["per (%d+) accuracy rating"] = function(num) return { tag = { type = "PerStat", stat = "Accuracy", div = num } } end,
 	["per (%d+)%% block chance"] = function(num) return { tag = { type = "PerStat", stat = "BlockChance", div = num } } end,
 	["per (%d+)%% chance to block"] = function(num) return { tag = { type = "PerStat", stat = "BlockChance", div = num } } end,
@@ -2772,6 +2773,9 @@ local specialModList = {
 		flag("ShockImmune"),
 	},
 	["you gain (%d+)%% increased damage for each trap"] = function(num) return { mod("Damage", "INC", num, { type = "PerStat", stat = "ActiveTrapLimit" }) } end,
+	["(%d+)%% increased spell damage per (%d+) spirit"] = function(num, _, spirit) return { 
+		mod("Damage", "INC", num, { type = "PerStat", stat = "Spirit", div = spirit }, { type = "SkillType", skillType = SkillType.Spell }) 
+	} end,
 	["you gain (%d+)%% increased area of effect for each mine"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "PerStat", stat = "ActiveMineLimit" }) } end,
 	["triggers level (%d+) summon triggerbots when allocated"] = { flag("HaveTriggerBots") },
 	-- Slayer


### PR DESCRIPTION
Fixes #544 .

### Description of the problem being solved:
Add Threaded Light Woven Focus spell dmg per 10 spirit request.
Also added _"per (%d+) spirit"_ for future reference.

### Steps taken to verify a working solution:
- Tested on POB2
- Automatic tests successful

### Link to a build that showcases this PR:
https://pobb.in/6NwRXbHnSHEh

### After screenshot:

![no](https://github.com/user-attachments/assets/e0997456-818f-4bb5-958b-7b9d8001992a) 
![on_spark](https://github.com/user-attachments/assets/83e08c4f-73e1-49e5-8a0b-f9c5192fc53d)
![off_boneshatter](https://github.com/user-attachments/assets/cffeb87f-7536-4403-982c-341886dfafe7)
![on_boneshatter](https://github.com/user-attachments/assets/043f0567-b528-4480-ae1d-08acc8592c29)


