### PR TITLE
ENH: minion skill multiple count spirit reservation

### DIFF
--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -149,32 +149,6 @@ function calcs.getMiscCalculator(build)
 	end, env.player.output
 end
 
-local function getActiveSkillCount(activeSkill)
-	if not activeSkill.socketGroup then
-		return 1, true
-	elseif activeSkill.socketGroup.groupCount then
-		return activeSkill.socketGroup.groupCount, true
-	else
-		local gemList = activeSkill.socketGroup.gemList
-		for _, gemData in pairs(gemList) do
-			if gemData.gemData then
-				if gemData.gemData.vaalGem then
-					if activeSkill.activeEffect.grantedEffect == gemData.gemData.grantedEffectList[1] then
-						return gemData.count or 1,  gemData.enableGlobal1 == true
-					elseif activeSkill.activeEffect.grantedEffect == gemData.gemData.grantedEffectList[2] then
-						return gemData.count or 1,  gemData.enableGlobal2 == true
-					end
-				else
-					if (activeSkill.activeEffect.grantedEffect == gemData.gemData.grantedEffect and not gemData.gemData.grantedEffect.support) or isValueInArray(gemData.gemData.additionalGrantedEffects, activeSkill.activeEffect.grantedEffect) then
-						return gemData.count or 1, true
-					end
-				end
-			end
-		end
-	end
-	return 1, true
-end
-
 function calcs.calcFullDPS(build, mode, override, specEnv)
 	local fullEnv, cachedPlayerDB, cachedEnemyDB, cachedMinionDB = calcs.initEnv(build, mode, override, specEnv)
 	local usedEnv = nil
@@ -204,7 +178,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 
 	for _, activeSkill in ipairs(fullEnv.player.activeSkillList) do
 		if activeSkill.socketGroup and activeSkill.socketGroup.includeInFullDPS then
-			local activeSkillCount, enabled = getActiveSkillCount(activeSkill)
+			local activeSkillCount, enabled = calcs.getActiveSkillCount(activeSkill)
 			if enabled then
 				fullEnv.player.mainSkill = activeSkill
 				calcs.perform(fullEnv, true)


### PR DESCRIPTION
Related to #242 and #397 

At the moment, minion skill always reserve spirit as only 1 minion is summoned.
To fix that, for all skill flagged as MultipleReservation (it seems unused atm) the gem count is used as a multiplier for spirit flat reservation.

the function getActiveSkillCount can be moved from Calcs.lua to CalcDefence.lua to avoid repetition