### PR TITLE
Added Support for Attacks Gain Extra mods on Quivers

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2356,10 +2356,13 @@ c["Attack Skills have +1 to maximum number of Summoned Totems"]={{[1]={flags=0,k
 c["Attacks Chain 2 additional times"]={{[1]={flags=1,keywordFlags=0,name="ChainCountMax",type="BASE",value=2}},nil}
 c["Attacks Chain an additional time"]={nil,"Attacks Chain an additional time "}
 c["Attacks Chain an additional time Attacks Chain 2 additional times"]={nil,"Attacks Chain an additional time Attacks Chain 2 additional times "}
-c["Attacks Gain 10% of Damage as Extra Cold Damage"]={nil,"Attacks Gain 10% of Damage as Extra Cold Damage "}
-c["Attacks Gain 10% of Damage as Extra Fire Damage"]={nil,"Attacks Gain 10% of Damage as Extra Fire Damage "}
-c["Attacks Gain 20% of Physical Damage as extra Chaos Damage"]={nil,"Attacks Gain 20% of Physical Damage as extra Chaos Damage "}
-c["Attacks gain increased Accuracy Rating equal to their Critical Hit Chance"]={nil,"Attacks gain increased Accuracy Rating equal to their Critical Hit Chance "}
+c["Attacks Gain 10% of Damage as Extra Cold Damage"]={{[1]={flags=1,keywordFlags=0,name="DamageGainAsCold",type="BASE",value=10}},nil}
+c["Attacks Gain 10% of Damage as Extra Fire Damage"]={{[1]={flags=1,keywordFlags=0,name="DamageGainAsFire",type="BASE",value=10}},nil}
+c["Attacks Gain 15% of Physical Damage as extra Chaos Damage"]={{[1]={flags=1,keywordFlags=0,name="PhysicalDamageGainAsChaos",type="BASE",value=15}},nil}
+c["Attacks Gain 20% of Physical Damage as extra Chaos Damage"]={{[1]={flags=1,keywordFlags=0,name="PhysicalDamageGainAsChaos",type="BASE",value=20}},nil}
+c["Attacks Gain 8% of Damage as Extra Cold Damage"]={{[1]={flags=1,keywordFlags=0,name="DamageGainAsCold",type="BASE",value=8}},nil}
+c["Attacks Gain 8% of Damage as Extra Fire Damage"]={{[1]={flags=1,keywordFlags=0,name="DamageGainAsFire",type="BASE",value=8}},nil}
+c["Attacks gain increased Accuracy Rating equal to their Critical Hit Chance"]={nil,"increased Accuracy Rating equal to their Critical Hit Chance "}
 c["Attacks have +1% to Critical Hit Chance"]={{[1]={flags=1,keywordFlags=0,name="CritChance",type="BASE",value=1}},nil}
 c["Attacks have 10% chance to Maim on Hit"]={{}," to Maim  "}
 c["Attacks have 25% chance to Maim on Hit"]={{}," to Maim  "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1118,7 +1118,7 @@ local preFlagList = {
 	["^attacks with this weapon [hd][ae][va][el] "] = { tagList = { { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack } } },
 	["^hits with this weapon [hd][ae][va][el] "] = { flags = ModFlag.Hit, tagList = { { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.Attack } } },
 	-- Skill types
-	["^attacks [hd][ae][va][el] "] = { flags = ModFlag.Attack },
+	["^attacks [ghd][ae][iva][eln] "] = { flags = ModFlag.Attack },
 	["^attack skills [hd][ae][va][el] "] = { keywordFlags = KeywordFlag.Attack },
 	["^spells [hd][ae][va][el] a? ?"] = { flags = ModFlag.Spell },
 	["^spell skills [hd][ae][va][el] "] = { keywordFlags = KeywordFlag.Spell },
@@ -5820,7 +5820,7 @@ end
 local function capitalizeWordsInString(string)
 	local wordsToIgnore = {
 		"increased", "with", "to", "when", "by", "if", "you", "haven't", "been", "deal", "reduced", "of", "on",
-		"from", "your", "chance", "inflict"
+		"from", "your", "chance", "inflict", "their",
 	}
 	local finalString = ""
 	for word in string:gmatch("%S+") do

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5820,7 +5820,7 @@ end
 local function capitalizeWordsInString(string)
 	local wordsToIgnore = {
 		"increased", "with", "to", "when", "by", "if", "you", "haven't", "been", "deal", "reduced", "of", "on",
-		"from", "your", "chance", "inflict",
+		"from", "your", "chance", "inflict"
 	}
 	local finalString = ""
 	for word in string:gmatch("%S+") do

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5820,7 +5820,7 @@ end
 local function capitalizeWordsInString(string)
 	local wordsToIgnore = {
 		"increased", "with", "to", "when", "by", "if", "you", "haven't", "been", "deal", "reduced", "of", "on",
-		"from", "your", "chance", "inflict", "their",
+		"from", "your", "chance", "inflict",
 	}
 	local finalString = ""
 	for word in string:gmatch("%S+") do


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

- Blackgleam
- Asphyxia's Wrath
- Beyond Reach

These quivers all have "Attacks gain % of damage as extra [type] damage"

It only checks for the Attack flag. So it does apply to concoctions as well. I assume this is right, but I do not have a Ranger to test. If someone could confirm that would be great!

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
