### PR TITLE
Fix Morior Invictus Spirit not applying with Lead me Through Grace

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -923,7 +923,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				local srcList = item.modList or (item.slotModList and item.slotModList[slot.slotNum]) or {}
 
 				-- Remove Spirit Base if CannotGainSpiritFromEquipment flag is true
-				if nodesModsList:Flag(nil, "CannotGainSpiritFromEquipment") then
+				if nodesModsList:Flag(nil, "CannotGainSpiritFromEquipment") and item.name ~= "Morior Invictus, Grand Regalia" then
 					srcList = copyTable(srcList, true)
 					for index = #srcList, 1, -1 do
 						local mod = srcList[index]


### PR DESCRIPTION
Fixes #828

EDIT: Closed for now, likely is a bug in the end. Will keep an eye for a patch to confirm.

### Description of the problem being solved:
Morior Invictus '+10 to Spirit per Socketed Rune or Soul Core' applies in game even with Invoker 'Lead me Through Grace' node taken. It could be intentional, similar to "when on full life" mods in PoE1 not counting as life modifiers.
### Steps taken to verify a working solution:
- This is probably an okay way to do it, when we check for the 'CannotGainSpiritFromEquipment' flag, we can just add `and item.name ~= "Morior Invictus, Grand Regalia"`. This way the spirit mod bypasses the removal. I tried adding the mod to 'data.itemTagSpecialExclusionPattern', but I guess there isn't spirit tag yet? I see none in 'ModItemExclusive.lua', not sure if I'm right on that but seeing other mods tagged with things like "chaos", "physical", etc made me come to this conclusion. Let me know if I'm looking in the wrong place.

### Link to Build
https://maxroll.gg/poe2/pob/v12ff0em
### Before screenshot:
![image](https://github.com/user-attachments/assets/8d956c72-bbd4-4778-94fa-9574ac898255)

### After screenshot:
![image](https://github.com/user-attachments/assets/dcf93ca5-fab9-4941-a87a-7e7478cca154)
