### PR TITLE
Add support for Skeletal Warrior gem quality

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2075,6 +2075,9 @@ return {
 ["minion_ailment_damage_+%"] = {
 	mod("MinionModifier", "LIST", { mod = mod("Damage", "INC", nil, 0, KeywordFlag.Ailment) }),
 },
+["minion_block_%"] = {
+	mod("MinionModifier", "LIST", { mod = mod("BlockChance", "BASE", nil, 0, 0) }),
+},
 ["base_number_of_zombies_allowed"] = {
 	mod("ActiveZombieLimit", "BASE", nil),
 },


### PR DESCRIPTION
### Description of the problem being solved:
Skelatal Warrior gem has +15% block chance at 20% quality. I added the stat to SkillStatMap as it seems generic and will possibly be used by other gems later on.
### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/r8i630d9
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/c6f17bef-979b-4c9c-92f7-6298639d90db)
