### PR TITLE
Add support for Soul Core stat requirement conversion

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -215,4 +215,28 @@ describe("TestItemParse", function()
 		assert.are.equals(1, #item.explicitModLines)
 		assert.are.equals("+50% chance to Ignite", item.explicitModLines[1].line)
 	end)
+
+	it("attribute coverted", function()
+		local item = new("Item", [[
+			Test Item
+			Expert Barrier Quarterstaff
+			Quality: 20
+			Sockets: S S S
+			Rune: Soul Core of Cholotl
+			Rune: Soul Core of Zantipi
+			Rune: Soul Core of Atmohua
+			LevelReq: 79
+			Implicits: 4
+			{enchant}{rune}Convert 20% of Requirements to Dexterity
+			{enchant}{rune}Convert 20% of Requirements to Intelligence
+			{enchant}{rune}Convert 20% of Requirements to Strength
+			{tags:block}{range:1}+(10-15)% to Block chance
+			Corrupted
+			]])
+		item:BuildAndParseRaw()
+		assert.are.equals(45, item.requirements.strMod)
+		assert.are.equals(111, item.requirements.dexMod)
+		assert.are.equals(71, item.requirements.intMod)	
+		
+	end)
 end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1587,13 +1587,12 @@ function ItemClass:BuildModList()
 		local strConversion = calcLocal(baseList, "AttributeRequirementsConvertedToStrength", "BASE", 0) / 100  
 		local dexConversion = calcLocal(baseList, "AttributeRequirementsConvertedToDexterity", "BASE", 0) / 100 
 		local intConversion = calcLocal(baseList, "AttributeRequirementsConvertedToIntelligence", "BASE", 0) / 100 
-		self.requirements.intBase = intConversion * (self.requirements.str + self.requirements.dex) + (self.requirements.int + calcLocal(baseList, "IntRequirement", "BASE", 0)) + (-1 * (strConversion * self.requirements.int)) + (-1 * (dexConversion * self.requirements.int))
-		self.requirements.intMod = m_floor((self.requirements.intBase) * (1 + calcLocal(baseList, "IntRequirement", "INC", 0) / 100))
-		self.requirements.dexBase = dexConversion * (self.requirements.str + self.requirements.int) + (self.requirements.dex + calcLocal(baseList, "DexRequirement", "BASE", 0)) + (-1 * (strConversion * self.requirements.dex)) + (-1 * (intConversion * self.requirements.dex))
+		self.requirements.intBase = intConversion * (self.requirements.str + self.requirements.dex) + (self.requirements.int + calcLocal(baseList, "IntRequirement", "BASE", 0)) - self.requirements.int * (strConversion + dexConversion)
+		self.requirements.intMod = m_floor(self.requirements.intBase * (1 + calcLocal(baseList, "IntRequirement", "INC", 0) / 100))
+		self.requirements.dexBase = dexConversion * (self.requirements.str + self.requirements.int) + (self.requirements.dex + calcLocal(baseList, "DexRequirement", "BASE", 0)) - self.requirements.dex * (strConversion + intConversion)
 		self.requirements.dexMod = m_floor( self.requirements.dexBase * (1 + calcLocal(baseList, "DexRequirement", "INC", 0) / 100))
-		self.requirements.strBase = strConversion * (self.requirements.int + self.requirements.dex) + (self.requirements.str + calcLocal(baseList, "StrRequirement", "BASE", 0)) + (-1 * (dexConversion * self.requirements.str)) + (-1 * (intConversion * self.requirements.str))
+		self.requirements.strBase = strConversion * (self.requirements.int + self.requirements.dex) + (self.requirements.str + calcLocal(baseList, "StrRequirement", "BASE", 0)) - self.requirements.str * (dexConversion + intConversion)
 		self.requirements.strMod = m_floor(self.requirements.strBase * (1 + calcLocal(baseList, "StrRequirement", "INC", 0) / 100))
-		
 	else
 		self.requirements.strMod = m_floor((self.requirements.str + calcLocal(baseList, "StrRequirement", "BASE", 0)) * (1 + calcLocal(baseList, "StrRequirement", "INC", 0) / 100))
 		self.requirements.dexMod = m_floor((self.requirements.dex + calcLocal(baseList, "DexRequirement", "BASE", 0)) * (1 + calcLocal(baseList, "DexRequirement", "INC", 0) / 100))

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -793,7 +793,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					end)
 					if strippedModeLine == runeStrippedModeLine then
 						modLine.soulcore = name:match("Soul Core") ~= nil
-						modLine.runeCount = round(value/runeValue, 0)
+						modLine.runeCount = round(value/runeValue)
 						if shouldFixRunesOnItem then
 							for i = 1, modLine.runeCount do
 								t_insert(self.runes, name)
@@ -1533,7 +1533,7 @@ function ItemClass:BuildModList()
 				self.classRestriction = modLine.line:gsub("{variant:([%d,]+)}", ""):match("Requires Class (.+)")
 			end
 			-- handle understood modifier variable properties
-			if not (modLine.extra) then
+			if not modLine.extra then
 				if modLine.range then
 					-- Check if line actually has a range
 					if modLine.line:find("%((%-?%d+%.?%d*)%-(%-?%d+%.?%d*)%)") then
@@ -1556,10 +1556,7 @@ function ItemClass:BuildModList()
 				if modLine.modTags and #modLine.modTags > 0 then
 					self.hasModTags = true
 				end
-			else
-				
 			end
-
 		end
 	end
 	for _, modLine in ipairs(self.enchantModLines) do

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -793,7 +793,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					end)
 					if strippedModeLine == runeStrippedModeLine then
 						modLine.soulcore = name:match("Soul Core") ~= nil
-						modLine.runeCount = round(value/runeValue)
+						modLine.runeCount = round(value/runeValue, 0)
 						if shouldFixRunesOnItem then
 							for i = 1, modLine.runeCount do
 								t_insert(self.runes, name)
@@ -1533,7 +1533,7 @@ function ItemClass:BuildModList()
 				self.classRestriction = modLine.line:gsub("{variant:([%d,]+)}", ""):match("Requires Class (.+)")
 			end
 			-- handle understood modifier variable properties
-			if not modLine.extra then
+			if not (modLine.extra) then
 				if modLine.range then
 					-- Check if line actually has a range
 					if modLine.line:find("%((%-?%d+%.?%d*)%-(%-?%d+%.?%d*)%)") then
@@ -1556,7 +1556,10 @@ function ItemClass:BuildModList()
 				if modLine.modTags and #modLine.modTags > 0 then
 					self.hasModTags = true
 				end
+			else
+				
 			end
+
 		end
 	end
 	for _, modLine in ipairs(self.enchantModLines) do
@@ -1583,6 +1586,17 @@ function ItemClass:BuildModList()
 		self.requirements.strMod = 0
 		self.requirements.dexMod = 0
 		self.requirements.intMod = 0
+	elseif calcLocal(baseList, "AttributeRequirementsConverted", "FLAG", 0) then
+		local strConversion = calcLocal(baseList, "AttributeRequirementsConvertedToStrength", "BASE", 0) / 100  
+		local dexConversion = calcLocal(baseList, "AttributeRequirementsConvertedToDexterity", "BASE", 0) / 100 
+		local intConversion = calcLocal(baseList, "AttributeRequirementsConvertedToIntelligence", "BASE", 0) / 100 
+		self.requirements.intBase = intConversion * (self.requirements.str + self.requirements.dex) + (self.requirements.int + calcLocal(baseList, "IntRequirement", "BASE", 0)) + (-1 * (strConversion * self.requirements.int)) + (-1 * (dexConversion * self.requirements.int))
+		self.requirements.intMod = m_floor((self.requirements.intBase) * (1 + calcLocal(baseList, "IntRequirement", "INC", 0) / 100))
+		self.requirements.dexBase = dexConversion * (self.requirements.str + self.requirements.int) + (self.requirements.dex + calcLocal(baseList, "DexRequirement", "BASE", 0)) + (-1 * (strConversion * self.requirements.dex)) + (-1 * (intConversion * self.requirements.dex))
+		self.requirements.dexMod = m_floor( self.requirements.dexBase * (1 + calcLocal(baseList, "DexRequirement", "INC", 0) / 100))
+		self.requirements.strBase = strConversion * (self.requirements.int + self.requirements.dex) + (self.requirements.str + calcLocal(baseList, "StrRequirement", "BASE", 0)) + (-1 * (dexConversion * self.requirements.str)) + (-1 * (intConversion * self.requirements.str))
+		self.requirements.strMod = m_floor(self.requirements.strBase * (1 + calcLocal(baseList, "StrRequirement", "INC", 0) / 100))
+		
 	else
 		self.requirements.strMod = m_floor((self.requirements.str + calcLocal(baseList, "StrRequirement", "BASE", 0)) * (1 + calcLocal(baseList, "StrRequirement", "INC", 0) / 100))
 		self.requirements.dexMod = m_floor((self.requirements.dex + calcLocal(baseList, "DexRequirement", "BASE", 0)) * (1 + calcLocal(baseList, "DexRequirement", "INC", 0) / 100))

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -126,7 +126,7 @@ local formList = {
 	["^are "] = "FLAG",
 	["^gain "] = "FLAG",
 	["^you gain "] = "FLAG",
-	["is (%-?%d+)%%? "] = "OVERRIDE",
+	["is (%-?%d+)%%? "] = "OVERRIDE"
 }
 
 -- Map of modifier names
@@ -3168,6 +3168,10 @@ local specialModList = {
 	} end,
 	["exsanguinate debuffs deal fire damage per second instead of physical damage per second"] = { flag("Condition:ExsanguinateDebuffIsFireDamage", { type = "SkillName", skillName = "Exsanguinate", includeTransfigured = true })},
 	["reap debuffs deal fire damage per second instead of physical damage per second"] = { flag("Condition:ReapDebuffIsFireDamage", { type = "SkillName", skillName = "Reap" })},
+	["convert (%d+)%% of requirements to (%a+)"] = function(_, num, attr) 	return {
+			flag("AttributeRequirementsConverted"),
+			mod("AttributeRequirementsConvertedTo" .. attr:gsub("^%l", string.upper), "BASE", num),
+		} end,
 	-- Crit
 	["your critical hit chance is lucky"] = { flag("CritChanceLucky") },
 	["your critical hit chance is lucky while on low life"] = { flag("CritChanceLucky", { type = "Condition", var = "LowLife" }) },
@@ -5321,7 +5325,7 @@ local specialModList = {
 	} end,
 	["physical damage reduction from armour is based on your combined armour and evasion rating"] = { mod("EvasionAddsToPdr", "FLAG", true) }
 }
-for _, name in pairs(data.keystones) do
+	for _, name in pairs(data.keystones) do
 	specialModList[name:lower()] = { mod("Keystone", "LIST", name) }
 end
 local oldList = specialModList

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -126,7 +126,7 @@ local formList = {
 	["^are "] = "FLAG",
 	["^gain "] = "FLAG",
 	["^you gain "] = "FLAG",
-	["is (%-?%d+)%%? "] = "OVERRIDE"
+	["is (%-?%d+)%%? "] = "OVERRIDE",
 }
 
 -- Map of modifier names
@@ -5325,7 +5325,7 @@ local specialModList = {
 	} end,
 	["physical damage reduction from armour is based on your combined armour and evasion rating"] = { mod("EvasionAddsToPdr", "FLAG", true) }
 }
-	for _, name in pairs(data.keystones) do
+for _, name in pairs(data.keystones) do
 	specialModList[name:lower()] = { mod("Keystone", "LIST", name) }
 end
 local oldList = specialModList

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3168,10 +3168,10 @@ local specialModList = {
 	} end,
 	["exsanguinate debuffs deal fire damage per second instead of physical damage per second"] = { flag("Condition:ExsanguinateDebuffIsFireDamage", { type = "SkillName", skillName = "Exsanguinate", includeTransfigured = true })},
 	["reap debuffs deal fire damage per second instead of physical damage per second"] = { flag("Condition:ReapDebuffIsFireDamage", { type = "SkillName", skillName = "Reap" })},
-	["convert (%d+)%% of requirements to (%a+)"] = function(_, num, attr) 	return {
-			flag("AttributeRequirementsConverted"),
-			mod("AttributeRequirementsConvertedTo" .. attr:gsub("^%l", string.upper), "BASE", num),
-		} end,
+	["convert (%d+)%% of requirements to (%a+)"] = function(_, num, attr) return {
+		flag("AttributeRequirementsConverted"),
+		mod("AttributeRequirementsConvertedTo" .. attr:gsub("^%l", string.upper), "BASE", num),
+	} end,
 	-- Crit
 	["your critical hit chance is lucky"] = { flag("CritChanceLucky") },
 	["your critical hit chance is lucky while on low life"] = { flag("CritChanceLucky", { type = "Condition", var = "LowLife" }) },


### PR DESCRIPTION
Fixes #153 .

### Description of the problem being solved:
Rune: Soul Core of Cholotl
Rune: Soul Core of Zantipi
Rune: Soul Core of Atmohua
do not properly redistribute stats on gear.

Created mod in special mod list and updated logic in Classes/Item.lua to process flag and apply convert calcuations to base.

### Steps taken to verify a working solution:
-Added custom item on Expert Barrier Quarterstaff base with all three runes and matched values to in-game calculation
-Added custom item on Expert Tribal Mask base with one rune + reduced Attribute Requirements and matched values to in-game calcs
-Matched Attribute Requirement calculations to items equipped
-Test case added to TestItemParse_spec.lua

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/lt5vh0et
### Before screenshot:
![Screenshot 2025-03-05 101344](https://github.com/user-attachments/assets/8ad56fb7-8d1e-44ef-8cb1-4f2a083fd5be)
![Screenshot 2025-03-05 103528](https://github.com/user-attachments/assets/e570ae52-d111-49a4-b194-df7648a1ee66)
![Screenshot 2025-03-05 104137](https://github.com/user-attachments/assets/44da20bf-5ce5-40ab-a657-99196ae1485c)
### After screenshot:
![Screenshot 2025-03-05 101455](https://github.com/user-attachments/assets/b2d11232-8647-4c1d-a3e0-1f90c97fe2a4)
![Screenshot 2025-03-05 103620](https://github.com/user-attachments/assets/d151c85f-e362-4c82-b6a0-d9dcdd529e22)
![Screenshot 2025-03-05 104231](https://github.com/user-attachments/assets/fc6d3631-1bb5-48bd-bd02-b177d7f13e1b)

In-game Calcuations for items
![Screenshot 2025-02-21 105930](https://github.com/user-attachments/assets/c7c705a1-8512-4bf7-b340-7f1f079aae95)
