### PR TITLE
Initial fake poison hits implementation

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -291,6 +291,11 @@ return {
 	skill("corpseExplosionLifeMultiplier", nil),
 	div = 1000,
 },
+["corpse_explosion_monster_life_permillage_chaos"] = {
+	skill("corpseExplosionLifeMultiplier", nil),
+	div = 1000,
+	flag("fakeHit"),
+},
 ["spell_base_fire_damage_%_maximum_life"] = {
 	skill("selfFireExplosionLifeMultiplier", nil),
 	div = 100,
@@ -1097,6 +1102,9 @@ return {
 ["display_fake_attack_hit_poison"] = {
 	mod("PoisonChance", "BASE", nil, ModFlag.Attack),
 	value = 100,
+	flag("fakeHit"),
+	skill("cannotBeEvaded", true),
+	
 },
 ["base_chance_to_ignite_%"] = {
 	mod("EnemyIgniteChance", "BASE", nil),

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1101,6 +1101,8 @@ return {
 },
 ["display_fake_attack_hit_poison"] = {
 	mod("PoisonChance", "BASE", nil, ModFlag.Attack),
+	-- TODO: handle GasShotSkeletonSniperMinion
+	--mod("MinionModifier", "LIST", { mod = mod("PoisonChance", "BASE", nil, ModFlag.Attack) }),
 	value = 100,
 	flag("fakeHit"),
 	skill("cannotBeEvaded", true),

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1013,6 +1013,9 @@ skills["GasArrowPlayer"] = {
 				projectile = true,
 				area = true,
 			},
+			baseMods = {
+				flag("fakeHit"),
+			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 18 },
 				{ "movement_speed_+%_final_while_performing_action", -70 },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4493,9 +4493,13 @@ skills["CorpseCloudPlayer"] = {
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "corpse_cloud_statset_0",
 			baseFlags = {
-				spell = true,
 				area = true,
 				duration = true,
+			},
+			baseMods = {
+				mod("PoisonChance", "BASE", 100),
+				skill("explodeCorpse", true),
+				skill("corpseExplosionDamageType", "Chaos"),
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 16 },

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -109,6 +109,7 @@ statMap = {
 #skill GasArrowPlayer
 #set GasArrowPlayer
 #flags attack projectile area
+#baseMod flag("fakeHit")
 #mods
 #set GasArrowGasDegenPlayer
 #flags attack area duration projectile

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -289,7 +289,10 @@ statMap = {
 #from item
 #skill CorpseCloudPlayer
 #set CorpseCloudPlayer
-#flags spell area duration
+#flags area duration
+#baseMod mod("PoisonChance", "BASE", 100)
+#baseMod skill("explodeCorpse", true)
+#baseMod skill("corpseExplosionDamageType", "Chaos")
 #mods
 #set CorpseCloudExplosionPlayer
 #flags spell area

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2170,6 +2170,10 @@ function calcs.offence(env, actor, activeSkill)
 		if enemyDB:Flag(nil, "CannotBlockAttacks") and isAttack then
 			output.enemyBlockChance = 0
 		end
+		
+		if skillModList:Flag(cfg, "fakeHit") then
+			output.enemyBlockChance = 0
+		end
 
 		output.HitChance = output.AccuracyHitChance * (1 - output.enemyBlockChance / 100)
 		if output.enemyBlockChance > 0 and not isAttack then
@@ -3109,9 +3113,9 @@ function calcs.offence(env, actor, activeSkill)
 			local lifeLeechTotal = 0
 			local energyShieldLeechTotal = 0
 			local manaLeechTotal = 0
-			local noLifeLeech = skillModList:Flag(cfg, "CannotLeechLife") or enemyDB:Flag(nil, "CannotLeechLifeFromSelf") or skillModList:Flag(cfg, "CannotGainLife")
-			local noEnergyShieldLeech = skillModList:Flag(cfg, "CannotLeechEnergyShield") or enemyDB:Flag(nil, "CannotLeechEnergyShieldFromSelf") or skillModList:Flag(cfg, "CannotGainEnergyShield")
-			local noManaLeech = skillModList:Flag(cfg, "CannotLeechMana") or enemyDB:Flag(nil, "CannotLeechManaFromSelf") or skillModList:Flag(cfg, "CannotGainMana")
+			local noLifeLeech = skillModList:Flag(cfg, "CannotLeechLife") or enemyDB:Flag(nil, "CannotLeechLifeFromSelf") or skillModList:Flag(cfg, "CannotGainLife") or skillModList:Flag(cfg, "fakeHit")
+			local noEnergyShieldLeech = skillModList:Flag(cfg, "CannotLeechEnergyShield") or enemyDB:Flag(nil, "CannotLeechEnergyShieldFromSelf") or skillModList:Flag(cfg, "CannotGainEnergyShield") or skillModList:Flag(cfg, "fakeHit")
+			local noManaLeech = skillModList:Flag(cfg, "CannotLeechMana") or enemyDB:Flag(nil, "CannotLeechManaFromSelf") or skillModList:Flag(cfg, "CannotGainMana") or skillModList:Flag(cfg, "fakeHit")
 			for _, damageType in ipairs(dmgTypeList) do
 				local damageTypeHitMin, damageTypeHitMax, damageTypeHitAvg, damageTypeLuckyChance, damageTypeHitAvgLucky, damageTypeHitAvgNotLucky = 0, 0, 0, 0, 0
 				if skillFlags.hit and canDeal[damageType] then
@@ -5007,6 +5011,20 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 
+	
+	-- Set hit damage to 0 for skills that only apply ailment as though they hit
+	if skillModList:Flag(cfg, "fakeHit") then
+		output.AverageHit = 0
+		output.AverageDamage = 0
+		output.TotalDPS = 0
+		output.TotalMin = 0
+		output.TotalMax = 0
+		for _, damageType in ipairs(dmgTypeList) do
+			output[damageType.."Min"] = 0
+			output[damageType.."Max"] = 0
+		end
+	end
+	
 	-- Calculate combined DPS estimate, including DoTs
 	local baseDPS = output[(skillData.showAverage and "AverageDamage") or "TotalDPS"]
 	output.CombinedDPS = baseDPS


### PR DESCRIPTION
Implements damage calculation of the poison cloud part of decompose and gas arrow and generic support for "fake hits" for other similar skills.
Fake hits cannot be evaded or blocked and have 100% hit chance as they should always apply an ailment. Their damage will be reset to 0 after ailment calculation.

There is currently a bug in decompose skill as the poison row is shown and calculated either in Cloud and Explosion section, I could not fix it
![image](https://github.com/user-attachments/assets/8df394e6-2e86-419a-a185-2e94f3d8851f)


