### PR TITLE
Fix ES bypass regression from #552

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -19,6 +19,16 @@ describe("TestDefence", function()
 		runCallback("OnFrame")
 	end
 
+	-- a small helper function to calculate damage taken from limited test parameters
+	local function takenHitFromTypeMaxHit(type, enemyDamageMulti)
+		return build.calcsTab.calcs.takenHitFromDamage(build.calcsTab.calcsOutput[type.."MaximumHitTaken"] * (enemyDamageMulti or 1), type, build.calcsTab.calcsEnv.player)
+	end
+	
+	local function poolsRemainingAfterTypeMaxHit(type, enemyDamageMulti)
+		local _, takenDamages = takenHitFromTypeMaxHit(type, enemyDamageMulti)
+		return build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
+	end
+
 	it("no armour max hits", function()
 		build.configTab.input.enemyIsBoss = "None"
 		build.configTab.input.customMods = ""
@@ -92,12 +102,29 @@ describe("TestDefence", function()
 		assert.are.equals(3000, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
 		assert.are.equals(3000, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
 		assert.are.equals(3000, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		local poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+
+		build.configTab.input.customMods = "\z
+		+200 to all resistances\n\z
+		+200 to all maximum resistances\n\z
+		50% reduced damage taken\n\z
+		50% less damage taken\n\z
+		Nearby enemies deal 20% less damage\n\z
+		Gain 100% of life as extra maximum energy shield\n\z
+		intelligence provides no bonus to energy shield\n\z
+		"
+		pob1and2Compat()
+		assert.are.equals(600, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
+		assert.are.equals(6000, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(6000, build.calcsTab.calcsOutput.ColdMaximumHitTaken)
+		assert.are.equals(6000, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(4500, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		assert.are.equals(0, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 	end)
-	
-	-- a small helper function to calculate damage taken from limited test parameters
-	local function takenHitFromTypeMaxHit(type, enemyDamageMulti)
-		return build.calcsTab.calcs.takenHitFromDamage(build.calcsTab.calcsOutput[type.."MaximumHitTaken"] * (enemyDamageMulti or 1), type, build.calcsTab.calcsEnv.player)
-	end
 
 	it("armoured max hits", function()
 		build.configTab.input.enemyIsBoss = "None"
@@ -269,9 +296,9 @@ describe("TestDefence", function()
 		Chaos Inoculation\n\z
 		"
 		pob1and2Compat()
-		local _, takenDamages = takenHitFromTypeMaxHit("Cold")
-		local poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Life))
+		local poolsRemaining = poolsRemainingAfterTypeMaxHit("Cold")
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 	end)
 	
 	it("damage conversion to different size pools", function()
@@ -286,10 +313,10 @@ describe("TestDefence", function()
 		10% of lightning damage taken as cold damage\n\z
 		"   -- Small amount of conversion into a smaller pool leads to the higher pool damage type (lightning) draining it's own excess pool (mana), and then joining back on the shared pools (life)
 		pob1and2Compat()
-		local _, takenDamages = takenHitFromTypeMaxHit("Lightning")
-		local poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Mana))
-		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
+		local poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 
 		build.configTab.input.customMods = "\z
 		+140 to maximum life\n\z
@@ -301,10 +328,10 @@ describe("TestDefence", function()
 		20% of lightning damage taken as cold damage\n\z
 		"   -- This is a case where cold damage drains the whole life pool and lightning damage drains the entire mana pool, leaving nothing
 		pob1and2Compat()
-		_, takenDamages = takenHitFromTypeMaxHit("Lightning")
-		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Life))
-		assert.are.equals(0, round(poolsRemaining.Mana))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 
 		build.configTab.input.customMods = "\z
 		+40 to maximum life\n\z
@@ -316,10 +343,10 @@ describe("TestDefence", function()
 		20% of lightning damage taken as cold damage\n\z
 		"   -- Any extra mana in this case will not help and be left over after death, since life hits 0 from the cold damage alone
 		pob1and2Compat()
-		_, takenDamages = takenHitFromTypeMaxHit("Lightning")
-		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Life))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
 		assert.are.not_false(1000 < round(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 
 		-- conversion into a bigger pool
 		build.configTab.input.customMods = "\z
@@ -332,10 +359,10 @@ describe("TestDefence", function()
 		90% of cold damage taken as lightning damage\n\z
 		"   -- With inverted conversion amounts the behaviour of converting into a bigger pool should be exactly the same as converting into a lower one.
 		pob1and2Compat()
-		_, takenDamages = takenHitFromTypeMaxHit("Cold")
-		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Mana))
-		assert.are.not_false(poolsRemaining.Life / 100 < 0.1)
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Cold")
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 
 		build.configTab.input.customMods = "\z
 		+140 to maximum life\n\z
@@ -347,10 +374,10 @@ describe("TestDefence", function()
 		80% of cold damage taken as lightning damage\n\z
 		"
 		pob1and2Compat()
-		_, takenDamages = takenHitFromTypeMaxHit("Cold")
-		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Life))
-		assert.are.equals(0, round(poolsRemaining.Mana))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Cold")
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 
 		build.configTab.input.customMods = "\z
 		+40 to maximum life\n\z
@@ -362,10 +389,33 @@ describe("TestDefence", function()
 		80% of cold damage taken as lightning damage\n\z
 		"
 		pob1and2Compat()
-		_, takenDamages = takenHitFromTypeMaxHit("Cold")
-		poolsRemaining = build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
-		assert.are.equals(0, round(poolsRemaining.Life))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Cold")
 		assert.are.not_false(1000 < round(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+
+		build.configTab.input.customMods = "\z
+		+940 to maximum life\n\z
+		+950 to mana\n\z
+		+1000 to energy shield\n\z
+		+10000 to armour\n\z
+		+110% to all elemental resistances\n\z
+		Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage\n\z
+		100% of Lightning Damage is taken from Mana before Life\n\z
+		80% of cold damage taken as lightning damage\n\z
+		50% of fire damage taken as chaos damage\n\z
+		"
+		pob1and2Compat()
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Cold")
+		assert.are.equals(0, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Fire")
+		assert.are.equals(0, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(1000, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 	end)
 
 	it("energy shield bypass tests #pet", function()
@@ -378,6 +428,10 @@ describe("TestDefence", function()
 			+60% to all resistances
 		]]
 		pob1and2Compat()
+		local poolsRemaining = poolsRemainingAfterTypeMaxHit("Chaos")
+		assert.are.equals(100, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
 		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
 
@@ -385,18 +439,91 @@ describe("TestDefence", function()
 		build.configTab.input.customMods = [[
 			+40 to maximum life
 			+100 to energy shield
-			50% of chaos damage taken does not bypass energy shield
+			physical damage taken bypasses energy shield
 			You have no intelligence
 			+60% to all resistances
 		]]
 		pob1and2Compat()
+		assert.are.equals(100, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
 		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
 		assert.are.equals(150, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Physical")
+		assert.are.equals(100, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Chaos")
+		assert.are.equals(0, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 		-- Chaos damage should still bypass
 		build.configTab.input.customMods = build.configTab.input.customMods .. "\nAll damage taken bypasses energy shield"
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
+		assert.are.equals(100, build.calcsTab.calcsOutput.PhysicalMaximumHitTaken)
 		assert.are.equals(100, build.calcsTab.calcsOutput.FireMaximumHitTaken)
 		assert.are.equals(100, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Physical")
+		assert.are.equals(100, floor(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Chaos")
+		assert.are.equals(100, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+
+		-- Bypass + MoM
+		build.configTab.input.customMods = [[
+			+40 to maximum life
+			+50 to mana
+			+200 to energy shield
+			50% of damage taken bypasses energy shield
+			50% of Lightning Damage is taken from Mana before Life
+			intelligence provides no bonus to energy shield
+			+60% to all resistances
+		]]
+		pob1and2Compat()
+		assert.are.equals(400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Chaos")
+		assert.are.equals(0, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Fire")
+		assert.are.equals(100, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
+		assert.are.equals(0, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+
+		build.configTab.input.customMods = [[
+			+40 to maximum life
+			+150 to mana
+			+300 to energy shield
+			50% of damage taken bypasses energy shield
+			50% of Lightning Damage is taken from Mana before Life
+			intelligence provides no bonus to energy shield
+			+60% to all resistances
+		]]
+		pob1and2Compat()
+		assert.are.equals(400, build.calcsTab.calcsOutput.LightningMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.FireMaximumHitTaken)
+		assert.are.equals(200, build.calcsTab.calcsOutput.ChaosMaximumHitTaken)
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Chaos")
+		assert.are.equals(100, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Fire")
+		assert.are.equals(200, round(poolsRemaining.EnergyShield))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
+		poolsRemaining = poolsRemainingAfterTypeMaxHit("Lightning")
+		assert.are.equals(100, round(poolsRemaining.EnergyShield))
+		assert.are.equals(100, floor(poolsRemaining.Mana))
+		assert.are.equals(0, floor(poolsRemaining.Life))
+		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 	end)
 end)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -470,33 +470,21 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 			local esDamageTypeMultiplier = damageType == "Chaos" and 2 or 1
 			local esBypass = output[damageType.."EnergyShieldBypass"] / 100 or 0
 			local lifeHitPool = calcLifeHitPoolWithLossPrevention(life, output.Life, output.preventedLifeLoss, lifeLossBelowHalfPrevented)
-			if energyShield > 0 and (not modDB:Flag(nil, "EnergyShieldProtectsMana")) and (esBypass) < 1 then
-				local esPool = esBypass > 0 and m_min(lifeHitPool / esBypass - lifeHitPool, energyShield) or energyShield
-				local tempDamage = m_min(damageRemainder * (1 - esBypass), esPool / esDamageTypeMultiplier) * esDamageTypeMultiplier
-				esPoolRemaining = m_min(esPoolRemaining, esPool - tempDamage)
-				energyShield = energyShield - tempDamage
+			local MoMEffect = m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
+			local MoMPool = MoMEffect < 1 and m_min(lifeHitPool / (1 - MoMEffect) - lifeHitPool, mana) or mana
+			if energyShield > 0 and esBypass < 1 then
+				local MoMEBPool = esBypass > 0 and m_min((MoMPool + lifeHitPool) / esBypass * esDamageTypeMultiplier - (MoMPool + lifeHitPool), energyShield) or energyShield
+				local tempDamage = m_min(damageRemainder * (1 - esBypass), MoMEBPool / esDamageTypeMultiplier)
+				esPoolRemaining = m_min(esPoolRemaining, MoMEBPool - tempDamage * esDamageTypeMultiplier)
+				energyShield = energyShield - tempDamage * esDamageTypeMultiplier
 				damageRemainder = damageRemainder - tempDamage
 			end
-			if (output.sharedMindOverMatter + output[damageType.."MindOverMatter"]) > 0 then
-				local MoMEffect = m_min(output.sharedMindOverMatter + output[damageType.."MindOverMatter"], 100) / 100
-				local MoMPool = MoMEffect < 1 and m_min(lifeHitPool / (1 - MoMEffect) - lifeHitPool, mana) or mana
+			if MoMEffect > 0 and mana > 0 then
 				local MoMDamage = damageRemainder * MoMEffect
-				if modDB:Flag(nil, "EnergyShieldProtectsMana") and energyShield > 0 and esBypass < 1 then
-					local MoMEBPool = esBypass > 0 and m_min(MoMPool / esBypass - MoMPool, energyShield) or energyShield
-					local tempDamage = m_min(MoMDamage * (1 - esBypass), MoMEBPool / esDamageTypeMultiplier) * esDamageTypeMultiplier
-					esPoolRemaining = m_min(esPoolRemaining, MoMEBPool - tempDamage)
-					energyShield = energyShield - tempDamage
-					MoMDamage = MoMDamage - tempDamage
-					local tempDamage2 = m_min(MoMDamage, MoMPool)
-					MoMPoolRemaining = m_min(MoMPoolRemaining, MoMPool - tempDamage2)
-					mana = mana - tempDamage2
-					damageRemainder = damageRemainder - tempDamage - tempDamage2
-				elseif mana > 0 then
-					local tempDamage = m_min(MoMDamage, MoMPool)
-					MoMPoolRemaining = m_min(MoMPoolRemaining, MoMPool - tempDamage)
-					mana = mana - tempDamage
-					damageRemainder = damageRemainder - tempDamage
-				end
+				local tempDamage = m_min(MoMDamage, MoMPool)
+				MoMPoolRemaining = m_min(MoMPoolRemaining, MoMPool - tempDamage)
+				mana = mana - tempDamage
+				damageRemainder = damageRemainder - tempDamage
 			else
 				MoMPoolRemaining = 0
 			end


### PR DESCRIPTION
### Description of the problem being solved:
#552 introduced a bug <sup>(who could've done such a thing?)</sup> where ES bypass + MoM did not work because code was relying on "EnergyShieldProtectsMana" flag which is not set to true by default in pob2 (should it?)

Added some tests which should prevent this happening again in the future

### Before screenshot (current dev):
![image](https://github.com/user-attachments/assets/f6709a1a-12dc-4569-aeac-8f3e7cf4c3e8)

### After screenshot:
![image](https://github.com/user-attachments/assets/b25a9129-151b-4605-8cf2-a68202f4b735)

