### PR TITLE
Fix "Exploit Weakness" Support not applying for "ArmourFullyBroken"

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -709,7 +709,7 @@ skills["SupportExploitWeaknessPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_gem_consume_enemy_fully_broken_armour_to_gain_damage_+%_final"] = {
-					mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "ArmourBroken"})
+					mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "ArmourFullyBroken"})
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -178,7 +178,7 @@ statMap = {
 #set SupportExploitWeaknessPlayer
 statMap = {
 	["support_gem_consume_enemy_fully_broken_armour_to_gain_damage_+%_final"] = {
-		mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "ArmourBroken"})
+		mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "ArmourFullyBroken"})
 	},
 },
 #mods


### PR DESCRIPTION
Fixes #731 .

### Description of the problem being solved:
- Original PR forgot to change "ArmourBroken" to "ArmourFullyBroken" in the statMap for "Exploit Weakness" support in `sup_str.txt` . Now it's fixed and works again.

### Steps taken to verify a working solution:
- Check Config for "Is enemy Armour broken?" is set correctly (no manual value)
- Exploit Weakness support damage bonus applies correctly

### After screenshot:
![image](https://github.com/user-attachments/assets/f8e26312-2b6e-4714-81cb-45723147d7cf)

_note: the 51.7% is a result of rounding due to the tiny damage values. modifier is correctly applied as "50% More"_