### PR TITLE
Add support for War Banner aura mods

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -12555,10 +12555,10 @@ skills["WarBannerPlayer"] = {
 			statDescriptionScope = "war_banner",
 			statMap = {
 				["skill_war_banner_attack_damage_+%_final"] = {
-					mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+					mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 				},
 				["skill_war_banner_accuracy_+%"] = {
-					mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+					mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 				},
 			},
 			baseFlags = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -12553,6 +12553,14 @@ skills["WarBannerPlayer"] = {
 			label = "War Banner",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "war_banner",
+			statMap = {
+				["skill_war_banner_attack_damage_+%_final"] = {
+					mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+				},
+				["skill_war_banner_accuracy_+%"] = {
+					mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -652,5 +652,13 @@ statMap = {
 #skill WarBannerPlayer
 #set WarBannerPlayer
 #flags
+statMap = {
+	["skill_war_banner_attack_damage_+%_final"] = {
+		mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+	},
+	["skill_war_banner_accuracy_+%"] = {
+		mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+	},
+},
 #mods
 #skillEnd

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -654,10 +654,10 @@ statMap = {
 #flags
 statMap = {
 	["skill_war_banner_attack_damage_+%_final"] = {
-		mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+		mod("Damage", "MORE", nil,  ModFlag.Attack, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 	},
 	["skill_war_banner_accuracy_+%"] = {
-		mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Buff"}),
+		mod("Accuracy", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 	},
 },
 #mods

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -228,7 +228,7 @@ local configSettings = {
 		modList:NewMod("Condition:BannerPlanted", "FLAG", true, "Config")
 	end },
 	{ var = "bannerValour", type = "count", label = "Banner Valour:", tooltip = "The amount of valour consumed for the placed banner", ifSkill = { "Dread Banner", "War Banner", "Defiance Banner" }, apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:ValourStacks", "BASE", val, "Config", { type = "IgnoreCond" }, { type = "Condition", var = "Combat" })
+		modList:NewMod("Multiplier:ValourStacks", "BASE", m_min(val, 50), "Config", { type = "IgnoreCond" }, { type = "Condition", var = "Combat" })
 	end },
 	{ label = "Barkskin:", ifSkill = "Barkskin" },
 	{ var = "barkskinStacks", type = "count", label = "# of Barkskin Stacks:", ifSkill = "Barkskin", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

War Banner aura was not implemented yet, it now applies the increased accuracy and more damage for attacks, and scales with valour stacks.

Valour stack is currently not limited in the config. It should be limited to 50 as base, but unsure if there is anything that alters the max stackable honour.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/na9lh05n
### Before screenshot:

### After screenshot:
-Valour 50, no quality on gem
![image](https://github.com/user-attachments/assets/6786f213-c3f2-4df0-8859-1ae1dd260e07)
![image](https://github.com/user-attachments/assets/43900739-784e-4219-8504-d6dfa935595c)
-Valour 50, 20 quality
![image](https://github.com/user-attachments/assets/2e2aa740-79ec-4ac6-9816-d7ab4e6321c9)
