### PR TITLE
Update Time-Lost Jewel affixes with proper wording

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1647,6 +1647,10 @@ function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outp
 			if item.type == "Flask" then
 				label = mod.affix .. "   ^8[" .. modString .. "]"
 			end
+			-- shorten time-lost jewel affix labels to fit the dropdown
+			if label and item.baseName:find("Time%-Lost") ~= nil then
+				label = label:gsub(" Passive Skills in Radius also grant", ":")
+			end
 			control.list[i + 1] = {
 				label = label,
 				modList = { modId },

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -557,6 +557,19 @@ data.itemMods = {
 	Runes = LoadModule("Data/ModRunes")
 }
 
+-- update JewelRadius affixes for Time-Lost jewels
+do
+	for index, value in pairs(data.itemMods.Jewel) do
+		if index:find("JewelRadius") and value.nodeType and value[1] then
+			if value.nodeType == 1 then
+				value[1] = "Small Passive Skills in Radius also grant "..value[1]
+			elseif value.nodeType == 2 then
+				value[1] = "Notable Passive Skills in Radius also grant "..value[1]
+			end
+		end
+	end
+end
+
 data.costs = LoadModule("Data/Costs")
 do
 	local map = { }


### PR DESCRIPTION
Fixes #743 

### Description of the problem being solved:
"JewelRadius..." mods for Time-Lost jewels do not have the "Small Passive Skills in Radius also grant" or "Notable Passive Skills in Radius also grant" lines. This PR updates the data.itemMods.Jewel once when starting the application and it shortens the affix labels in the dropdown so they fit, identical to what we're doing with Against the Darkness rangeLine labels.

### Link to a build that showcases this PR:
<pre>eNrNW91z4zYOf17_FRrP3Fs2kWQ7tjNJO47tbNLJh2tnd3v30mEk2maXFl2JSuJ2-r8fQEryR0yFcu7hujO7loQfQAAECEDq-c-vC-480zhhIrqoe8du3aFRIEIWzS7qXx-vPnfqP_9UOx8ROX-YXqaM4xP_p9qnc3XhcPpMOQAbdSfgJEnuyYJe1MckmtG47pAkoFHYXz-4FxGtO5LEMyq_5VLd3z1Az0lMAknjW-TYS6W4EyEgZJwCYkFYNBHBDyq_xCJdgsC688zoi6a5uRs9jB_rsKpP5yNOVjSeSCKdBP66qPdAOzKjA7KAvwFFeAqQxnHL9U6b7dOG3_BOW_WTUvBlGifyMA6TJaVhAfKOfRPhKKbD6ZQGkj3Tfsxkf06iYC3OKGAPrX_cLCW_S7lkS87QRTnERH_9hnuza6J9FJLwwWiyJj32Xa_bbnutTrvd7ZTjhCxwronyO5PzSw4WPUAKYm9mEZP0QPBIsEREH9BvE2pUsZ9yDjFmRTumCY2fiWTbyzLzFosnFh1kvTsSkb5ILHyElCMaQ-TLSoAJDQQki6oyKiJv2ZTaU1bSIwNUXc1hegwntnSVGR-2oDEkRzvKiUi5JaVcZ6i2iWhAX9dELXOo_LlJ6HvGjHcTSRuhzwLD7n0dVPAPr0frM6DtHXdabsft-p2u3zCeB_NVwgLC78grW6QLyMOP5AddC_R937yrZnMZQRIxYb2WMYdfsZgeAOsLHh4CmxORHKDhHdQD1yQKe0GQQtmwWmczzzO6jMQ_IpoktmkV0qQ1AuPYZt1QDQRnSHwTBQV9p4zr1yjOVmPn-SkdQ9Bi2fLEqS1kLSSL_bXvXLdc1oxGmcCVnZluKQ3mX8B_YyKpXaYvqLqnpYZF2k3DljLdY1gz-21ABSMhcL-RGselZ21FM02WDAo7mxVpyj3aV8BUMMAwovFsNZkzykOLw2eDOrdYnyxt9Af_b6Kt9sG2uEpbeRNa0Vd4UlaV9kySzdOmU55hMnK7WKBQTwMgpDt1vmvuVMQf2KfwarBevBBpbOlKTWylQH5Q6v5sTMM0sDuZi3brkkNraatGgYJ1cl4J2pOSBD8GIpxZG00JqYTYXt8kXS4hanE32DLACgBOQLZRoH1uWlA_wFa2ilWsFewFrKmtBRT1j72UHYi9LljA7IixIbYWULjzDlLFApKuGijciY28bXQNdJJWbaEitGxPR-IFVj7HCU5SjRrKvPXhZ1xKTKO_Vtb8t8itBAyjECpGCARrGbuIfWIu0-k0cQJor4m8Bfde1OvOE9zLf0OVmtDsQiMe2QISb5IMiCROmHUT30jMSCR9Nd9KKImDOYKuCOdPkDmQ0_quulIzsSvGJY0HcA-XiarscvTybXJ-ouZ2-OtmsRSxdOgr_jMisVxd1KeEJ1QTqjvAJ5EsUhMGyF-c153JXLz0wmeU9CgET3KQQ5ZLGoVbPB5jSh2SZ6MAF6GUxwtnQRJY9Upv8AS12RgX3oRKjUjAAqCq7zRd78jzmu5Ry222ukfQvnXco0ar1WjC3118CM2Ue9Rs4n3_tNnwj1rdNtDDdcs98hodv3N06jU8_-i00el0jrxWy20f-U23c9QA5i20LDa7JF71tpcRMdBagiY7A8v1MlGnT-dfx7fqx6e5lMvk7OTk5eXleEnkXEzpKxyWx7A9TpYAAmt8Tn4wzj8j15Me_Hc56_WGt-748nr8eHMTP_wxcFff__yr-R93sPztiz-5nz0-z0aLX0e_3P1Cbh6nALlQQk9yqed6PJroJWRXyn64RmWLusMkXeBlljIAvok6x6QUM7B4xgTOq5g9pZLmD2A7vN6_cUlmSmV07RhtdGXczNrKO9pT2guZ0VkkM4bgABnnv_Plba0IVgv7Rm1i3Fj4415I_Qxv5hfnEzRuAsERyy90kVyuILNdYaG2MwHLdiZST6jUQbeJyafPIZ2SlOP9X1PCGQaKu3n3Vg_BIxEvin4dWEGg4PGrOT6ulqhZ7_Y2C4FMqsPCdWzqhePPPuGBVvomWqbgSDU-X7Ak-B3zCs69lcHUnH54dTXsP958G2a5ZROiNtrvUbp4wmmv_nd9ZkyoqpWcJH1K9M-L-jdGX9RCBlQSxiFDBoJzskxoEdxq0ZkGHHAl3BQVtPb59Hw_rzWBmdPwlcaQi2bfIQHGjBrXVTx_Z1FaIBbgmItN3HAsbWakK7o-ZDJd-hsspd4BmLngTN6oDj4swUIWJ9woOXv6jiUk7k0ILTZlAR585S7HnaypSuxSzGWM_s7KUTMPNec3MdAPzWA9qzehs6clVlXvCYxW1U_N8AENiFF3_dAMLrpJEV1jS7-fS0FVwuleRGqTQ9D0GMfi0ejZIacFiZnhg5zTODuwTZzuIEflJKWBo48WI58NihJbqbmbwUL4zAzVgyWDDvisJGiyYYsp2ll5yG6PRAz-2KQxs9LNhNGGWWNS4oasJze4QD8t0SQfSxiUyB6XBIrKwb1nwULdnBpCZoesLGlAQfNxNqrj_jib3Rb84xyvoOr8YfR39tQM_yoZ1i97uOhKx4oJBtbHOGB8fYwD9mKLg9Hj3VJkjR2XFyFF17gXnD8ti_2smTyYg255D4arjvxgtDoABnRKQYPSE6CgKQkOmUYDMIYsCQxLVmpZ-7PIWrtKvPRZuFfTyhx1dGfvtsoSgCZ5hxEc5tcl5aIdp2KqdE0Jxy8bBP8Ywzfv8D7CDOfi6ZJEYc7uYV-RvvaDpfWETICnmn8McPz-URtGdLHaw8i8rvOTvK1TkxFstLJ5zkTG2AH_JcTi3xf1z41m67jbaLTdZts_7bT0g6zL7GadJVTgAwZujNX2y8Ui4W_AodtqHbtN6Lo9t93oNrX4G2j_k6zrxd9F02vmlyZUfwTwnZKliBRCW0p3msAl62BVxz4mUPqszpxxbzys9dMYmMkaeu7zrUikM1zQmPCw1o_JVNLwzEEhtVFMp-z1zPk7xs_Gzrx_fqEvlI9JyNLkUrxoKxZU-AlZbQI98P4LZaUx_fPMcWuaxZkzgbac16AX4iyA0MFHjX85LApiSsBljpbgvDA5d0BgomYP0GKrz9gctSro-I9b9Y1mHZyJym9bwd9jhXtwMhLUhq9LaGCdQQrmU407yjKYQqlivjCrv3WRTSvOHN-tZYMeMAb-qY3TiGZU-3-u7djubJrOq_0tySw5I6rz_QdUcHQTnDhTFlOHRA4JQ4YhQrjTi2PQ8VBzNvaY84q90vD_cksleMvJBnxOomdQLAKFEeKA14Uzg_VI53---XCOZI7UzQA9n3Ah1Rxw9PR1fItJR8-JvnDxjAddPiJ08xmcCaDFON4a4r8HUXXZJuJdIb1FyqmsAFB1odOojKiyKK2GX91WVSCXlMsDvOFMXvCtkjVujHmo0rpEuHLytvEtSmWZmxAgu7NnDVdx6GyMo3P2lhY8SD-v8naoYpFrCrWirGRCId9Gmg5pCFv9egiyBsQz1gbfKb6bTHQBoY5wNSAW0ZTNssNcX2THucIXdxzJJKc4dVLT6u1kMOIkoHPBQxpna6NY1GTfLOfD4rZbqGQAbL0FzWHvgYpXrvloOAd286-pzfI2vnnOUSWYyRy25UQdUm9G4GYZcKf6yvB1eHWUOmHWgI5vpl8U327jJ8lQrYVKsb5IIzmhfLqhYMtCw12ntay9NsIqP4c1bFGV5aFBK4na_hyk0q7CXbwLa3ROLcxYaYX5i9o1wi9ZWsJmjD9MVd8OrlbDB-s9DHGCtoDsqT5k3I0B37XaaPhCZfUVihVozKCg5yv7FWx-TGLj80kgVDtUMVbj9Qumwgvv7az8ECuEeC3_1MYeOLiIDjFG9oUStIqquNvMsO8gi0FrkSKaJbusP8c3c_ttCD1ofjTojlRd_VQ7P3nz__j8F5DEykA=</pre>

### Before screenshot:
![411269760-d29292b4-ec37-4085-a62c-2bbab1158a83](https://github.com/user-attachments/assets/82b1afc0-8ff6-458d-b544-335a04283541)

### After screenshot:
![image](https://github.com/user-attachments/assets/36c01684-eec8-4b03-8216-2c1308c6ea1a)
![image](https://github.com/user-attachments/assets/7c6f3f7a-1ecd-434e-bddd-a8c0f10ea3f9)

No changes to Against the Darkness
![image](https://github.com/user-attachments/assets/41d46b17-20b3-4319-a986-f31187afdbe6)
