### PR TITLE
Add support for Ice Crystal life

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1368,7 +1368,7 @@ c["200% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC
 c["200% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=200}},nil}
 c["200% increased Critical Hit Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="INC",value=200}},nil}
 c["200% increased Evasion and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EvasionAndEnergyShield",type="INC",value=200}},nil}
-c["200% increased Ice Crystal Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="INC",value=200}}," Ice Crystal  "}
+c["200% increased Ice Crystal Life"]={{[1]={flags=0,keywordFlags=0,name="IceCrystalLife",type="INC",value=200}},nil}
 c["200% increased Stun Recovery"]={{[1]={flags=0,keywordFlags=0,name="StunRecovery",type="INC",value=200}},nil}
 c["200% increased bonuses gained from Equipped Quiver"]={{[1]={flags=0,keywordFlags=0,name="EffectOfBonusesFromQuiver",type="INC",value=200}},nil}
 c["22.5 Life Regeneration per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=22.5}},nil}
@@ -2108,7 +2108,7 @@ c["60% increased Stun Threshold for each time you've been Stunned Recently"]={{[
 c["60% increased bonuses gained from Equipped Rings"]={{[1]={flags=0,keywordFlags=0,name="EffectOfBonusesFromRings",type="INC",value=60}},nil}
 c["60% increased maximum Energy Shield"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=60}},nil}
 c["60% reduced Bleeding Duration on you"]={{[1]={flags=0,keywordFlags=0,name="SelfBleedDuration",type="INC",value=-60}},nil}
-c["60% reduced Ice Crystal Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="INC",value=-60}}," Ice Crystal  "}
+c["60% reduced Ice Crystal Life"]={{[1]={flags=0,keywordFlags=0,name="IceCrystalLife",type="INC",value=-60}},nil}
 c["65% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC",value=65}},nil}
 c["65% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=65}},nil}
 c["65% increased Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=65}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2276,6 +2276,10 @@ return {
 ["support_grenade_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),
 },
+-- Ice Crystal
+["frost_wall_maximum_life"] = {
+	mod("IceCrystalLifeBase", "BASE", nil),
+},
 -- Other
 ["triggered_skill_damage_+%"] = {
 	mod("TriggeredDamage", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.Triggered }),

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8324,6 +8324,11 @@ skills["FrozenLocusPlayer"] = {
 			label = "Crystal",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "ice_ambush_statset_0",
+			statMap = {
+				["frozen_locus_crystal_display_stat"] = {
+					-- Display Only
+				},
+			},
 			baseFlags = {
 				duration = true,
 			},

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1930,6 +1930,11 @@ skills["SupportIciclePlayer"] = {
 			label = "Icicle",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_icicle_ice_crystal_maximum_life_+%_final"] = {
+					mod("IceCrystalLife", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1739,6 +1739,11 @@ skills["SupportGlacierPlayer"] = {
 			label = "Glacier",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_glacier_ice_crystal_maximum_life_+%_final"] = {
+					mod("IceCrystalLife", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -534,6 +534,11 @@ statMap = {
 #skill FrozenLocusPlayer
 #set FrozenLocusPlayer
 #flags duration
+statMap = {
+	["frozen_locus_crystal_display_stat"] = {
+		-- Display Only
+	},
+},
 #mods
 #set FrozenLocusGroundPlayer
 #flags area duration

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -457,6 +457,11 @@ statMap = {
 
 #skill SupportIciclePlayer
 #set SupportIciclePlayer
+statMap = {
+	["support_icicle_ice_crystal_maximum_life_+%_final"] = {
+		mod("IceCrystalLife", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -413,6 +413,11 @@ statMap = {
 
 #skill SupportGlacierPlayer
 #set SupportGlacierPlayer
+statMap = {
+	["support_glacier_ice_crystal_maximum_life_+%_final"] = {
+		mod("IceCrystalLife", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1192,6 +1192,14 @@ function calcs.offence(env, actor, activeSkill)
 			breakdown.LinkEffectMod = breakdown.mod(skillModList, skillCfg, "LinkEffect", "BuffEffect")
 		end
 	end
+	if activeSkill.skillTypes[SkillType.IceCrystal] then
+		local IceCrystalLifeMod = calcLib.mod(skillModList, skillCfg, "IceCrystalLife")
+		local baseIceCrystal = skillModList:Sum("BASE", skillCfg, "IceCrystalLifeBase")
+		output.IceCrystalLife = baseIceCrystal * IceCrystalLifeMod
+		if breakdown then
+			breakdown.IceCrystalLife = breakdown.mod(skillModList, skillCfg, "IceCrystalLife")
+		end
+	end
 	if (skillFlags.trap or skillFlags.mine) and not (skillData.trapCooldown or skillData.cooldown) then
 		skillFlags.notAverage = true
 		skillFlags.showAverage = false

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1197,7 +1197,12 @@ function calcs.offence(env, actor, activeSkill)
 		local baseIceCrystal = skillModList:Sum("BASE", skillCfg, "IceCrystalLifeBase")
 		output.IceCrystalLife = baseIceCrystal * IceCrystalLifeMod
 		if breakdown then
-			breakdown.IceCrystalLife = breakdown.mod(skillModList, skillCfg, "IceCrystalLife")
+			breakdown.IceCrystalLife = {
+				s_format("%.f ^8(Base Crystal Life)", baseIceCrystal),
+				s_format("x %.2f ^8(effect modifiers)", IceCrystalLifeMod),
+				s_format("\n"),
+				s_format("= %.f ^8(Ice Crystal Life)", output.IceCrystalLife),
+			}
 		end
 	end
 	if (skillFlags.trap or skillFlags.mine) and not (skillData.trapCooldown or skillData.cooldown) then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -701,6 +701,10 @@ return {
 		{ breakdown = "EnemyCurseLimit" },
 		{ modName = { "CurseLimitIsMaximumPowerCharges", "EnemyCurseLimit" } },
 	}, },
+	{ label = "Ice Crystal Life", { format = "{0:output:IceCrystalLife}",
+		{ breakdown = "IceCrystalLife" },
+		{ modName = { "IceCrystalLife" }, cfg = "skill" }
+	},},
 	{ label = "Mark Effect Mod", haveOutput = "MarkEffectMod", { format = "x {2:output:MarkEffectMod}",
 		{ breakdown = "MarkEffectMod" },
 		{ modName = "MarkEffect", cfg = "skill" },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -604,6 +604,7 @@ local modNameList = {
 	["to deal double damage"] = "DoubleDamageChance",
 	["to deal triple damage"] = "TripleDamageChance",
 	["curse activation"] = "CurseFrequency",
+	["ice crystal life"] = "IceCrystalLife",
 	-- Effects
 	["onslaught effect"] = "OnslaughtEffect",
 	["effect of onslaught on you"] = "OnslaughtEffect",


### PR DESCRIPTION
### Description of the problem being solved:
A small number of skills have Ice Crystals, and two nodes on the tree affect crystal life. I tried to copy the Perfect Timing section, as I think showing the modifier values in the breakdown is cleaner than having a separate breakdown only for the effect modifiers, considering Ice Crystals aren't exactly the most important thing.

Also the description for Frozen Locus has a buggy Chilled Ground section. It's missing level scaling. So the displayed Ice Crystal Life shows 43 life at level 1, and 1 life at anything above. Related to that, Ice Nova Cast on Frostbolt has a similar problem. No level scaling, so the spell min and max damage shows 1-1 at anything above level 1.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/ku3l10ii
### After screenshot:
![image](https://github.com/user-attachments/assets/481caa59-181d-470b-86a1-a4644823fd8a)
