### PR TITLE
Fix warcry speed scaled by cast speed instead of warcry speed

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2320,7 +2320,12 @@ function calcs.offence(env, actor, activeSkill)
 				skillModList:NewMod("Multiplier:TraumaStacks", "BASE", skillModList:Sum("BASE", skillCfg, "Multiplier:SustainableTraumaStacks"), "Maximum Sustainable Trauma Stacks")
 			end
 			local inc = skillModList:Sum("INC", cfg, "Speed")
-			output.Speed = 1 / (baseTime / round((1 + inc/100) * more, 2) + skillModList:Sum("BASE", cfg, "TotalAttackTime") + skillModList:Sum("BASE", cfg, "TotalCastTime"))
+			if skillFlags.warcry then
+				output.Speed = 1 / output.WarcryCastTime
+			else
+				output.Speed = 1 / (baseTime / round((1 + inc/100) * more, 2) + skillModList:Sum("BASE", cfg, "TotalAttackTime") + skillModList:Sum("BASE", cfg, "TotalCastTime"))
+		
+			end
 			output.CastRate = output.Speed
 			if skillFlags.selfCast then
 				-- Self-cast skill; apply action speed


### PR DESCRIPTION
Fixes #531  .

### Description of the problem being solved:
The cast time for warcries seem to be correct in the Tree tab (deriving from output.WarcryCastTime), but the dps is derived from generic speed that is related to cast speed

### Steps taken to verify a working solution:
select cast speed or warcry speed in test build tree and now dps only scale with warcry speed
IMPORTANT: "99999% increased warcry cooldown recovery rate" is necessary otherwise the long cooldown will "hide" the dps change related to cast/warcry speed

### Link to a build that showcases this PR:
[test build](eNqlW1932rgSf-5-Ch_OuW80YBsM7CF7TwJJk27-sJC2u089whagW9lmbZmEfvo7I9nGUGRs0ofWWPObkUYzo5mRO_zvm8-NDY1iFgaXDfOi3TBo4IYeC5aXjS8vtx_7jf_-8dtwQsTqeXGdMI4j1h-_fRjKHwanG8ovG1a3YbicxPET8ell4xuJIhZGDYPELg280d7IPAIWFAYFiZZUfM2Et7-bwGRFIuIKGj0g46tEhI-hBzgRJbRh-IQFs9D9QcWnKEzWMOGGsWH0VdHcP06epy8NmNyH4YSTLY1mgggjhr8uG1ewSLKkd0wAhPAE6M2Bc9FttErpr5MoFmPiw2M13GxNqbcjvbAdS0sLynCj7YjE4oX5O_7tC7vbMztWX_3t6OCTiN4sFtQVbENHEROjFQncAhsdri7tY8IFW3OGe5bSWzr6u19Ym20t85dQED6ezHZsnd5Fzzb1GlOIUJye-DcmVtcc9qIWf0TdLwMmaG3YJGRxGJy1miJIvxMJ5-A4lWinNKbRhgi2PyE979Cfs6CmrkZhyL3wNSjYbdu2tf4UUfK8UPY6JR5L4kcqIhrn6I7epx5JQEZhXPDc9qCMdkIjCDtiD9I-AZhRN4RItSel07_oliigIOo4A63MB7ag1SlrLScF1J3Neeu4mVWlq834vAlNIU5Xo5yFCa9IKXZxzzS7ep_7t0hptbWUY_qWk_V0RPeBOE00ppsQnfz0ImSoubmb7NytZ10M-qbV73Tbjt3XnjGrbcxcwh_JG_MTH8L7C_lBdwId09Sb1XIlAghZOmzH1h5ttyyiZ8BGEJHOga1IGJ-1wgWtQgc5gfs7Et8Hbk7fL-P6JYhkCC-kEifmMQUvwZRlzmlVyE5I6mxVzmwla0mDVOC2Wnx5oNRdfYL0bUoErRaUC3G4U6pZJC5qtpTrEc2W8N9H1FATAo-rqXvRLwPVVNRszSJWaUaK8tjyq2NqKOAmoNFyO1sxyr0K8b5AnWlsRNZV1g8GUERXMoR9cbWMuQituVd4ONWVtiFxMb6bbatcE4q-mjdQSI8B4NGqxcAkCv-H5QavB7uK_DCJKu6lIq60gOxsUuXZlHqJW-0wzKumaw7FZNVl5CiYJ-e1oFdCEPfHOPSWlZUmhdRC7M9vlqzX4LZoDVUZ4KELlQMrJEUfOxWon8GWKzkrHs_VBeyoKwvIU47qUg4g1deCOcOBmCrElQXk2_kIscKHqCs7C49hIXBrtwZKxUp1nySsWH9OwleY-Qp7NnE9asiscoC2PryNaPBzW5n_HnklATeBl0ToCJVlHCKOiblOFovYcKF-JuIBtvey0TDm8C57dpMopukPhcBWDwfHHBNBDC9N4L-SiJFAWLKjFVMSuSsE3RLO5xA5kNPuLf46AJqZNQxbsi-HT_f-OoyEQd_wnwmJxPaysSA8popQvgE-sWCB7BRAmOK8YcxW4euVt8F1v0CFH2cgg6zXNPD2eLxElBokCzouTkKuEX8YPokFHHLKjmOcdKEbeO9hE8kIQpgA5ER9a9BtQkni2E2r33U6TduG2qRp93vtXtPudiynaZldp9-0Bj3HajptswuPTgdB7UGvaQ4GnaZlOabT7DpIYduD_qDpdEyzh2_adtOEV71mx3GsftPs9voWSOrbg2an79hms2OibBDRM5umBUI7g57dAe4DHOyZvW6za_Yts2kPbAfmZVs2PPbMdtM0rQ5w7DjdDm4S1qok2l7tLzVgoFkB2jrodmbjSm8fhl-mD_Lhw0qIdfx7q_X6-nqxJmIVLugbnLsXYGmtNYBA4x_jH4zzj8i1dQV_rpc3o_vnZzv5PNjwz-5P5n_-8tfddHRrD37-nC-61_31P9-eLGf1-Lfjeeb3p9tv1uex5bt_0sHAudlMXtwb0f_8Kfm5-XP-12DJ58_zO7Z5fX7pAPfLSznBVjbDoerDxi31C8NaxGAz1fSHcOJFbJ4Img2Apb09qd1uGCwQ-XMsoqdfrUDtitqzVMNyz1LNS4tQG1LYM2kWasuUtahNlHuT2ZLcM2UF0l4a6QJaeysYttCEpT-hjePDUyjUGL7MfgxnuAexEYOLfaJ-fL2FWHqLueFBUy11EqSeUaHcvIjJOtweXZCE4_u_EsIZ-my7-PZB9duDMPLzohxYgc_iga84vmzXqM6rh4fUG1OpBitYmnwpG-pXu6mNCHdjOTkWuDzxoGBNz5LUhDmZo3i8JMBK0ys25gt8cjEfhjCflPgTD-eEWxkkuzloN_bGzWx8oyIbeseMsthn7ggzZmn0-y9V4G4Y_xY0tqQ-Ej1SQTwItK17AZpuobpbcobwVOQaED-NYOlbQ74-WKUbJoHIz100EmSV2kuqZGkzyirwUWpUUtwH60RIQZcNn8Xudzwm8OJCuoC8b7m5vb0Zvdx_vUmPiiJErvt7kPhzXKr6d5cCzKhMfY04mcfq8bLxldFXOZExKIHxGOfPOVnHNA_i0iLSmXPAlXCTVHcsvws5zmtHoOd080YjOHOW8vaDUe288vETk1ICsaBStyjHueGlgZ6RStDxJkaVchpNybsdPRe8LNEuBwdLsHBaE66VnI6e0IRAxwcrZgvmYh5TvuUYJhRViV5cSGCIuy3Z77S60POQtzA6BmpQD1a3Kjp0OlqiVXmXo9WqGtXDx9Ql2rWrQT047w6Egbx1PM4lpyrh9BQG0sjBaa4Yx1pAu7M3nOYkeobPYkWjNDHTcXqEGJWRlDqOOue1fAoUJbqSnVSNhnBMD1WtQs0acKzEadLmmc7bWbnL7re4NPtRpNGzUrWhVodpnVmyDWmLRbMFarRkJVmbSbOIdLjEUWQMvtqEzFO9Bo3LHJCVBQ1IL9_PRjZQ3s_msKPyfo63kPn_0O53OqqHfxEMU50jXFSmUokJOtb7OKB_vY8Dltb-2ejpYSqyw07Lk5C8CXAUnI2W-X7aGzibg-pgnA2XDZaz0fIAGNMFhRWUngA5TYlziCQYgzJEiWNUZCWndTyK7FZXi5c6C4-utDZH5d3p7WBZAFAkJxjBYX5Xki5W45Q3Ce8o4fgNSsjfx_CXW9D3MMN7jmRNAi9j93wsSd_tQ0XthSIGnrLPNcbrlPfqMKD-9ggj_byGrayskx0wLLTS9txMQFHmQhlhxOo7sJ9h6P8DdZpt4217Z2Ba5qDXVe_TWt5spwU85OJjBhsaSUPMJoCUf182-j3zoteDvwfdtmOqLwKGsqpNewv4nLcW9OySmKoPKr5Rsg4DicDSXhWcioeWaL-DwENhQP7sT-Zfpg_YFFCVKtTxG3Q1HMIavJ2VyzqAEmKYNSDyZKiFuPITTkUNgDyZDPsYQna-7j0glw1MHJT9xgz6mb5SbqSviqwriayvB6u-sutArikXZ2ynMXvFe45K6pPt1331pa9qqG8KIbXewkJva2Spc20NatdXNj2ztgXWWdAdheNO1NJAKH511WErDQQy1skgI3tZYbBgyzTcqB9pwJGg_M1elCj2sNwkFqH_GHrxruc1wD__wX5jRAnEXeNVfhQLgVh9XWhE6WW5EZGsVpd3NS5dAQWNUt4Uo3j68W3WHeu12ycAe7d4GewUKL8yzHpheTeubVmnBBa-vc1g3ROY4r1sjjm5MnhzxvxQ1hkweZTtEP2Ont7PvybGr2bhdPJmsveGvdUZ5YuC3G6FNdZWTL57E0xvMphdFVV_I9DEDlXayT5g1cLykjzXaZlSZysIqlKP8S_N4VJbxO8nIKD9CKCwPcRbp5a2_wFGPT-AN1U3YOaGMrWqt7r0qxDI56YkKM6ud2pZ2YmQS7L6gxJMzJaMPy9kQQaTlFVlnS041J7druCjVXU3WmFz_7jqII3NQrZKauWvP34btn757x7_B9CoHB0=
)
