### PR TITLE
Rerun Node search when switching class

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -495,8 +495,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	end
 
 	-- Update cached node data
-	if self.searchStrCached ~= self.searchStr then
+	if self.searchStrCached ~= self.searchStr or self.searchNeedsForceUpdate == true then
 		self.searchStrCached = self.searchStr
+		self.searchNeedsForceUpdate = false
 
 		local function prepSearch(search)
 			search = search:lower()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -229,12 +229,14 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 				self.spec:AddUndoState()
 				self.spec:SetWindowTitleWithBuildClass()
 				self.buildFlag = true
+				self.treeTab.viewer.searchNeedsForceUpdate = true
 			else
 				main:OpenConfirmPopup("Class Change", "Changing class to "..value.label.." will reset your passive tree.\nThis can be avoided by connecting one of the "..value.label.." starting nodes to your tree.", "Continue", function()
 					self.spec:SelectClass(value.classId)
 					self.spec:AddUndoState()
 					self.spec:SetWindowTitleWithBuildClass()
-					self.buildFlag = true					
+					self.buildFlag = true
+					self.treeTab.viewer.searchNeedsForceUpdate = true
 				end)
 			end
 		end


### PR DESCRIPTION
Fixes #849 

### Description of the problem being solved:
PoE2 has different starting trees for each class. Currently just Witch changes the tree, but eventually the other classes (ones not released yet) will too. If the search bar was looking for "minion" as a Sorceress, and the class was switched to Witch, the nodes by the start would not get highlighted. Somewhat minor of an issue as you could backspace one letter to refresh the search, but worth fixing so that it is automated I think.

### After screenshot:
Minion nodes that otherwise would not be highlighted upon switching classes.
![image](https://github.com/user-attachments/assets/180771f9-d044-459a-88ea-17f718cbe007)
