### PR TITLE
Fix Crash when switching between multiple choice Ascendancies

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -718,9 +718,7 @@ function PassiveSpecClass:AllocNode(node, altPath)
 		local parent = node.linked[1]
 		for _, optNode in ipairs(parent.linked) do
 			if optNode.isMultipleChoiceOption and optNode.alloc and optNode ~= node then
-				optNode.alloc = false
-				optNode.allocMode = nil
-				self.allocNodes[optNode.id] = nil
+				self:DeallocSingleNode(optNode)
 			end
 		end
 	end


### PR DESCRIPTION
Fixes a possible crash (#575) when a node `allocMode` is set to `nil`, which breaks generating the modlist in `CalcSetup.lua`

Fixes #575  .

### Description of the problem being solved:
When multiple choice passives are deallocated, `allocMode` was being set to `nil`, which breaks how modlists are generated for weapon sets in [CalcSetup.lua:310](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/blob/ac80996c3a0e70387e98e125bd16c9f7f8be0baa/src/Modules/CalcSetup.lua#L310).

### Steps taken to verify a working solution:
- Select Ranger, Deadeye ascendency in passive tree configuration. Allocate `Projectile Proximity Specialization` and one of `Far Shot` or `Point Blank`. Hover over the other.
- Use devAltMode to verify that the nodes have `allocMode=0`
- Code in `DeallocSingleNode` performs the same changes to the node data as the deleted lines in this change (and would also handle a multiple choice mastery, if that ever happened)

### Before screenshot:
![Screenshot 2025-01-24 142515](https://github.com/user-attachments/assets/526fc638-c770-45a6-8c03-fb0e1667ee2b)

### After screenshot:
![Screenshot 2025-01-24 144621](https://github.com/user-attachments/assets/27c3f337-45dd-49dd-83d2-014da14ee347)
![Screenshot 2025-01-24 144608](https://github.com/user-attachments/assets/45fae3cf-f11b-4484-a1d5-d944727f2d05)
![Screenshot 2025-01-24 143455](https://github.com/user-attachments/assets/fc17913a-312b-43c4-b42b-06e0b45523a1)
![Screenshot 2025-01-24 143445](https://github.com/user-attachments/assets/296a341e-5163-4585-890d-e4026010be8f)
