### PR TITLE
Add support for Rolling Slam "more damage against heavy stunned enemies"

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -755,6 +755,9 @@ return {
 ["active_skill_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),
 },
+["active_skill_damage_+%_final_against_heavy_stunned_enemies"] = {
+	mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "HeavyStunned" }),
+},
 ["sigil_attached_target_hit_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Condition", var = "TargetingBrandedEnemy"}),
 },


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Rolling Slam's second slam has mod "50% more damage against heavy stunned enemies". Now fixed.

### Steps taken to verify a working solution:
- Verified that only the Second Slam gets the 50% more damage, not the Rolling Slam or First Slam.
- Heavy Stunned pops up in the config when Second Slam is selected in the Main Skill tab on the left.
-

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/cd99605x
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/45955cf4-ed6f-4e07-87d8-6892ced6f6fa)
