### PR TITLE
Add support for Enfeeble "enemies deal less damage" mods

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -5580,6 +5580,14 @@ skills["EnfeeblePlayer"] = {
 			baseEffectiveness = 0,
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "enfeeble",
+			statMap = {
+				["enfeeble_damage_+%_final"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "Unique", neg = true }),
+				},
+				["enfeeble_damage_+%_vs_unique_final"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "Unique" }),
+				},
+			},
 			baseFlags = {
 				area = true,
 				spell = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -351,6 +351,14 @@ statMap = {
 #skill EnfeeblePlayer
 #set EnfeeblePlayer
 #flags area spell duration
+statMap = {
+	["enfeeble_damage_+%_final"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "Unique", neg = true }),
+	},
+	["enfeeble_damage_+%_vs_unique_final"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }, { type = "Condition", var = "Unique" }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1766,6 +1766,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyArmour']:SetPlaceholder(data.monsterArmourTable[defaultLevel], true)
 			build.configTab.varControls['enemyEvasion']:SetPlaceholder(data.monsterEvasionTable[defaultLevel], true)
 		elseif val == "Boss" then
+			enemyModList:NewMod("Condition:Unique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			modList:NewMod("WarcryPower", "BASE", 20, "Boss")
 			modList:NewMod("Multiplier:EnemyPower", "BASE", 20, "Boss")
@@ -1799,6 +1800,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyArmour']:SetPlaceholder(data.monsterArmourTable[defaultLevel], true)
 			build.configTab.varControls['enemyEvasion']:SetPlaceholder(data.monsterEvasionTable[defaultLevel], true)
 		elseif val == "Pinnacle" then
+			enemyModList:NewMod("Condition:Unique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("Condition:PinnacleBoss", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			modList:NewMod("WarcryPower", "BASE", 20, "Boss")
@@ -1831,6 +1833,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyArmour']:SetPlaceholder(round(data.monsterArmourTable[defaultLevel] * (data.bossStats.PinnacleArmourMean/100)), true)
 			build.configTab.varControls['enemyEvasion']:SetPlaceholder(round(data.monsterEvasionTable[defaultLevel] * (data.bossStats.PinnacleEvasionMean/100)), true)
 		elseif val == "Uber" then
+			enemyModList:NewMod("Condition:Unique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("Condition:PinnacleBoss", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 			enemyModList:NewMod("DamageTaken", "MORE", -70, "Boss")


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

I copied the similar code from a spectre from PoE1 to start. We don't check if the enemy is cursed, I guess because just having a the curse skill gem itself auto sets the "enemy is cursed" flag.

I added a separate flag to the Boss config, as "Unique". Enfeeble acts a little different in PoE2, it applies the bigger damage reduction to Normal, Magic, and Rare. And the lesser the Unique enemies. In PoE1, it applied bigger to Normal and Magic, and smaller to Rare and Unique.

### Steps taken to verify a working solution:
- Checked that the damage reduction changes according to enemy selection.


### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/vc95b008
### Before screenshot:
![image](https://github.com/user-attachments/assets/3d228b11-fff4-49ff-a97d-6a928858aec8)
### After screenshot:
Unique Boss
![image](https://github.com/user-attachments/assets/2fd50f00-1067-4c74-916b-c544a0292a76)
Set to "no"
![image](https://github.com/user-attachments/assets/4998e3b2-4000-4bf8-aede-ab1b26fc56c2)


