### PR TITLE
Add support for Blasphemy less curse effect

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -885,6 +885,11 @@ skills["SupportBlasphemyPlayer"] = {
 			label = "Curses",
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_blasphemy_curse_effect_+%_final"] = {
+					mod("CurseEffect", "MORE", nil, 0, 0),
+				},
+			},
 			baseFlags = {
 				area = true,
 			},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -69,6 +69,11 @@ statMap = {
 #skill SupportBlasphemyPlayer
 #set SupportBlasphemyPlayer
 #flags area
+statMap = {
+	["support_blasphemy_curse_effect_+%_final"] = {
+		mod("CurseEffect", "MORE", nil, 0, 0),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Curse skills attached to Blasphemy should have less curse effect. 

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/9t9al00w
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/17ef004a-7b05-4608-85d6-3bed8e348d85)
