### PR TITLE
Fix item range crash on ventor's gamble

### DIFF
--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -76,7 +76,7 @@ function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 	local strippedLine = line:gsub("([%+-]?)%((%-?%d+%.?%d*)%-(%-?%d+%.?%d*)%)", function(sign, min, max)
 		local value = min + range * (tonumber(max) - min)
 		if sign == "-" then value = value * -1 end
-		return (sign == "+" and value > 0 ) and sign..tostring(value) or tostring(value)
+		return (sign == "+" and value >= 0 ) and sign..tostring(value) or tostring(value)
 	end)
 	:gsub("%-(%d+%.?%d*%%) (%a+)", antonymFunc)
 	:gsub("(%-?%d+%.?%d*)", function(value)


### PR DESCRIPTION
Ventor's stats weren't showing and would disappear resulting it the list getting corrupted and crashing. This was introduced in the proper scalability PR and resulted in signs not being presented on 0 values causing mod parser to fail resulting in them being hidden, this changes it such that the + sign is used for 0 values like it did previously.

### Before screenshot:
![image](https://github.com/user-attachments/assets/b0666aa9-a70b-4942-8817-e290f6dbf8c7)

### After screenshot:
![image](https://github.com/user-attachments/assets/bb892f7f-fd2b-4597-b0c8-079592f4f41c)
