### PR TITLE
Add support for Heavy Armour notable

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -889,7 +889,7 @@ c["100% of Elemental Damage Converted to Chaos Damage"]={{[1]={flags=0,keywordFl
 c["100% of Fire Damage Converted to Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="FireDamageConvertToCold",type="BASE",value=100}},nil}
 c["100% of Fire Damage from Hits taken as Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="FireDamageFromHitsTakenAsPhysical",type="BASE",value=100}},nil}
 c["100% of Lightning Damage Converted to Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningDamageConvertToCold",type="BASE",value=100}},nil}
-c["100% of Strength Requirements from Boots, Gloves and Helmets also added to Armour"]={{[1]={flags=0,keywordFlags=0,name="StrRequirement",type="BASE",value=100}}," s from Boots, Gloves and Helmets also added to Armour "}
+c["100% of Strength Requirements from Boots, Gloves and Helmets also added to Armour"]={{[1]={[1]={percent=100,stat="StrRequirementsOnBoots",type="PerStat"},flags=0,keywordFlags=0,name="Armour",type="BASE",value=1},[2]={[1]={percent=100,stat="StrRequirementsOnGloves",type="PerStat"},flags=0,keywordFlags=0,name="Armour",type="BASE",value=1},[3]={[1]={percent=100,stat="StrRequirementsOnHelmet",type="PerStat"},flags=0,keywordFlags=0,name="Armour",type="BASE",value=1}},nil}
 c["11% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=11}},nil}
 c["11% increased Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootRarity",type="INC",value=11}},nil}
 c["12 Life Regeneration per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=12}},nil}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1432,6 +1432,7 @@ function calcs.perform(env, skipEHP)
 						else
 							req = m_floor(reqSource[attr] * reqMultItem)
 						end
+						output[attr.."RequirementsOn"..reqSource.sourceSlot] = req;
 					elseif reqSource.source == "Gem" then
 						req = m_floor(reqSource[attr] * reqMultGem)
 					end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2270,6 +2270,11 @@ local specialModList = {
 		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }, { type = "Multiplier", var = "BeenHitRecently", limit = cap / numChance }),
 	} end,
 	["you can wield two%-handed axes, maces and swords in one hand"] = { flag("GiantsBlood") },
+	["(%d+)%% of strength requirements from boots, gloves and helmets also added to armour"] = function(num) return { 
+		mod("Armour", "BASE", 1, { type = "PerStat", stat = "StrRequirementsOnBoots", percent = num }),
+		mod("Armour", "BASE", 1, { type = "PerStat", stat = "StrRequirementsOnGloves", percent = num }),
+		mod("Armour", "BASE", 1, { type = "PerStat", stat = "StrRequirementsOnHelmet", percent = num }),
+	} end,
 	-- Legacy support
 	["(%d+)%% chance to defend with double armour"] = function(numChance) return {
 		mod("ArmourDefense", "MAX", 100, "Armour Mastery: Max Calc", { type = "Condition", var = "ArmourMax" }),


### PR DESCRIPTION
Fixes #331 .

### Description of the problem being solved:
Heavy Notable passive tree skill notable wasn't supported yet. Now it's implemented and adds strength requirements from equipped items to armour.

### Steps taken to verify a working solution:
- imported build from the game to PoB
- compared value calculated by game and PoB

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/z34yd0y5

### Before screenshot:
![image](https://github.com/user-attachments/assets/57dcbb02-6113-47d6-987e-4dd57291f124)

### After screenshot:
![image](https://github.com/user-attachments/assets/0b7555ca-0d44-4749-b0db-83349f441eff)
![image](https://github.com/user-attachments/assets/cc14970e-88e7-4ee0-8651-808cab031af5)
![image](https://github.com/user-attachments/assets/f9668305-7bb0-479a-a277-996a75e2de91)