### PR TITLE
Fix Items tab search error

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1094,14 +1094,10 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 				self:Redo()
 				self.build.buildFlag = true
 			elseif event.key == "f" and IsKeyDown("CTRL") then
-				local selUnique = self.selControl == self.controls.uniqueDB.controls.search
-				local selRare = self.selControl == self.controls.rareDB.controls.search
-				if selUnique or (self.controls.selectDB:IsShown() and not selRare and self.controls.selectDB.selIndex == 2) then
+				if self.selectedDB == "RARE" then
 					self:SelectControl(self.controls.rareDB.controls.search)
-					self.controls.selectDB.selIndex = 2
 				else
 					self:SelectControl(self.controls.uniqueDB.controls.search)
-					self.controls.selectDB.selIndex = 1
 				end
 			elseif event.key == "d" and IsKeyDown("CTRL") then
 				self.showStatDifferences = not self.showStatDifferences


### PR DESCRIPTION
### Description of the problem being solved:
When I changed the drop down in the rare templates to 2 buttons, I broke the CTRL+F search function for the Items tab.
This gets rid of the error. On 1080p where only one box shows as a time, it will properly select the search box. However on higher res (hard to test myself) it will always jump to the unique section. Not necessarily a problem, but it would be nice to have it jump to the search of the last selected Item List. That is if we have enough rare templates at some point that searching might be useful.