### PR TITLE
Add support for Attrition

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -363,6 +363,14 @@ function ModStoreClass:EvalMod(mod, cfg)
 			end
 		elseif tag.type == "MultiplierThreshold" then
 			local target = self
+			local thresholdTarget = self
+			if tag.thresholdActor then
+			    if self.actor[tag.thresholdActor] then
+			        thresholdTarget = self.actor[tag.thresholdActor].modDB
+			    else
+			        return
+			    end
+			end
 			if tag.actor then
 				if self.actor[tag.actor] then
 					target = self.actor[tag.actor].modDB
@@ -378,7 +386,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 			else
 				mult = target:GetMultiplier(tag.var, cfg)
 			end
-			local threshold = tag.threshold or target:GetMultiplier(tag.thresholdVar, cfg)
+			local threshold = tag.threshold or thresholdTarget:GetMultiplier(tag.thresholdVar, cfg)
 			if (tag.upper and mult > threshold) or (not tag.upper and mult < threshold) then
 				return
 			end

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -365,11 +365,11 @@ function ModStoreClass:EvalMod(mod, cfg)
 			local target = self
 			local thresholdTarget = self
 			if tag.thresholdActor then
-			    if self.actor[tag.thresholdActor] then
-			        thresholdTarget = self.actor[tag.thresholdActor].modDB
-			    else
-			        return
-			    end
+				if self.actor[tag.thresholdActor] then
+			    	thresholdTarget = self.actor[tag.thresholdActor].modDB
+				else
+					return
+				end
 			end
 			if tag.actor then
 				if self.actor[tag.actor] then

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -366,7 +366,7 @@ function ModStoreClass:EvalMod(mod, cfg)
 			local thresholdTarget = self
 			if tag.thresholdActor then
 				if self.actor[tag.thresholdActor] then
-			    	thresholdTarget = self.actor[tag.thresholdActor].modDB
+					thresholdTarget = self.actor[tag.thresholdActor].modDB
 				else
 					return
 				end

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -762,6 +762,19 @@ skills["AttritionPlayer"] = {
 			label = "Attrition",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "attrition",
+			statMap = {
+				["skill_attrition_presence_max_seconds"] = {
+					mod("Multiplier:AttritionMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+				},
+				["skill_attrition_culling_strike_at_x_or_more_stacks"] = {
+					mod("Multiplier:AttritionCullSeconds", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+				},
+				["skill_attrition_hit_damage_+%_final_vs_rare_or_unique_enemy_per_second_ever_in_presence_up_to_max"] = {
+					{mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "Buff"}, { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limitVar = "AttritionMaxDamage", div = 2, limitTotal = true }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" })},
+					{mod("CullPercent", "MAX", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}, { type = "MultiplierThreshold", var = "EnemyPresenceSeconds", actor = "enemy", thresholdVar = "AttritionCullSeconds"}, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),
+					value = 10,}
+					},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -41,6 +41,20 @@ local skills, mod, flag, skill = ...
 #skill AttritionPlayer
 #set AttritionPlayer
 #flags
+statMap = {
+statMap = {
+	["skill_attrition_presence_max_seconds"] = {
+		mod("Multiplier:AttritionMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+	},
+	["skill_attrition_culling_strike_at_x_or_more_stacks"] = {
+		mod("Multiplier:AttritionCullSeconds", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+	},
+	["skill_attrition_hit_damage_+%_final_vs_rare_or_unique_enemy_per_second_ever_in_presence_up_to_max"] = {
+		{mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "Buff"}, { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limitVar = "AttritionMaxDamage", div = 2, limitTotal = true }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" })},
+		{mod("CullPercent", "MAX", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}, { type = "MultiplierThreshold", var = "EnemyPresenceSeconds", actor = "enemy", thresholdVar = "AttritionCullSeconds"}, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),
+		value = 10,}
+		},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:

1% more damage per 2 seconds the enemy is in your presence properly works. And it limited to the gems maximum damage.

Thanks to @Paliak, thresholdVar works properly for the culling strike mod. Culling strike is enabled once the enemy is in your presence for the required time.

Culling Strike code will need to be changed slightly if #618 gets added, quick fix at that point.

### After screenshot:
![image](https://github.com/user-attachments/assets/4de605bc-e3e8-4691-95e7-2c2cc070631e)
![image](https://github.com/user-attachments/assets/79a4796d-b29d-44b6-bdfb-0b3fd703c6f3)
![image](https://github.com/user-attachments/assets/01a4e689-75c1-4a95-8e6d-d6078d2bf6a5)

