### PR TITLE
Use slider instead of text editor for ring quality

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -427,12 +427,8 @@ holding Shift will put it in the second.]])
 		function(index, value)
 			self.displayItem.catalyst = index - 1
 			if not self.displayItem.catalystQuality then
-				if string.match(self.displayItem.name, "Breach Ring") then 
-					self.displayItem.catalystQuality = 50 
-				else 
-					self.displayItem.catalystQuality = 20 
-				end 
-				self.controls.displayItemCatalystQualityEdit:SetText(self.displayItem.catalystQuality)
+				self.displayItem.catalystQuality = string.match(self.displayItem.name, "Breach Ring") and 50 or 20
+				self.controls.displayItemCatalystQualityEdit:SetVal(self.displayItem.catalystQuality)
 			end
 			if self.displayItem.crafted then
 				for i = 1, self.displayItem.affixLimit do
@@ -447,18 +443,12 @@ holding Shift will put it in the second.]])
 	self.controls.displayItemCatalyst.shown = function()
 		return self.displayItem and (self.displayItem.crafted or self.displayItem.hasModTags) and (self.displayItem.base.type == "Amulet" or self.displayItem.base.type == "Ring")
 	end
-	self.controls.displayItemCatalystQualityEdit = new("EditControl", {"LEFT",self.controls.displayItemCatalyst,"RIGHT"}, {2, 0, 60, 20}, nil, nil, "%D", 2, function(buf)
-		self.displayItem.catalystQuality = tonumber(buf)
-		if self.displayItem.crafted then
-			for i = 1, self.displayItem.affixLimit do
-				-- Force affix selectors to update
-				local drop = self.controls["displayItemAffix"..i]
-				drop.selFunc(drop.selIndex, drop.list[drop.selIndex])
-			end
-		end
+	self.controls.displayItemCatalystQualityEdit = new("SliderControl", {"LEFT",self.controls.displayItemCatalyst,"RIGHT"}, {2, 0, 60, 20}, function(val)
+		self.displayItem.catalystQuality = round(tonumber(val) * (string.match(self.displayItem.name, "Breach Ring") and 50 or 20))
 		self.displayItem:BuildAndParseRaw()
 		self:UpdateDisplayItemTooltip()
 	end)
+	self.controls.displayItemCatalystQualityEdit.width = 100;
 	self.controls.displayItemCatalystQualityEdit.shown = function()
 		return self.displayItem and (self.displayItem.crafted or self.displayItem.hasModTags) and self.displayItem.catalyst and self.displayItem.catalyst > 0
 	end
@@ -1466,9 +1456,10 @@ function ItemsTabClass:SetDisplayItem(item)
 		self.controls.displayItemQualityEdit:SetText(item.quality)
 		self.controls.displayItemCatalyst:SetSel((item.catalyst or 0) + 1)
 		if item.catalystQuality then
-			self.controls.displayItemCatalystQualityEdit:SetText(m_max(item.catalystQuality, 0))
+			local val = item.catalystQuality / (string.match(self.displayItem.name, "Breach Ring") and 50 or 20)
+			self.controls.displayItemCatalystQualityEdit:SetVal(m_max(val, 0))
 		else
-			self.controls.displayItemCatalystQualityEdit:SetText(0)
+			self.controls.displayItemCatalystQualityEdit:SetVal(0)
 		end
 		self:UpdateCustomControls()
 		self:UpdateRuneControls()


### PR DESCRIPTION
Fixes #613.

### Description of the problem being solved:
- Use a slider instead of a text editor for the quality of the ring/amulet (catalyst).
- Breach Ring: 0% - 50%
- Other rings and amulets: 0% - 20%

### Steps taken to verify a working solution:
- Tested on POB2
- Automatic tests successful
<img width="527" alt="image" src="https://github.com/user-attachments/assets/0481b6f4-2a5a-468f-ae60-b71974a4d52c" />


### Link to a build that showcases this PR:
https://pobb.in/_f7MFDiaTEBu

### Before screenshot:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/6d13b574-f525-42c6-a639-737ff9ed7b79" />
<img width="355" alt="image" src="https://github.com/user-attachments/assets/0a952e14-30e2-4aac-8050-ec6173941b3c" />
<img width="357" alt="image" src="https://github.com/user-attachments/assets/0b9c5fc3-fe00-4523-9e20-5633dbd15ab2" />

### After screenshot:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/949b275c-9801-4432-a1bd-fce34c1e5b56" />
<img width="314" alt="image" src="https://github.com/user-attachments/assets/db3d8168-4ec5-4435-badc-ef86a5c75e13" />
<img width="355" alt="image" src="https://github.com/user-attachments/assets/bb2514b1-5bd9-4dc3-9abf-ef53ec72ffd6" />

