### PR TITLE
Add support for Berserk Gem

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -881,7 +881,7 @@ skills["BerserkPlayer"] = {
 					div = 60
 				},
 				["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
-					mod("PhysicalDamageLifeLeech", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+					mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
 					div = 100,
 				},
 				["rage_effect_+%"] = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -875,6 +875,19 @@ skills["BerserkPlayer"] = {
 			label = "Berserk",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "berserk",
+			statMap = {
+				["life_loss_%_per_minute_per_rage_while_not_losing_rage"] = {
+					mod("LifeDegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+					div = 60
+				},
+				["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
+					mod("PhysicalDamageLifeLeech", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+					div = 100,
+				},
+				["rage_effect_+%"] = {
+					mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+				}
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -53,7 +53,7 @@ statMap = {
 		div = 60
 	},
 	["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
-		mod("PhysicalDamageLifeLeech", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+		mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
 		div = 100,
 	},
 	["rage_effect_+%"] = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -47,6 +47,19 @@ local skills, mod, flag, skill = ...
 #skill BerserkPlayer
 #set BerserkPlayer
 #flags
+statMap = {
+	["life_loss_%_per_minute_per_rage_while_not_losing_rage"] = {
+		mod("LifeDegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+		div = 60
+	},
+	["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
+		mod("PhysicalDamageLifeLeech", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
+		div = 100,
+	},
+	["rage_effect_+%"] = {
+		mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+	}
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Berserk gem was not implemented in, this solves that.

One small issue that I'm not sure on, which would also apply to PoB1. Rage effect doesn't seem to apply when the config is only 1 Rage. Not sure if it's intended, but I thought 0.2 leech would become 0.3 with 50% increased rage effect? When it's set to 2 Rage, it correctly shows 0.6 leech. Then 3 Rage is 0.8, then 4 Rage is 1.2. So I guess the effect is "additive" where it needs 100% total effect to add another stack of the mod, if that makes sense. Is this how it should function? Same applies for the life degen. Apologies if I didn't explain it well enough.

### Steps taken to verify a working solution:
- Copied the code from PoB1 for the life regen mod. Which is related to [Rite of Ruin](https://www.poewiki.net/wiki/Rite_of_Ruin). The life regen scales from Rage Effect.
- As the regen scales from effect, I assume the life leech should also scale, and that's how I implemented it.
- Rage effect increases properly, quality increases effect as well.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/35ep600u

### After screenshot:
This is with 10 Rage set on the build I linked.
![image](https://github.com/user-attachments/assets/e92054ca-b1da-4c0a-b34f-034a3bc04872)
![image](https://github.com/user-attachments/assets/638668ea-42a5-4293-9316-9d6978bf3f03)
