### PR TITLE
Add support for Bidding support gem

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2154,6 +2154,12 @@ return {
 ["minion_skill_physical_damage_%_to_convert_to_fire"] = {
 	mod("MinionModifier", "LIST", { mod = mod("SkillPhysicalDamageConvertToFire", "BASE", nil) })
 },
+["is_commandable_skill"] = {
+	flag("Condition:CommandableSkill")
+},
+["support_command_skill_damage_+%_final"] = {
+	mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil, 0, 0, {type = "Condition", var = "CommandableSkill"}) }),
+},
 --Golem
 ["golem_buff_effect_+%"] = {
 	mod("BuffEffect", "INC", nil, 0, 0)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Bidding support gem applies 30% more damage to commandable minion skills. Not sure if this is the best implementation or not. I think I'd prefer the minion commandable skills to have an actual `SkillType.CommandableSkill`, but I'm not sure if that's possible. I considered ModFlags too, but as far as I know it would have to be added manually to each skill? Which isn't great for future proofing.

Let me know if there's a preferred way. 

### Steps taken to verify a working solution:
- Checked different minions and confirmed that the MORE damage only applies to the commandable skill.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/5z7nx00m
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/6c3538d9-2e66-4cc0-8eca-d55bd8097b9d)
