### PR TITLE
Don't add stat comparisons for hovered gem quality if gem has no quality stats

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -787,7 +787,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			addQualityLines(qualityTable, gemData.secondaryGrantedEffect)
 		end
 		-- Add stat comparisons for hovered quality (based on set quality)
-		if self.displayGroup.gemList[index] then
+		if gemData and (gemData.grantedEffect.qualityStats or (gemData.secondaryGrantedEffect and gemData.secondaryGrantedEffect.qualityStats)) and self.displayGroup.gemList[index] then
 			local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then
 				local storedQuality = self.displayGroup.gemList[index].quality


### PR DESCRIPTION
### Before screenshot:
![before](https://github.com/user-attachments/assets/f708e1b0-6b55-4cce-bbae-f8160322d063)



### After screenshot:
![after](https://github.com/user-attachments/assets/1c718164-5046-4edd-9948-662c6e9f88f6)
