### PR TITLE
Add support for Discipline

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4937,7 +4937,15 @@ skills["DisciplinePlayer"] = {
 			label = "Discipline",
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "discipline",
+			statMap = {
+				["discipline_grant_allies_total_maximum_energy_shield_+"] = {
+					mod("EnergyShield", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+				},
+			},
 			baseFlags = {
+			},
+			baseMods = {
+				skill("auraCannotAffectSelf", true),
 			},
 			constantStats = {
 				{ "skill_desired_amount_override", 1 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -318,6 +318,12 @@ statMap = {
 #skill DisciplinePlayer
 #set DisciplinePlayer
 #flags
+statMap = {
+	["discipline_grant_allies_total_maximum_energy_shield_+"] = {
+		mod("EnergyShield", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+	},
+},
+#baseMod skill("auraCannotAffectSelf", true)
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Copied the code for Discipline from a spectre. And applied a baseMod so that it doesn't affect the player, same as the Purity Auras on sceptres.
### Steps taken to verify a working solution:
- Checked that ES is only gained by minions, and not the player.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/lteug0d5
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/cbd36b53-c6b3-459d-b13d-fcdec1f22a64)
