### PR TITLE
Add support for Defiance Banner

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2055,7 +2055,7 @@ skills["MagneticSalvoPlayer"] = {
 	name = "Magnetic Salvo",
 	baseTypeName = "Magnetic Salvo",
 	color = 2,
-	description = "Aims skyward and fires energy missiles at lingering arrows or bolts created by other Lightning Attacks in front of you. The missiles explode if they land close to a lingering bolt or arrow, dealing more damage in a larger area but destroying that bolt or arrow in the process.",
+	description = "Aims skyward and fires energy missiles at lingering bolts or arrows created by other Lightning Attacks in front of you. The missiles explode if they land close to a lingering bolt or arrow, dealing more damage in a larger area but destroying that bolt or arrow in the process.",
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Lightning] = true, [SkillType.ProjectileNoCollision] = true, },
 	weaponTypes = {
 		["Bow"] = true,

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1967,6 +1967,15 @@ skills["DefianceBannerPlayer"] = {
 			label = "Defiance Banner",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "defiance_banner",
+			statMap = {
+				["skill_defiance_banner_armour_evasion_+%_final"] = {
+					mod("Armour", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+					mod("Evasion", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+				},
+				["skill_defiance_banner_movement_speed_+%"] = {
+					mod("MovementSpeed", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -126,6 +126,15 @@ local skills, mod, flag, skill = ...
 #skill DefianceBannerPlayer
 #set DefianceBannerPlayer
 #flags
+statMap = {
+	["skill_defiance_banner_armour_evasion_+%_final"] = {
+		mod("Armour", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+		mod("Evasion", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+	},
+	["skill_defiance_banner_movement_speed_+%"] = {
+		mod("MovementSpeed", "INC", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Defiance Banner has more "more armour and evasion" as well as "increased movement speed" mods. Both scale by Valour stacks. Should work here.

Quality for defiance banner is not yet implemented. Mana Tempest uses the same stat. Seems weird to be on Defiance banner, does the banner count as empowering? I didn't think so, but dunno.

Also small text edit for Magnetic Salvo. They switched arrows and bolts at one point, likely because they repeat the order in a later sentence.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/1s9k707b
### Before screenshot:

### After screenshot:
50 stack, 20 gem
![image](https://github.com/user-attachments/assets/a92edce3-b6d9-4468-9b0b-85764559147d)
![image](https://github.com/user-attachments/assets/8c59678c-c1b4-4d94-9507-ae341a0c1fd7)
![image](https://github.com/user-attachments/assets/abb58045-5d55-4bfd-b2e4-be4e76f44269)

0 Stack, 20 gem
![image](https://github.com/user-attachments/assets/f2a2b5d3-62e8-448a-926d-ac2778f44229)
![image](https://github.com/user-attachments/assets/55113c3b-48e0-439e-9e02-a720639731d5)
![image](https://github.com/user-attachments/assets/a5ded484-cb99-488c-b73c-fde60da7b26f)

Salvo Text
![image](https://github.com/user-attachments/assets/62963363-61c4-4516-a28a-9bb3e853605f)
