### PR TITLE
Add support for "Price Of Power" (Lich Ascendancy Notable)

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2738,6 +2738,8 @@ local specialModList = {
 	["cannot be slowed to below base speed"] = { mod("MinimumActionSpeed", "MAX", 100, { type = "GlobalEffect", effectType = "Global", unscalable = true }) },
 	["gain accuracy rating equal to your strength"] = { mod("Accuracy", "BASE", 1, { type = "PerStat", stat = "Str" }) },
 	["gain accuracy rating equal to twice your strength"] = { mod("Accuracy", "BASE", 2, { type = "PerStat", stat = "Str" }) },
+	-- Lich
+	["non%-channelling spells consume power charges to deal (%d+)%% more damage"] = function(num) return { mod("Damage", "MORE", num, nil, 0,KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel, neg = true }, { type = "MultiplierThreshold", var = "RemovablePowerCharge", threshold = 1 })} end,
 	-- Mercenary
 	-- +2 Weapon Set Passive Skill Points
 	["%+(%d) weapon set passive skill points"] = function(num) return { mod("WeaponSetPassivePoints", "BASE", num) } end,


### PR DESCRIPTION
### Description of the problem being solved:
- Add support for "Price Of Power" (Lich Ascendancy Notable)
    - Non-channelling Spells consume Power Charges to deal 25% more Damage

### Notes:
- Might want to introduce some kind of "charge sustain" logic in the future, but that goes too far for now I think

### Steps taken to verify a working solution:
- Mod parsed correctly
- Damage bonus is limited to non-channeling spells
- Requires minimum 1 "removable" Power Charge

### After screenshot:
![image](https://github.com/user-attachments/assets/1afa03a9-095b-40dd-9451-1d51390e72c4)

![image](https://github.com/user-attachments/assets/c526bf6e-c793-400d-b390-df89d95b102a)
