### PR TITLE
Add support for "Rupture The Soul" (Lich Ascendancy Notable)

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2005,6 +2005,9 @@ local specialModList = {
 	["cursed enemies you or your minions kill have a (%d+)%% chance to explode, dealing a (.+) of their maximum life as (.+) damage"] = function(chance, _, amount, type)	-- Profane Bloom
 		return explodeFunc(chance, amount, type, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
 	end,
+	["cursed enemies killed by you or allies in your presence have a (%d+)%% chance to explode, dealing a (.+) of their maximum life as (.+) damage"] = function(chance, _, amount, type)	-- Rupture The Soul (Lich Ascendancy)
+		return explodeFunc(chance, amount, type, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
+	end,
 	["enemies you kill explode, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- legacy synth, legacy crusader
 		return explodeFunc(100, amount, type)
 	end,


### PR DESCRIPTION
### Description of the problem being solved:
- Add support for "Rupture The Soul" (Lich Ascendancy Notable)
    - Cursed Enemies Killed by you or Allies in your Presence have a 33% chance to Explode, dealing a quarter of their maximum Life as Chaos Damage

### After screenshot:
![image](https://github.com/user-attachments/assets/1d7a5774-79fb-41d3-af3a-410d907aa3ac)
