### PR TITLE
Add parsing for "Your speed is unaffected by Slows"

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -138,6 +138,24 @@ function ModStoreClass:Sum(modType, cfg, ...)
 	return self:SumInternal(self, modType, cfg, flags, keywordFlags, source, ...)
 end
 
+
+--- Returns the value of all positive modifiers to a mod added together, ignoring any negative modifiers.
+--- Works by creating a table using Tabulate and then filtering for positive values.
+---
+--- @param modType string # the mod type for which we want to create the table, e.g. "INC" or "MORE"
+--- @param cfg table | nil # passed configuration, may be nil
+--- @param modName string # the name of the mod for which we want to create the table, e.g. "FlaskRecoveryRate", "ActionSpeed", ...
+function ModStoreClass:SumPositiveValues(modType, cfg, modName, ...)
+	local total = 0
+	local modTable = self:Tabulate(modType, cfg, modName)
+	for i = 1, #modTable do
+		if modTable[i].value > 0 then
+			total = total + modTable[i].value
+		end
+	end
+	return total
+end
+
 function ModStoreClass:More(cfg, ...)
 	local flags, keywordFlags = 0, 0
 	local source

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -773,7 +773,7 @@ function calcs.actionSpeedMod(actor)
 	-- if we are unaffected by slows, only count the positive modifiers to action speed
 	if modDB:Flag(nil, "UnaffectedBySlows") then
 		local actionSpeedSum = sumPositiveValues(modDB, "ActionSpeed")
-		local tempChainsSum = sumPositiveValues(modDB, "TemporalChainsActionSpeed")
+		local tempChainsSum = m_max(-data.misc.TemporalChainsEffectCap, sumPositiveValues(modDB, "TemporalChainsActionSpeed"))
 		actionSpeedMod = 1 + (tempChainsSum + actionSpeedSum) / 100
 	else
 	    actionSpeedMod = 1 + (m_max(-data.misc.TemporalChainsEffectCap, modDB:Sum("INC", nil, "TemporalChainsActionSpeed")) + modDB:Sum("INC", nil, "ActionSpeed")) / 100

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -751,11 +751,33 @@ local function doActorCharges(env, actor)
 	modDB.multipliers["SpiritCharge"] = output.SpiritCharges
 end
 
+
+-- helper function to sum only positive values from Tabulate
+local function sumPositiveValues(modDB, modType)
+    local total = 0
+    local modTable = modDB:Tabulate("INC", nil, modType)
+    for i = 1, #modTable do
+        if modTable[i].value > 0 then
+            total = total + modTable[i].value
+        end
+    end
+    return total
+end
+
 function calcs.actionSpeedMod(actor)
 	local modDB = actor.modDB
 	local minimumActionSpeed = modDB:Max(nil, "MinimumActionSpeed") or 0
 	local maximumActionSpeedReduction = modDB:Max(nil, "MaximumActionSpeedReduction")
-	local actionSpeedMod = 1 + (m_max(-data.misc.TemporalChainsEffectCap, modDB:Sum("INC", nil, "TemporalChainsActionSpeed")) + modDB:Sum("INC", nil, "ActionSpeed")) / 100
+	local actionSpeedMod = 0
+	
+	-- if we are unaffected by slows, only count the positive modifiers to action speed
+	if modDB:Flag(nil, "UnaffectedBySlows") then
+		local actionSpeedSum = sumPositiveValues(modDB, "ActionSpeed")
+		local tempChainsSum = sumPositiveValues(modDB, "TemporalChainsActionSpeed")
+		actionSpeedMod = 1 + (tempChainsSum + actionSpeedSum) / 100
+	else
+	    actionSpeedMod = 1 + (m_max(-data.misc.TemporalChainsEffectCap, modDB:Sum("INC", nil, "TemporalChainsActionSpeed")) + modDB:Sum("INC", nil, "ActionSpeed")) / 100
+	end
 	actionSpeedMod = m_max(minimumActionSpeed / 100, actionSpeedMod)
 	if maximumActionSpeedReduction then
 		actionSpeedMod = m_min((100 - maximumActionSpeedReduction) / 100, actionSpeedMod)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2777,7 +2777,7 @@ local specialModList = {
 		mod("PhysicalDamageGainAsChaos", "BASE", num, { type = "SkillType", skillType = SkillType.Triggered, neg = true }, { type = "SkillType", skillType = SkillType.Channel, neg = true }, { type = "Condition", var = "UsingAmethystFlask" })
 	} end,
 	["double the number of your poisons that targets can be affected by at the same time"] =  function(num) return { flag("PoisonCanStack"), mod("PoisonStacks", "MORE", 100) } end,
-	["your speed is unaffected by slows"] = { mod("MinimumActionSpeed", "MAX", 100, { type = "GlobalEffect", effectType = "Global", unscalable = true }) },
+	["your speed is unaffected by slows"] = { flag("UnaffectedBySlows") },
 	-- Raider
 	["nearby enemies have (%d+)%% less accuracy rating while you have phasing"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("Accuracy", "MORE", -num) }, { type = "Condition", var = "Phasing" }) } end,
 	["immun[ei]t?y? to elemental ailments while phasing"] = { flag("ElementalAilmentImmune", { type = "Condition", var = "Phasing" }), },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2777,6 +2777,7 @@ local specialModList = {
 		mod("PhysicalDamageGainAsChaos", "BASE", num, { type = "SkillType", skillType = SkillType.Triggered, neg = true }, { type = "SkillType", skillType = SkillType.Channel, neg = true }, { type = "Condition", var = "UsingAmethystFlask" })
 	} end,
 	["double the number of your poisons that targets can be affected by at the same time"] =  function(num) return { flag("PoisonCanStack"), mod("PoisonStacks", "MORE", 100) } end,
+	["your speed is unaffected by slows"] = { mod("MinimumActionSpeed", "MAX", 100, { type = "GlobalEffect", effectType = "Global", unscalable = true }) },
 	-- Raider
 	["nearby enemies have (%d+)%% less accuracy rating while you have phasing"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("Accuracy", "MORE", -num) }, { type = "Condition", var = "Phasing" }) } end,
 	["immun[ei]t?y? to elemental ailments while phasing"] = { flag("ElementalAilmentImmune", { type = "Condition", var = "Phasing" }), },


### PR DESCRIPTION
Fixes part of #190

### Description of the problem being solved:
This adds parsing for "Your speed is unaffected by Slows" modifiers, such as on Pathfinder's "Relentless Pursuit" notable or the unique "Wanderlust" boots.

### Steps taken to verify a working solution:
- Restarted PoB with rebuilt ModCache
- Lines in "Relentless Pursuit" and "Wanderlust" now parse correctly (blue)
- Added an Attack (Molten Blast) to my Character and noted default Attack Rate: **1.26**
- Attack Rate when "Are you chilled?" is active drops to **1.13**
- Allocating "Relentless Pursuit" bounces the attack rate back to **1.26**, ignoring the slow of the chill

### Link to a build that showcases this PR:
https://pobb.in/uP9iiR1OtT2i

### Before screenshot:
![image](https://github.com/user-attachments/assets/2f56a2e2-c2c1-4179-9eb5-9d3ea854e8a1)


### After screenshot:
![image](https://github.com/user-attachments/assets/b121a27a-aff1-4337-a089-59b0da788c04)

