### PR TITLE
Widened dropdown to properly display ascendancy class names

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -239,7 +239,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			end
 		end
 	end)
-	self.controls.ascendDrop = new("DropDownControl", {"LEFT",self.controls.classDrop,"RIGHT"}, {8, 0, 120, 20}, nil, function(index, value)
+	self.controls.ascendDrop = new("DropDownControl", {"LEFT",self.controls.classDrop,"RIGHT"}, {8, 0, 150, 20}, nil, function(index, value)
 		self.spec:SelectAscendClass(value.ascendClassId)
 		self.spec:AddUndoState()
 		self.spec:SetWindowTitleWithBuildClass()


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
The dropdown box was too small to properly display some of the ascendancy class names.
### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
![after](https://github.com/user-attachments/assets/6e1880c2-240e-4719-81e1-51d739c54726)

