### PR TITLE
Add support for "I Am The Thunder..." and "I Am The Blizzard..."

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1393,7 +1393,7 @@ c["25% chance for Attacks to Maim on Hit against Poisoned Enemies 25% increased 
 c["25% chance for Projectiles to Pierce Enemies within 3m distance of you"]={{[1]={flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=25}}," for  to Pierce Enemies within 3m distance of you "}
 c["25% chance for Trigger skills to refund half of Energy Spent"]={{}," for Trigger skills to refund half of Energy Spent "}
 c["25% chance on Consuming a Shock on an Enemy to reapply it"]={{}," on Consuming a Shock on an Enemy to reapply it "}
-c["25% chance on Shocking Enemies to created Shocked Ground"]={{}," on Shocking Enemies to created Shocked Ground "}
+c["25% chance on Shocking Enemies to created Shocked Ground"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="OnShockedGround"},flags=0,keywordFlags=0,name="ShockBase",type="BASE",value=20}},nil}
 c["25% chance to Avoid Physical Damage from Hits"]={{[1]={flags=0,keywordFlags=0,name="AvoidPhysicalDamageChance",type="BASE",value=25}},nil}
 c["25% chance to Intimidate Enemies for 4 seconds on Hit"]={{}," to Intimidate Enemies   "}
 c["25% chance to Poison on Hit"]={{[1]={flags=0,keywordFlags=0,name="PoisonChance",type="BASE",value=25}},nil}
@@ -2998,7 +2998,7 @@ c["Offerings have 15% increased Maximum Life"]={nil,"Offerings have 15% increase
 c["Offerings have 30% increased Maximum Life"]={nil,"Offerings have 30% increased Maximum Life "}
 c["Offerings have 30% increased Maximum Life Recover 3% of Life when you create an Offering"]={nil,"Offerings have 30% increased Maximum Life Recover 3% of Life when you create an Offering "}
 c["Offerings have 30% reduced Maximum Life"]={nil,"Offerings have 30% reduced Maximum Life "}
-c["On Freezing Enemies create Chilled Ground"]={nil,"On Freezing Enemies create Chilled Ground "}
+c["On Freezing Enemies create Chilled Ground"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="OnChilledGround"},flags=0,keywordFlags=0,name="ChillBase",type="BASE",value=10}},nil}
 c["On Hitting an enemy, gains maximum added Lightning damage equal to"]={nil,"On Hitting an enemy, gains maximum added Lightning damage equal to "}
 c["On Hitting an enemy, gains maximum added Lightning damage equal to the enemy's Power for 6 seconds, up to a total of 500"]={nil,"On Hitting an enemy, gains maximum added Lightning damage equal to the enemy's Power for 6 seconds, up to a total of 500 "}
 c["On-Kill Effects happen twice"]={nil,"On-Kill Effects happen twice "}

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1597,6 +1597,10 @@ Huge sets the radius to 11.
 		enemyModList:NewMod("Multiplier:FrozenByYouSeconds", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 		enemyModList:NewMod("Condition:FrozenByYou", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
+	{ var = "conditionEnemyOnChilledGround", type = "check", label = "Is the enemy on ^x3F6DB3Chilled ^7Ground?", ifEnemyCond = "OnChilledGround", implyCond = "Chilled", tooltip = "This also implies that the enemy is ^x3F6DB3Chilled.", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Condition:OnChilledGround", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+		enemyModList:NewMod("Condition:Chilled", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+	end },
 	{ var = "conditionEnemyBrittle", type = "check", ifFlag = "inflictBrittle", label = "Is the enemy ^x3F6DB3Brittle?", tooltip = "Hits against ^x3F6DB3Brittle ^7enemies have up to +6% Critical Strike Chance.\nThis option will also allow you to input the effect of ^x3F6DB3Brittle.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Brittle", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 		enemyModList:NewMod("Condition:BrittleConfig", "FLAG", true, "Config", { type = "Condition", var = "Effective" })

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2885,6 +2885,8 @@ local specialModList = {
 	} end,
 	-- Monk - Invoker
 	["critical hits ignore non%-negative enemy monster elemental resistances"] = { flag("IgnoreNonNegativeEleRes", { type = "Condition", var = "CriticalStrike" }) },
+	["(%d+)%% chance on shocking enemies to created shocked ground"] = { mod("ShockBase", "BASE", data.nonDamagingAilment["Shock"].default, { type = "ActorCondition", actor = "enemy", var = "OnShockedGround" }) },
+	["on freezing enemies create chilled ground"] = { mod("ChillBase", "BASE", data.nonDamagingAilment["Chill"].default, { type = "ActorCondition", actor = "enemy", var = "OnChilledGround" }) },
 	-- Chronomancer
 	["skills have (%d+)%% chance to not consume a cooldown when used"] = function(num) return { 
 		mod("CooldownChanceNotConsume", "BASE", num / 100, { type = "SkillType", skillType = SkillType.Cooldown })


### PR DESCRIPTION
Add support for "I Am The Thunder..." and "I Am The Blizzard..." invoker tree nodes

Partially Fixes #https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/182.

### Description of the problem being solved:

This PR implements the two invoker accendency nodes "I Am The Thunder..." and "I Am The Blizzard...". This PR also adds a condition for enemies on chilled ground.

I followed the impl of other "create shocked ground" mods for this impl. Doing this through the config as even if you have a high chance to shock/freeze, mobs can still move in and out of the ground effects. 

Note there is a typo in the "I Am The Thunder" node: `created` should be `create`. Seems to be part of the game currently https://poe2db.tw/us/I_am_the_Thunder... . Not sure if theres a way to deal with these typos to future proof it or just will fix in the future patch.

### Steps taken to verify a working solution:
- Allocated both nodes
- Verified config option was present for shocked or chilled ground
- Enabled shocked ground -> verified that enemy had shock ground effect applied
- Enabled chilled ground -> verified that enemy had chilled effect applied

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/8921p00k

### Before screenshot:

Nodes allocated:
![image](https://github.com/user-attachments/assets/c9d769af-a558-40f7-af7c-0861a8de73b1)

No shocked / chilled ground option in config:
![image](https://github.com/user-attachments/assets/f2e3b8d8-b052-47bd-ac9e-c1bdbcfeee98)

### After screenshot:

Shocked / chilled ground option showing in config:
![image](https://github.com/user-attachments/assets/65aaf3ba-e5c0-4e1e-ad13-d5d5f9fa8f95)

Enemy ailments from ground effects:
![image](https://github.com/user-attachments/assets/6ec0bc6c-4f79-4670-9b8e-97c27f9abdd6)

