### PR TITLE
pinned enemies cant evade

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2181,7 +2181,7 @@ function calcs.offence(env, actor, activeSkill)
 				}
 			end
 		end
-		if not isAttack or skillModList:Flag(cfg, "CannotBeEvaded") or skillData.cannotBeEvaded or (env.mode_effective and enemyDB:Flag(nil, "CannotEvade")) or enemyDB:Flag(nil, "Condition:Pinned") then
+		if not isAttack or skillModList:Flag(cfg, "CannotBeEvaded") or skillData.cannotBeEvaded or (env.mode_effective and enemyDB:Flag(nil, "CannotEvade")) then
 			output.AccuracyHitChance = 100
 		else
 			local enemyEvasion = m_max(round(calcLib.val(enemyDB, "Evasion")), 0)
@@ -3251,6 +3251,10 @@ function calcs.offence(env, actor, activeSkill)
 								resist = m_min(m_max(-data.misc.NegArmourDmgBonusCap, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction), data.misc.DamageReductionCap)
 								resist = resist > 0 and resist * (1 - (skillModList:Sum("BASE", nil, "PartialIgnoreEnemyPhysicalDamageReduction") / 100 + ChanceToIgnoreEnemyPhysicalDamageReduction / 100)) or resist
 							end
+							if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
+								takenInc = takenInc + 20
+							end
+							
 						else
 							resist = calcResistForType(damageType, cfg)
 							if ((skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") or skillModList:Flag(cfg, "ChaosDamageUsesHighestResistance")) and damageType == "Chaos") or
@@ -4186,6 +4190,7 @@ function calcs.offence(env, actor, activeSkill)
 					if skillModList:Flag(cfg, ailment .. "ToChaos") then
 						local resist = calcResistForType("Chaos", dotCfg)
 						local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
+						
 						local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", "ChaosDamageTaken", "ChaosDamageTakenOverTime")
 						effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
 						globalOutput[ailment .. "EffMult"] = effMult

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2181,7 +2181,7 @@ function calcs.offence(env, actor, activeSkill)
 				}
 			end
 		end
-		if not isAttack or skillModList:Flag(cfg, "CannotBeEvaded") or skillData.cannotBeEvaded or (env.mode_effective and enemyDB:Flag(nil, "CannotEvade")) then
+		if not isAttack or skillModList:Flag(cfg, "CannotBeEvaded") or skillData.cannotBeEvaded or (env.mode_effective and enemyDB:Flag(nil, "CannotEvade")) or enemyDB:Flag(nil, "Condition:Pinned") then
 			output.AccuracyHitChance = 100
 		else
 			local enemyEvasion = m_max(round(calcLib.val(enemyDB, "Evasion")), 0)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Pinned targets can no longer Evade.

### Steps taken to verify a working solution:
- tested by running the client

### Link to a build that showcases this PR:
N/A

### Before screenshot:
![image](https://github.com/user-attachments/assets/9e4f832e-2746-41bf-aa23-72febe8a2a98)

### After screenshot:
![image](https://github.com/user-attachments/assets/5d0b9c10-22b4-41f5-85dd-1c62ebf2c84c)
![image](https://github.com/user-attachments/assets/5fa97109-674c-4e98-abaf-522d40263416)
