### PR TITLE
Add support for Minion Revival Time

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2915,11 +2915,11 @@ c["Meta Skills gain 35% more Energy"]={nil,"Meta Skills gain 35% more Energy "}
 c["Meta Skills gain 8% increased Energy"]={nil,"Meta Skills gain 8% increased Energy "}
 c["Minions Recoup 10% of Damage taken as Life"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="LifeRecoup",type="BASE",value=10}}}},nil}
 c["Minions Regenerate 3% of Life per second"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=3}}}},nil}
-c["Minions Revive 15% faster"]={nil,"Revive 15% faster "}
-c["Minions Revive 15% faster You gain 2% Life when one of your Minions is Revived"]={nil,"Revive 15% faster You gain 2% Life when one of your Minions is Revived "}
-c["Minions Revive 25% faster"]={nil,"Revive 25% faster "}
-c["Minions Revive 5% faster"]={nil,"Revive 5% faster "}
-c["Minions Revive 50% faster"]={nil,"Revive 50% faster "}
+c["Minions Revive 13% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-13}},nil}
+c["Minions Revive 15% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-15}},nil}
+c["Minions Revive 25% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-25}},nil}
+c["Minions Revive 5% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-5}},nil}
+c["Minions Revive 50% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-50}},nil}
 c["Minions deal (25-35)% increased Damage"]={nil,"(25-35)% increased Damage "}
 c["Minions deal (8-13)% increased Damage"]={nil,"(8-13)% increased Damage "}
 c["Minions deal 10% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=10}}}},nil}

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -13306,6 +13306,12 @@ skills["SacrificePlayer"] = {
 			label = "Sacrifice",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "harvester",
+			statMap = {
+				["harvester_minion_resummon_speed_+%_final"] = {
+					mod("MinionRevivalTime", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+					mult = -1,
+				},
+			},
 			baseFlags = {
 				minion = true,
 			},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -839,6 +839,12 @@ statMap = {
 #skill SacrificePlayer
 #set SacrificePlayer
 #flags minion
+statMap = {
+	["harvester_minion_resummon_speed_+%_final"] = {
+		mod("MinionRevivalTime", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+		mult = -1,
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1165,6 +1165,19 @@ function calcs.offence(env, actor, activeSkill)
 			}
 		end
 	end
+	if activeSkill.skillTypes[SkillType.CreatesSkeletonMinion] then
+		local minionRevivalTimeMod = calcLib.mod(skillModList, skillCfg, "MinionRevivalTime")
+		local baseMinionRevivalTime = data.misc.MinionRevivalTimeBase
+		output.MinionRevivalTime = baseMinionRevivalTime * minionRevivalTimeMod
+		if breakdown then
+			breakdown.MinionRevivalTime = {
+				s_format("%.3fs ^8(Base Revival Time)", baseMinionRevivalTime),
+				s_format("x %.2f ^8(effect modifiers)", minionRevivalTimeMod),
+				s_format("\n"),
+				s_format("= %.3fs ^8(Total Revival Time)", output.MinionRevivalTime),
+			}
+		end
+	end
 	if activeSkill.skillTypes[SkillType.Warcry] then
 		local full_duration = calcSkillDuration(skillModList, skillCfg, activeSkill.skillData, env, enemyDB)
 		local cooldownOverride = skillModList:Override(skillCfg, "CooldownRecovery")

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -627,6 +627,7 @@ return {
 	{ label = "Armour Break / hit", haveOutput = "ArmourBreakPerHit", { format = "{0:output:ArmourBreakPerHit}", { modName = "ArmourBreakPerHit", modType = "BASE"} }, },
 	{ label = "Soul Cost", color = colorCodes.RAGE, haveOutput = "SoulHasCost", { format = "{0:output:SoulCost}", { breakdown = "SoulCost" }, { modName = { "SoulCost" }, cfg = "skill" }, }, },
 	{ label = "Active Minion Limit", haveOutput = "ActiveMinionLimit", { format = "{0:output:ActiveMinionLimit}" } },
+	{ label = "Minion Revival Time", haveOutput = "MinionRevivalTime", { format = "{2:output:MinionRevivalTime}", { breakdown = "MinionRevivalTime" }, { modName = { "MinionRevivalTime" } } },},
 	{ label = "Quantity Multiplier", haveOutput = "QuantityMultiplier", { format = "{0:output:QuantityMultiplier}",
 	    { breakdown = "QuantityMultiplier" },
 	    { modName = { "QuantityMultiplier" }, cfg = "skill" },

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -184,6 +184,7 @@ data.misc = { -- magic numbers
 	TrapTriggerRadiusBase = 10,
 	MineDetonationRadiusBase = 60,
 	MineAuraRadiusBase = 35,
+	MinionRevivalTimeBase = 8,
 	BrandAttachmentRangeBase = 30,
 	ProjectileDistanceCap = 150,
 	MinStunChanceNeeded = 20,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3953,6 +3953,7 @@ local specialModList = {
 	["totems gain %+(%d+)%% to (%w+) resistance"] = function(num, _, resistance) return { mod("Totem"..firstToUpper(resistance).."Resist", "BASE", num) } end,
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
 	-- Minions
+	["minions revive (%d+)%% faster"] = function(num) return { mod("MinionRevivalTime", "INC", -num) } end,
 	["your strength is added to your minions"] = { flag("StrengthAddedToMinions") },
 	["your dexterity is added to your minions"] = { flag("DexterityAddedToMinions") },
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },


### PR DESCRIPTION
### Description of the problem being solved:
Persistent skeletal minions have a base revival time of 8 seconds. A few uniques affect this, as well as 4 tree nodes, and one Buff gem (Sacrifice).
### Steps taken to verify a working solution:
- Revival Time is listed under Skill-type specific stats. It only shows on the gem itself, it does not show when toggling "Show Minion Stats". I think that is fine, it's not a super important stat so keeping it on the gem keeps the minion breakdown uncluttered.
- Zombies do not have a revival time. They are duration based.
- SRS does not have revival time. Also duration based.
- Sacrifice uses a MORE multiplier to the revival time. Quality correctly reduces revive time by 5% at 20 quality, while gem itself increases the timer.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/6p9hk0z8
### After screenshot:
![image](https://github.com/user-attachments/assets/0557571c-3d5e-424e-8db0-0031260545ee)
