### PR TITLE
Add Base Attack Damage for Stomping Ground support

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1939,6 +1939,14 @@ skills["SupportStompingGroundPlayer"] = {
 			label = "Shockwave",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "stomping_ground_shockwave",
+			statMap = {
+				["attack_minimum_added_physical_damage_as_%_of_strength"] = {
+					skill("PhysicalMin", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
+				},
+				["attack_maximum_added_physical_damage_as_%_of_strength"] = {
+					skill("PhysicalMax", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1948,6 +1948,8 @@ skills["SupportStompingGroundPlayer"] = {
 				},
 			},
 			baseFlags = {
+				attack = true,
+				area = true,
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 18 },

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -484,6 +484,7 @@ statMap = {
 #skillEnd
 #skill StompingGroundShockwavePlayer
 #set StompingGroundShockwavePlayer
+#flags attack area
 statMap = {
 	["attack_minimum_added_physical_damage_as_%_of_strength"] = {
 		skill("PhysicalMin", nil, { type = "PercentStat", stat = "Str", percent = 1 }),

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -484,6 +484,14 @@ statMap = {
 #skillEnd
 #skill StompingGroundShockwavePlayer
 #set StompingGroundShockwavePlayer
+statMap = {
+	["attack_minimum_added_physical_damage_as_%_of_strength"] = {
+		skill("PhysicalMin", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
+	},
+	["attack_maximum_added_physical_damage_as_%_of_strength"] = {
+		skill("PhysicalMax", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
The Shockwave on Stomping Ground had no base Phys damage. It does 80% to 120% of players strength as phys damage. The DPS calc itself is probably off as it says it triggers "when you take a step". Not touching that at the moment. Not sure how we would get a proper calculation.
### Steps taken to verify a working solution:
- Base Phys changes according to Player strength. With 192 Strength 
- 192*0.8 = 153.6, rounded to 154 min
- 192*1.2 = 230.4 , rounded to 231 max.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/x69f50ze
### After screenshot:
![image](https://github.com/user-attachments/assets/c025b7b9-b60b-4bc9-9831-62a5b9131f05)
![image](https://github.com/user-attachments/assets/2692a611-16be-487c-a0de-9d2878d82c70)
