### PR TITLE
Fix support gem counting when not enabled

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1300,24 +1300,26 @@ function SkillsTabClass:UpdateGlobalGemCountAssignments()
 	local countSocketGroups = 0
 	for _, socketGroup in ipairs(self.socketGroupList) do
 		local countGroup = true
-		for _, gemInstance in ipairs(socketGroup.gemList) do
-			if gemInstance.fromItem or (gemInstance.gemData and gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.fromTree) then
-				countGroup = false
-			end
-			if gemInstance.gemData then
-				if GlobalGemAssignments[gemInstance.gemData.name] then
-					GlobalGemAssignments[gemInstance.gemData.name].count = GlobalGemAssignments[gemInstance.gemData.name].count + 1
-					if socketGroup.displayLabel then
-						t_insert(GlobalGemAssignments[gemInstance.gemData.name].groups, socketGroup.displayLabel)
-					end
-				else
-					GlobalGemAssignments[gemInstance.gemData.name] = { 
-						count = 1,
-						support = gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.support or false,
-						groups = { } 
-					}
-					if socketGroup.displayLabel then
-						t_insert(GlobalGemAssignments[gemInstance.gemData.name].groups, socketGroup.displayLabel)
+		if socketGroup.enabled then
+			for _, gemInstance in ipairs(socketGroup.gemList) do
+				if gemInstance.fromItem or (gemInstance.gemData and gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.fromTree) then
+					countGroup = false
+				end
+				if gemInstance.gemData and gemInstance.enabled then
+					if GlobalGemAssignments[gemInstance.gemData.name] then
+						GlobalGemAssignments[gemInstance.gemData.name].count = GlobalGemAssignments[gemInstance.gemData.name].count + 1
+						if socketGroup.displayLabel then
+							t_insert(GlobalGemAssignments[gemInstance.gemData.name].groups, socketGroup.displayLabel)
+						end
+					else
+						GlobalGemAssignments[gemInstance.gemData.name] = { 
+							count = 1,
+							support = gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.support or false,
+							groups = { } 
+						}
+						if socketGroup.displayLabel then
+							t_insert(GlobalGemAssignments[gemInstance.gemData.name].groups, socketGroup.displayLabel)
+						end
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #611 . Took a shot at it myself, first time working here so unsure if this is the way to do it properly, let me know if there's a better way. I tested the changes on my local with different setups, seems to work fine.

### Description of the problem being solved:
Just added two conditionals to check if the socket group is enabled ([L1303](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/612/files#diff-59529d6b10ff730a86299280a8a431ddac44ef9ef63592a48dbe2d45c1547f89R1303)), or if the single gem instance is enabled ([L1308](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/612/files#diff-59529d6b10ff730a86299280a8a431ddac44ef9ef63592a48dbe2d45c1547f89R1308)), before counting it

### Steps taken to verify a working solution:
- Using the POB code in the issue I recreated the scenario and it doesn't show the warning anymore.

### Link to a build that showcases this PR: 
```shell
eNrtWktz2zgSPie_gsXrVqyH7YkzJWdKtuxYVX5oJSeZOaVgEpKwBgkNAMrW_PrtBkBSUgSKlG-78SEhif4a6BfQ3VDvj9eEB0sqFRPpedg5aocBTSMRs3R2Hn59vP5wFv7x-X1vRPT8YXqRMY4j3c_v3_XMS8DpknIAhkHEiVL3JKHn4ZikMyrDgKiIpvFlOXAvUhoGmsgZ1d_ySds_ED0nkkSayltk2M-0uBMxILTMAJEQlk5E9Ez1FymyxXl4HAZLRl8szfBu9DB-DGFR73ojTlZUTjTRgYJ_zsNLkTyxlMaD0QQwhGcAaIet3cQTLQuijz6iAX0tiLqdUx_ZmP69Qdn2Ug5TXWfWpdCgr_1CPApN-NXNqKA87Ryd_XZ6_PGs87Hd_uRdxmi-Uiwi_I68siRLbph-JM-0nPA379pu2WyuU3AMH_TkzAe9ZpI2R10KHh-AmhOhDpFuSmuQTRY0-h1ph2lUkJ9VMf2aSqqoXNK45irGNBIQq-SJ05qIcooRlRCMpaN12u3qqWY0dfOt9vvcHUlJDQsYHSHtuo4qme7QkZ_9JqCBxAjcLXHn6JNfGCZZLfaWcocoDTANpLlKqZytJnNGebxfy-vUufiXZFFjs0RjrqNrGXVzukZONiazpn55tSRqfdM83iONJa_nnZRTCoCYwr6SRnQ_YiTFf2ikGW8G68tEZLKmPSxxLQHy_X5AEqPYOIvqHTBX0ymKsaQXHM7kumIUKFgn542gfa1J9DwQ8ay20swkjRCb65tkiwWEHnpDXQZ4lI2pYqoM0g8nNagfwJVrBRyeevUnKKlrT1Cc4_Vn2YLUlwXP4q1p6hDXnqAw5x1sFQnsnGBWGkPCWO6gXtNk4Dp10kVDKHQt2pF4gZXPMfVVzaghYyn3L-9SJE3_WdXmv0Fea4KrNM4kBkLtObYRu6a5yKZTFUSQoxN9C-Y9D8PgCb7lz1EmFXUvFvHIEth4lRoQTYLYJcXfiGQk1V1TiChKZDRH0DXh_Al2DuRUfjVvppi4ZhwqjgF8w2WiKNscO7mb9Fqm3sGnYbIQUgf0Ff8bEalX5-GUcEUtofkCfJRmKdGmwulzHgaTuXjpx0uc6VEIrnJQQBYLqJI2eDxKSgOS70YRLsIIjy9QDClY9co6uEJp1uqsYWzESKEwgqHT9snpJ5Q9EmlM5Kq_SZgyWJeGubZqsZIRzvqu93V8ax7ezbVeqN9brZeXl6MFlIRiSl_hODsCA7YWAIL1flDPjPMPyLXVh7-LWd_8GUatnFPPVnOqZd8wqiWDJdtperDhS_aUaZoPgD5f761MYcBSXTwrLfNnx6u1wazXQp0ZA6JS8eFeaDuGH_OX3gSXrcAxpP5CE3Wxgqi-xiRlq4R0VkHqCdXW4dYxecka0ynJOH7_d0Y4Qydpr3-9tYVzKmRSlFzACpwEjx7L8XG1QMn6t7fO_G7WgMW5S7iPpkLul0u7JDxSZnEsjXgWQ1HidrXC7Th5wgVgvY8FRbxea69xKiZ614MVmdCGFQxTMIhzIIv_wsUT4d2ci-sLdNub4518fGnjC73MbhwDq5kL8QJawIlxyORY8MmShMHfa6qc0cSSaBLDXtAaajBBC9bYMuuGh58ZpyRxAQWvGJH6J_EjkaXOrGuiOn2ivK3DtdHZr4x-HNPYnHc2LXPOsKYT92WbsJGKVKt0MsNjmE4zmyiXKjIDQTlymKJ61hz_I75apDt9KTc8dXOgqTGcw25zL21RjARu6JfXNvVa50q_3PaX2_4_bLbuEUhN8mPTG3w0IEMxTBeZNms4DxOmoh-YeWNL3aRV5gbg6vr66vJx-O3KZd_rEKOkH2mWPKEq7P9lVTWhppsQqOxJ2cfz8BujL2YhA1AS4wrl4pws1Fp8YmrjVs4BV8HNUN0wbU3i41US-DldvVIJ2frsO5QIklHvuorxPYuyE2KLCqsVHzeoHCsY2Z7HJeT6Y6K9PExRW8HlUjLtFQcHK7BQ5xDundmN7tGExgwWHJxNWYSlYbXJMd-1VBV6iaAmJNGqwt6uYePnccFRax4GdtAPHgmmMEJ3o91ohVZnKfPb04364QMaEa_sdtAPvqU0mn-Bw0ekN9i53s2loKrgdC9S4-S46TOO7RWvZa84LUj8DB_0nEpX0vo43cEelZNUBo6tHb181igqdGVufTwawjE_1F6GeGTAsYqgcXcKvmhn1SG72fn32GOdxs_Kttu8OnStuwozuK61xwR2tEKSvHHvEcINVwSK2YP7S8Fi2771hMwWWdWmIaLnt7MxPem3s9luUr-d4zUn6tlrbzfqh3_VDFOhHVxsBlOLCQbW2zhgfL2NA3Yrk4PR4-1UpMSOq5OQoq-6E5yPVsW-a7cezME2hQ-Gm571wWhzAAzolIIElSdAQVMRHDpLB6AMXREYNVmZZe3eRUrpGvGyZ-FOSRtztNHtfshQtQFYkj2M4DC_qUgX63Eq7l1uKOF6PhKCv43hTz_YeAszvDnOFiSNc3YPu5L00g41tSe0Ap7mhmCAF9Rv1WFKk9UORv519Vp5WWfuDrDQcjceEy2xA_GPEMlfpk7FJ9d8PnYNZ0i5BwzsJo2_5fMg4Z_5_U7PlLOu-43PRfPbzyBTdGJuHr5TshCpQVhd2FrScqkg2-xzc6EDSI6T0dPX8S3KZMtQKO-XGEc4ZC8tWtUAO03QaQAx234jRD_JONUNAObYCY4bI5qL0W2uqyaQC8r1AdYIJi94rVsbN8auUqN1iXgV5FlpYwUctLxOY2s2EeiGwkmiG2lA6J8DpddygWivVyWJIRxx5_hOsXun7PZiwt-0j0Q6ZTO3EdgXtxUYfPEl0ExzijWpuX7ZjOX1NlKUKS2SOxGrsu30r267HWgRDOirplDyrHLRRpxEdC54TKWDU9wrbRuk6EF9bLf3ADZ-fpDD9oGKbmbecSp6Xu1ud9-EsuhLFLDTPZj1H5QUmL2SwZcD1odzHQAzB0mJODvx08OGqNmCMyq_M0yEaDwxHS7sbE4on67Ne1pDxsaKKaw3wiQihx3XRTU3RNkuLlEn7U97YEXhW-i0SqkGsvlDrsZuiVDY5p5TqCSNSVTJolvH3eoqdDKHCnp7hk4FfSRMAlMbYFbkfs4GWZP5Gfr6rrAHmR8OxUzds0_tGgrc1vtxBUixGeMPU1MrgWSm4KsrGcZoXV1fzrGFvlt1kCzmu7RNHc3b5_e91k8_8_8vNKPRcA==
```

### Before screenshot:
Same as in issue

### After screenshot:
With one disabled the warning does not appear anymore
![imagen](https://github.com/user-attachments/assets/7ef3d12b-d27c-45e5-b93b-8a259ba45da3)

Disabling the socket group also works
![imagen](https://github.com/user-attachments/assets/e6f00abc-8f8b-4fd7-ba85-a2b432d898f9)

Warning still shows up with both enabled
![imagen](https://github.com/user-attachments/assets/c7379fc0-6f59-4640-93f8-ebf42aff49cf)

