### PR TITLE
Added support for Crown of thorns 5 life on using skill

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2893,8 +2893,7 @@ c["Lose 1% of Life on Kill"]={{[1]={[1]={percent=1,stat="Life",type="PercentStat
 c["Lose 1% of Mana on Kill"]={{[1]={[1]={percent=1,stat="Mana",type="PercentStat"},flags=0,keywordFlags=0,name="ManaOnKill",type="BASE",value=-1}},nil}
 c["Lose 2% of Life on Kill"]={{[1]={[1]={percent=2,stat="Life",type="PercentStat"},flags=0,keywordFlags=0,name="LifeOnKill",type="BASE",value=-1}},nil}
 c["Lose 3% of Life and Energy Shield when you use a Chaos Skill"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=-3}},"  and Energy Shield when you use a Chaos Skill "}
-c["Lose 5 Life when you use a Skill"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=-5}},"  when you use a Skill "}
-c["Lose 5 Life when you use a Skill 5 to 10 Physical Thorns damage"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=-5}},"  when you use a Skill 5 to 10 Physical Thorns damage "}
+c["Lose 5 Life when you use a Skill"]={{[1]={[1]={neg=true,skillType=150,type="SkillType"},flags=0,keywordFlags=0,name="LifeCost",type="BASE",value=5}},nil}
 c["Lose 5% of Energy Shield per second"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldDegenPercent",type="BASE",value=5}},nil}
 c["Lose all Fragile Regrowth when Hit"]={nil,"Lose all Fragile Regrowth when Hit "}
 c["Lose all Fragile Regrowth when Hit Gain 1 Fragile Regrowth each second"]={nil,"Lose all Fragile Regrowth when Hit Gain 1 Fragile Regrowth each second "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5083,6 +5083,9 @@ local specialModList = {
 	["gain sacrificial zeal when you use a skill, dealing you %d+%% of the skill's mana cost as physical damage per second"] = {
 		flag("Condition:SacrificialZeal"),
 	},
+	["lose (%d+)% life when you use a skill"] = function (num) return {
+		mod("LifeCost", "BASE", num, { type = "SkillType", skillType = SkillType.Persistent, neg = true }),
+	} end,
 	["skills gain a base life cost equal to (%d+)%% of base mana cost"] = function(num) return {
 		mod("ManaCostAsLifeCost", "BASE", num),
 	} end,


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Unique helm Crown of Thorns has the mod "lose 5 life when you use a skill". I feel the best way to represent that is just to add base 5 life cost to all skills, other than persistent skills.

### Steps taken to verify a working solution:
-Confirmed in game that activating persistent skills does not cost life.

### Link to a build that showcases this PR:

https://maxroll.gg/poe2/pob/185h30ft

### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/0f9192a4-0adc-44e9-a7b5-cbd7b406dcd9)
