### PR TITLE
Added support for Skin of the Loyal overcap mods

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2607,8 +2607,7 @@ c["Energy Generation is doubled"]={nil,"Energy Generation is doubled "}
 c["Energy Shield Recharge is not interrupted by Damage if Recharge began Recently"]={nil,"Energy Shield Recharge is not interrupted by Damage if Recharge began Recently "}
 c["Energy Shield Recharge starts when you use a Mana Flask"]={nil,"Energy Shield Recharge starts when you use a Mana Flask "}
 c["Energy Shield does not Recharge"]={{[1]={flags=0,keywordFlags=0,name="NoEnergyShieldRecharge",type="FLAG",value=true}},nil}
-c["Energy Shield is increased by Overcapped Cold Resistance"]={nil,"Energy Shield is increased by Overcapped Cold Resistance "}
-c["Energy Shield is increased by Overcapped Cold Resistance Evasion Rating is increased by Overcapped Lightning Resistance"]={nil,"Energy Shield is increased by Overcapped Cold Resistance Evasion Rating is increased by Overcapped Lightning Resistance "}
+c["Energy Shield is increased by Overcapped Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldIncreasedByOvercappedColdRes",type="FLAG",value=true}},nil}
 c["Energy Shield starts at zero"]={nil,"Energy Shield starts at zero "}
 c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield "}
 c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second"]={nil,"Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose 5% of Energy Shield per second "}
@@ -2617,7 +2616,7 @@ c["Energy Shield starts at zero Cannot Recharge or Regenerate Energy Shield Lose
 c["Equipment and Skill Gems have 25% increased Attribute Requirements"]={{[1]={flags=0,keywordFlags=0,name="GlobalAttributeRequirements",type="INC",value=25}},nil}
 c["Equipment and Skill Gems have 4% reduced Attribute Requirements"]={{[1]={flags=0,keywordFlags=0,name="GlobalAttributeRequirements",type="INC",value=-4}},nil}
 c["Equipment and Skill Gems have 50% reduced Attribute Requirements"]={{[1]={flags=0,keywordFlags=0,name="GlobalAttributeRequirements",type="INC",value=-50}},nil}
-c["Evasion Rating is increased by Overcapped Lightning Resistance"]={nil,"Evasion Rating is increased by Overcapped Lightning Resistance "}
+c["Evasion Rating is increased by Overcapped Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="EvasionRatingIncreasedByOvercappedLightningRes",type="FLAG",value=true}},nil}
 c["Every 12 seconds, gain 50% more Cast Speed for 4 seconds"]={nil,"Every 12 seconds, gain 50% more Cast Speed for 4 seconds "}
 c["Every 3 seconds during Effect, deal 50% of Mana spent in those seconds as Chaos Damage to Enemies within 3 metres"]={nil,"Every 3 seconds during Effect, deal 50% of Mana spent in those seconds as Chaos Damage to Enemies within 3 metres "}
 c["Every 3 seconds during Effect, deal 50% of Mana spent in those seconds as Chaos Damage to Enemies within 3 metres Recover all Mana when Used"]={nil,"Every 3 seconds during Effect, deal 50% of Mana spent in those seconds as Chaos Damage to Enemies within 3 metres Recover all Mana when Used "}

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -861,6 +861,13 @@ function calcs.defence(env, actor)
 		end
 	end
 
+	if modDB:Flag(nil, "EnergyShieldIncreasedByOvercappedColdRes") then
+		for i, value in ipairs(modDB:Tabulate("FLAG", nil, "EnergyShieldIncreasedByOvercappedColdRes")) do
+				local mod = value.mod
+				modDB:NewMod("EnergyShield", "INC", output.ColdResistOverCap, mod.source)
+			break
+		end
+	end
 	if modDB:Flag(nil, "ArmourIncreasedByUncappedFireRes") then
 		for i, value in ipairs(modDB:Tabulate("FLAG", nil, "ArmourIncreasedByUncappedFireRes")) do
 				local mod = value.mod
@@ -886,6 +893,13 @@ function calcs.defence(env, actor)
 		for i, value in ipairs(modDB:Tabulate("FLAG", nil, "EvasionRatingIncreasedByOvercappedColdRes")) do
 			local mod = value.mod
 			modDB:NewMod("Evasion", "INC", output.ColdResistOverCap, mod.source)			
+			break
+		end
+	end
+	if modDB:Flag(nil, "EvasionRatingIncreasedByOvercappedLightningRes") then
+		for i, value in ipairs(modDB:Tabulate("FLAG", nil, "EvasionRatingIncreasedByOvercappedLightningRes")) do
+			local mod = value.mod
+			modDB:NewMod("Evasion", "INC", output.LightningResistOverCap, mod.source)			
 			break
 		end
 	end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4343,6 +4343,8 @@ local specialModList = {
 	["(%d+)%% to maximum fire resistance for each (%d+)%% uncapped fire resistance"] = function(num, _, percent) return { mod("FireResistMax", "BASE", num, { type = "PerStat", stat = "FireResistTotal", div = tonumber(percent) }) } end,
 	["evasion rating is increased by uncapped cold resistance"] = { flag( "EvasionRatingIncreasedByUncappedColdRes") },
 	["evasion rating is increased by overcapped cold resistance"] = { flag( "EvasionRatingIncreasedByOvercappedColdRes") },
+	["energy shield is increased by overcapped cold resistance"] = { flag( "EnergyShieldIncreasedByOvercappedColdRes") },
+	["evasion rating is increased by overcapped lightning resistance"] = { flag( "EvasionRatingIncreasedByOvercappedLightningRes") },
 	["reflects (%d+) physical damage to melee attackers"] = { },
 	["ignore all movement penalties from armour"] = { flag("Condition:IgnoreMovementPenalties") },
 	["gain armour equal to your reserved mana"] = { mod("Armour", "BASE", 1, { type = "PerStat", stat = "ManaReserved", div = 1 }) },


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Two mods on Skin of the Loyal unique chest now work. "energy shield is increased by overcapped cold resistance" and "evasion rating is increased by overcapped lightning resistance".

### Steps taken to verify a working solution:
-
-

### Link to a build that showcases this PR:

https://maxroll.gg/poe2/pob/xf4g60ft

### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/37986d3f-8fc9-466f-a891-d4967fb11456)
![image](https://github.com/user-attachments/assets/40e88292-6a44-43ca-95df-7b9c46dc9108)
![image](https://github.com/user-attachments/assets/85e44899-438b-4170-9bc2-adbecf8367c2)
