### PR TITLE
fix Weapon comparison with Giant's Blood

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -712,14 +712,21 @@ function calcs.initEnv(build, mode, override, specEnv)
 	if not accelerate.requirementsItems then
 		local items = {}
 		local jewelLimits = {}
+		local giantsBlood = true
+		if build.calcsTab and build.calcsTab.mainEnv then
+			giantsBlood = build.calcsTab.mainEnv.modDB:Flag(nil, "GiantsBlood")
+		end
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
 			local item
 			if slotName == override.repSlotName then
 				item = override.repItem
 			elseif override.repItem and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") and
-			(override.repItem.base.type == "Staff" or override.repItem.base.type == "Two Handed Sword" or override.repItem.base.type == "Two Handed Axe" or override.repItem.base.type == "Two Handed Mace"
-			or (override.repItem.base.type == "Bow" and item and item.base.type ~= "Quiver")) then
+			(
+				override.repItem.base.type == "Staff"
+				or (not giantsBlood and (override.repItem.base.type == "Two Handed Sword" or override.repItem.base.type == "Two Handed Axe" or override.repItem.base.type == "Two Handed Mace"))
+				or (override.repItem.base.type == "Bow" and item and item.base.type ~= "Quiver")
+			) then
 				goto continue
 			elseif slot.nodeId and override.spec then
 				item = build.itemsTab.items[env.spec.jewels[slot.nodeId]]


### PR DESCRIPTION
Fixes #807  .

### Description of the problem being solved:
In PoB, mousing over a different weapon than the one that is equipped will show a stat comparison that seems to assume that the new weapon will replace the current weapon and unequip the shield.

### Test build
https://pobb.in/ospAQfkM35dt

### Before screenshot:
![image](https://github.com/user-attachments/assets/73fe4f0f-7063-4521-bf6f-e032ad62e3f2)

### After screenshot:
![image](https://github.com/user-attachments/assets/fc72291a-007c-4867-9887-0ae2b5983952)

