### PR TITLE
Add support for Sigil of Power

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -13768,6 +13768,14 @@ skills["SigilOfPowerPlayer"] = {
 			incrementalEffectiveness = 0.14000000059605,
 			damageIncrementalEffectiveness = 0.0065000001341105,
 			statDescriptionScope = "circle_of_power",
+			statMap = {
+				["circle_of_power_max_stages"] = {
+					mod("Multiplier:SigilOfPowerMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }),
+				},
+				["circle_of_power_spell_damage_+%_final_per_stage"] = {
+					mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "SigilOfPowerStage", limitVar = "SigilOfPowerMaxStages" } ),
+				},
+			},
 			baseFlags = {
 				spell = true,
 				area = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -843,6 +843,14 @@ statMap = {
 #skill SigilOfPowerPlayer
 #set SigilOfPowerPlayer
 #flags spell area duration
+statMap = {
+	["circle_of_power_max_stages"] = {
+		mod("Multiplier:SigilOfPowerMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }),
+	},
+	["circle_of_power_spell_damage_+%_final_per_stage"] = {
+		mod("Damage", "MORE", nil, ModFlag.Spell, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "SigilOfPowerStage", limitVar = "SigilOfPowerMaxStages" } ),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Sigil of Power works differently than in PoE1. In PoE2, it applies more spell damage per stage, up to 4x.
### Steps taken to verify a working solution:
- Made sure the damage only applies to spells by adding a melee skill to the build.
- Went above 4 stages in the Config, properly ignores anything over 4.
### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/rit600w8
### After screenshot:
![image](https://github.com/user-attachments/assets/91fcab40-a740-4c5d-8079-a7760f154047)
![image](https://github.com/user-attachments/assets/deda2b52-82cf-48d2-ad76-b33ce071fe86)
