### PR TITLE
Added support for Iron Will and Iron Grip

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2840,10 +2840,9 @@ c["Inherent loss of Rage is 25% slower"]={{[1]={flags=0,keywordFlags=0,name="Inh
 c["Instant Recovery"]={{[1]={flags=0,keywordFlags=0,name="FlaskInstantRecovery",type="BASE",value=100}},nil}
 c["Intelligence provides no inherent bonus to Maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="NoIntBonusToMana",type="FLAG",value=true}},nil}
 c["Intelligence's inherent bonus is 1% increased Evasion Rating per 2 Intelligence instead"]={{[1]={[1]={div="2",stat="Int",type="PerStat"},flags=0,keywordFlags=0,name="Evasion",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoIntBonusToMana",type="FLAG",value=true}},nil}
-c["Iron Grip"]={nil,"Iron Grip "}
-c["Iron Grip Iron Will"]={nil,"Iron Grip Iron Will "}
+c["Iron Grip"]={{[1]={[1]={div=2,stat="Str",type="PerStat"},flags=2,keywordFlags=0,name="Damage",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoStrBonusToLife",type="FLAG",value=true}},nil}
 c["Iron Reflexes"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Iron Reflexes"}},nil}
-c["Iron Will"]={nil,"Iron Will "}
+c["Iron Will"]={{[1]={[1]={div=2,stat="Str",type="PerStat"},flags=1,keywordFlags=0,name="Damage",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoStrBonusToLife",type="FLAG",value=true}},nil}
 c["Knocks Back Enemies if you get a Critical Hit with a Quarterstaff"]={{[1]={[1]={type="Condition",var="CriticalStrike"},flags=2097152,keywordFlags=0,name="EnemyKnockbackChance",type="BASE",value=100}},nil}
 c["Leech 5% of Physical Attack Damage as Life"]={nil,"Leech 5% of Physical Attack Damage as Life "}
 c["Leech 5% of Physical Attack Damage as Life You gain Onslaught for 4 seconds on Kill"]={nil,"Leech 5% of Physical Attack Damage as Life You gain Onslaught for 4 seconds on Kill "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2842,7 +2842,7 @@ c["Intelligence provides no inherent bonus to Maximum Mana"]={{[1]={flags=0,keyw
 c["Intelligence's inherent bonus is 1% increased Evasion Rating per 2 Intelligence instead"]={{[1]={[1]={div="2",stat="Int",type="PerStat"},flags=0,keywordFlags=0,name="Evasion",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoIntBonusToMana",type="FLAG",value=true}},nil}
 c["Iron Grip"]={{[1]={[1]={div=2,stat="Str",type="PerStat"},flags=2,keywordFlags=0,name="Damage",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoStrBonusToLife",type="FLAG",value=true}},nil}
 c["Iron Reflexes"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Iron Reflexes"}},nil}
-c["Iron Will"]={{[1]={[1]={div=2,stat="Str",type="PerStat"},flags=1,keywordFlags=0,name="Damage",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoStrBonusToLife",type="FLAG",value=true}},nil}
+c["Iron Will"]={{[1]={[1]={div=2,stat="Str",type="PerStat"},flags=1025,keywordFlags=0,name="Damage",type="INC",value=1},[2]={flags=0,keywordFlags=0,name="NoStrBonusToLife",type="FLAG",value=true}},nil}
 c["Knocks Back Enemies if you get a Critical Hit with a Quarterstaff"]={{[1]={[1]={type="Condition",var="CriticalStrike"},flags=2097152,keywordFlags=0,name="EnemyKnockbackChance",type="BASE",value=100}},nil}
 c["Leech 5% of Physical Attack Damage as Life"]={nil,"Leech 5% of Physical Attack Damage as Life "}
 c["Leech 5% of Physical Attack Damage as Life You gain Onslaught for 4 seconds on Kill"]={nil,"Leech 5% of Physical Attack Damage as Life You gain Onslaught for 4 seconds on Kill "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2275,7 +2275,7 @@ local specialModList = {
 		flag("NoStrBonusToLife") }
 	end,
 	["iron will"] = function() return {
-		mod("Damage", "INC", 1, ModFlag.Projectile, ModFlag.Attack, { type = "PerStat", stat = "Str", div = 2 } ),
+		mod("Damage", "INC", 1, nil, bor(ModFlag.Projectile, ModFlag.Attack), { type = "PerStat", stat = "Str", div = 2 } ),
 		flag("NoStrBonusToLife") }
 	end,
 	-- Legacy support

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2270,12 +2270,6 @@ local specialModList = {
 		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }, { type = "Multiplier", var = "BeenHitRecently", limit = cap / numChance }),
 	} end,
 	["you can wield two%-handed axes, maces and swords in one hand"] = { flag("GiantsBlood") },
-	-- Legacy support
-	["(%d+)%% chance to defend with double armour"] = function(numChance) return {
-		mod("ArmourDefense", "MAX", 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax" }),
-		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * 100, "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg" }),
-		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }),
-	} end,
 	["iron grip"] = function() return {
 		mod("Damage", "INC", 1, nil, ModFlag.Spell, { type = "PerStat", stat = "Str", div = 2 } ),
 		flag("NoStrBonusToLife") }
@@ -2284,6 +2278,12 @@ local specialModList = {
 		mod("Damage", "INC", 1, ModFlag.Projectile, ModFlag.Attack, { type = "PerStat", stat = "Str", div = 2 } ),
 		flag("NoStrBonusToLife") }
 	end,
+	-- Legacy support
+	["(%d+)%% chance to defend with double armour"] = function(numChance) return {
+		mod("ArmourDefense", "MAX", 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax" }),
+		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * 100, "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg" }),
+		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }),
+	} end,
 	-- Masteries
 	["hits have (%d+)%% chance to treat enemy monster elemental resistance values as inverted"] = function(num) return {
 		mod("HitsInvertEleResChance", "CHANCE", num / 100, nil)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2276,6 +2276,14 @@ local specialModList = {
 		mod("ArmourDefense", "MAX", math.min(numChance / 100, 1.0) * 100, "Armour Mastery: Average Calc", { type = "Condition", var = "ArmourAvg" }),
 		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }),
 	} end,
+	["iron grip"] = function() return {
+		mod("Damage", "INC", 1, nil, ModFlag.Spell, { type = "PerStat", stat = "Str", div = 2 } ),
+		flag("NoStrBonusToLife") }
+	end,
+	["iron will"] = function() return {
+		mod("Damage", "INC", 1, ModFlag.Projectile, ModFlag.Attack, { type = "PerStat", stat = "Str", div = 2 } ),
+		flag("NoStrBonusToLife") }
+	end,
 	-- Masteries
 	["hits have (%d+)%% chance to treat enemy monster elemental resistance values as inverted"] = function(num) return {
 		mod("HitsInvertEleResChance", "CHANCE", num / 100, nil)


### PR DESCRIPTION
### Description of the problem being solved:

The unique body armour Irongrasp had both mods, "Iron Will" and "Iron Grip". This PR adds both to the keystone area in modparser.lua as poe2db has them in the keystone family still.

### Steps taken to verify a working solution:
- Equipped a bow to ensure Iron Will only applies to spells.
- Iron Grip applies to spells and not attacks.
- NoStrBonusToLife flag set. As both Iron Will and Iron Grip make strength provide no bonus to life.

### Link to a build that showcases this PR:

https://maxroll.gg/poe2/pob/g45c30fo

### Before screenshot:
![image](https://github.com/user-attachments/assets/a8767b9c-3084-41ab-90db-167080c61ec6)
![image](https://github.com/user-attachments/assets/8d22e350-fa2f-4c9f-89d6-343418724c02)
![image](https://github.com/user-attachments/assets/8fdefd56-4bf9-494e-a5aa-9d40fe5a52f0)


### After screenshot:
![image](https://github.com/user-attachments/assets/0c1151e6-5139-4122-a908-68281a113c49)
![image](https://github.com/user-attachments/assets/3403c355-9dc6-40aa-8805-26bb3ff2b2a8)


