### PR TITLE
Fix the highlight node circle being too small

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -799,7 +799,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			SetDrawLayer(nil, 30)
 			local rgbColor = rgbColor or {1, 0, 0}
 			SetDrawColor(rgbColor[1], rgbColor[2], rgbColor[3])
-			local size = 140 * scale / self.zoom ^ 0.4
+			local size = 140 * scale / self.zoom ^ 0.2
 
 			if main.edgeSearchHighlight then
 				-- Snap node matches to the edge of the viewPort


### PR DESCRIPTION
### Description of the problem being solved:
The highlight circle around nodes was far too small the further you zoomed into the tree

### Before screenshot:
![image](https://github.com/user-attachments/assets/ab3cab06-b4fb-4635-a38a-409dba82c6c3)

### After screenshot:
![image](https://github.com/user-attachments/assets/b3856d4c-69ee-4e27-9ce2-3180d1ee9079)
