### PR TITLE
Add support for Siege Cascade dmg vs immobilised enemy

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2455,4 +2455,7 @@ return {
 ["quality_display_banner_buff_effect_+%_final_per_resource_is_gem"] = {
 	-- Display Only
 },
+["quality_display_siege_cascade_damage_+%_final_vs_immobilised_enemies_is_gem"] = {
+	-- Display Only
+},
 }

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -8319,6 +8319,11 @@ skills["SiegeCascadePlayer"] = {
 			label = "Impact",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "siege_cascade_piercing",
+			statMap = {
+				["siege_cascade_damage_+%_final_vs_immobilised_enemies"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Immobilised" }),
+				},
+			},
 			baseFlags = {
 				attack = true,
 				projectile = true,
@@ -8394,6 +8399,11 @@ skills["SiegeCascadePlayer"] = {
 			label = "Explosion",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "siege_cascade_piercing",
+			statMap = {
+				["siege_cascade_damage_+%_final_vs_immobilised_enemies"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Immobilised" }),
+				},
+			},
 			baseFlags = {
 				attack = true,
 				projectile = true,

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -473,9 +473,19 @@ statMap = {
 #skill SiegeCascadePlayer
 #set SiegeCascadePlayer
 #flags attack projectile area
+statMap = {
+	["siege_cascade_damage_+%_final_vs_immobilised_enemies"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Immobilised" }),
+	},
+},
 #mods
 #set SiegeCascadeExplodePlayer
 #flags attack projectile area
+statMap = {
+	["siege_cascade_damage_+%_final_vs_immobilised_enemies"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Immobilised" }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -702,7 +702,7 @@ return {
 		{ breakdown = "EnemyCurseLimit" },
 		{ modName = { "CurseLimitIsMaximumPowerCharges", "EnemyCurseLimit" } },
 	}, },
-	{ label = "Ice Crystal Life", { format = "{0:output:IceCrystalLife}",
+	{ label = "Ice Crystal Life", haveOutput = "IceCrystalLife", { format = "{0:output:IceCrystalLife}",
 		{ breakdown = "IceCrystalLife" },
 		{ modName = { "IceCrystalLife" }, cfg = "skill" }
 	},},


### PR DESCRIPTION
### Description of the problem being solved:
Siege cascade does 50% MORE damage against immobilised enemies. Both impact and explosion get this damage boost.

I also added haveoutput to Ice Crystal Life in the Skill specific tab. It was showing for all skills again, I made an oopsie and was showing it for all for testing and didn't change it back.

### After screenshot:
![image](https://github.com/user-attachments/assets/24b084b1-2002-460c-8fda-642942a7ab67)
