### PR TITLE
Fix total flask charges gained in flask uptime calculation

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2966,7 +2966,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		if hasUptime then
 			local flaskChargesUsed = flaskData.chargesUsed * (1 + usedInc / 100)
 			if flaskChargesUsed > 0 and flaskDuration > 0 then
-				local averageChargesGenerated = chargesGenerated * flaskDuration
+				local averageChargesGenerated = totalChargesGenerated * flaskDuration
 				local percentageMin = m_min(averageChargesGenerated / flaskChargesUsed * 100, 100)
 				if percentageMin < 100 and chanceToNotConsumeCharges < 100 then
 					local averageChargesUsed = flaskChargesUsed * (100 - chanceToNotConsumeCharges) / 100


### PR DESCRIPTION
Fixes #638 

### Description of the problem being solved:
Increased flask charges gained is not taken into account when calculating flask uptime

### Steps taken to verify a working solution:
- Import build code from the issue
- Verify that life flask uptime is now 100%

### Link to a build that showcases this PR:
Use the build code from the issue

### After screenshot:
![pic](https://github.com/user-attachments/assets/eade7db2-ba83-4cb2-9a2a-003b41c71bb6)

