### PR TITLE
Toggle Attribute Nodes with Right Click

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ Files in /Data /Export and /TreeData can be massive and cause the emmyLua langua
 ### PyCharm Community / IntelliJ Idea Community
 
 1. Create a new "Debug Configuration" of type "Emmy Debugger(NEW)".
-2. Select "x86" version.
+2. Select "x64" version
 3. Select if you want the program to block (checkbox) until you attached the debugger (useful if you have to debug the startup process).
 4. Copy the generated code snippet directly below `function launch:OnInit()` in `./src/Launch.lua`.
 5. Start Path of Building Community

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -317,6 +317,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				if hotkeyPressed then
 					processAttributeHotkeys(hoverNode.isAttribute)
 				elseif hoverNode.isAttribute then
+					-- If the attribute node is already set to str, int, or dex create a toggle effect between attrs
+					if hoverNode.dn == "Intelligence" then
+						spec.attributeIndex = 1
+					elseif hoverNode.dn == "Dexterity" then
+						spec.attributeIndex = 3
+					elseif hoverNode.dn == "Strength" then
+						spec.attributeIndex = 2
+					end
 					spec:SwitchAttributeNode(hoverNode.id, spec.attributeIndex or 1)
 				end
 				spec:AllocNode(hoverNode, self.tracePath and hoverNode == self.tracePath[#self.tracePath] and self.tracePath)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -790,7 +790,9 @@ function TreeTabClass:ModifyAttributePopup(hoverNode)
 	controls.hotkeyTooltip = new("LabelControl", nil, {0, 100, 0, 16}, 
 		"^8You can switch attributes quicker by holding hotkeys while allocating:\n"..colorCodes.INTELLIGENCE.."\"1\" or \"I\" for Intelligence, "
 		..colorCodes.STRENGTH.."\"2\" or \"S\" for Strength, "..colorCodes.DEXTERITY.."\"3\" or \"D\" for Dexterity\n\n"
-		..colorCodes.RARE.."Right-click ^8an attribute node to instantly allocate with your last used attribute")
+		..colorCodes.RARE.."Right-click ^8an allocated node to toggle attribute types or to set an\n" .. 
+		"unallocated node to your last used attribute\n\n"
+	)
 	main:OpenPopup(550, 185, "Choose Attribute", controls, "save")
 end
 


### PR DESCRIPTION
The goal here was to make it easy to toggle set attribute nodes between the attributes with just a mouse click. If an attribute node is unset, then it will use the last used attribute to set it. If it's already set, it will toggle between attributes. This keeps state with the spec.attributeIndex so it behaves the same as using a hotkey to set the attribute.

- Fix contributions notes saying to use the x86 to x64 for debugging in JetBrains products
- enable a toggle-like effect when right-clicking an attribute node
- update modal dialogue's message to described the new right-click behavior
