### PR TITLE
Add Shift + Ctrl + V to bypass item import confirmation box

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1067,6 +1067,9 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 					end
 					self:CreateDisplayItemFromRaw(newItem, true)
 				end
+				if self.displayItem and IsKeyDown("SHIFT") then
+					self:AddDisplayItem()
+				end
 			elseif event.key == "e" then
 				local mOverControl = self:GetMouseOverControl()
 				if mOverControl and mOverControl._className == "ItemSlotControl" and mOverControl.selItemId ~= 0 then
@@ -1092,6 +1095,8 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 			elseif event.key == "d" and IsKeyDown("CTRL") then
 				self.showStatDifferences = not self.showStatDifferences
 				self.build.buildFlag = true
+			elseif self.displayItem and IsKeyDown("RETURN") then
+				self:AddDisplayItem()
 			end
 		end
 	end


### PR DESCRIPTION
Adds the keybind to quickly import items into PoB without needing to confirm each time. You can also press enter now to confirm selection
