### PR TITLE
Add Damage Buff for fully broken enemy armour

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3251,9 +3251,6 @@ function calcs.offence(env, actor, activeSkill)
 								resist = m_min(m_max(-data.misc.NegArmourDmgBonusCap, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction), data.misc.DamageReductionCap)
 								resist = resist > 0 and resist * (1 - (skillModList:Sum("BASE", nil, "PartialIgnoreEnemyPhysicalDamageReduction") / 100 + ChanceToIgnoreEnemyPhysicalDamageReduction / 100)) or resist
 							end
-							if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
-								takenInc = takenInc + 20
-							end
 						else
 							resist = calcResistForType(damageType, cfg)
 							if ((skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") or skillModList:Flag(cfg, "ChaosDamageUsesHighestResistance")) and damageType == "Chaos") or

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3251,6 +3251,9 @@ function calcs.offence(env, actor, activeSkill)
 								resist = m_min(m_max(-data.misc.NegArmourDmgBonusCap, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction), data.misc.DamageReductionCap)
 								resist = resist > 0 and resist * (1 - (skillModList:Sum("BASE", nil, "PartialIgnoreEnemyPhysicalDamageReduction") / 100 + ChanceToIgnoreEnemyPhysicalDamageReduction / 100)) or resist
 							end
+							if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
+								takenInc = takenInc + 20
+							end
 						else
 							resist = calcResistForType(damageType, cfg)
 							if ((skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") or skillModList:Flag(cfg, "ChaosDamageUsesHighestResistance")) and damageType == "Chaos") or

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -499,6 +499,9 @@ local function doActorMisc(env, actor)
 			local effect = 5 * (100 + modDB:Sum("INC", nil, "WitherEffectOnSelf")) / 100 * modDB:More(nil, "WitherEffectOnSelf")
 			modDB:NewMod("ChaosDamageTaken", "INC", effect, "Withered", { type = "Multiplier", var = "WitheredStack", limit = 10 } )
 		end
+		if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
+			enemyDB:NewMod("PhysicalDamageTaken", "INC", 20, "Fully Broken Armour")
+		end
 		if modDB:Flag(nil, "Blind") and not modDB:Flag(nil, "CannotBeBlinded") then
 			if not modDB:Flag(nil, "IgnoreBlindHitChance") then
 				local effect = 1 + modDB:Sum("INC", nil, "BlindEffect", "BuffEffectOnSelf") / 100


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Fully Broken Armour now causes enemies to take 20% increased Physical Damage from Hits

### Steps taken to verify a working solution:
- attempted with normal mace, sunder skill
- checked that other elemental skill unaffected (frost bomb)

### Link to a build that showcases this PR:

> eNrVW1tz2zoOfm5-hcbvjS-JcxunZxzbaTITN147aXefOoxE29xQog9FOfH59QuQutk1ZSp52s6kkUR8AAEQIAEpvb_eQ-6tqYyZiK4b7eNWw6ORLwIWLa4bz0-3Xy8af3076k2IWj7ObxLGcaTz7ehLT994nK4pB2DD8zmJ4x8kpNeNKYkWVDY8Evs0CgbFwA8R0YaniFxQ9TMT2vqN6CWRxFdUPiDDfqLEWASAUDIBREhYNBP-K1XfpUhWWt6a0TdDcz-ePE6fGjCpL70JJxsqZ4ooL4b_rht9UI4s6JCE8D-gCE8A0ukcdzon3U6jWYm6SWSsakJnK0qDnLp1fHp-0c1_LmyoiaSj-Zz6iq3pQDI1WJLIL4R2bbg9tK3jsyrqccIVW3GGDkoRJzb6uz-Yt616PwlF-HAyK0hhIifdVvv8ooM_1TihivkfoiwLsRIPEs5hqTrRTmlM5ZooWI5uvEX4wiIa9NcL9xUlKXmcGx9PScCSeEyVpHHJbZc27JhEZCDiwkSdbhXphEqIO7WFaB0AzKgvIFTLkHb7-PLs5Cz9OXeQuJ-PVfQDm1N3ylpapYC6s_mYHqOZK11txh-b0BTylRvlTCTckVIV-eLcHkh_l-k69mwxpO_FQrOu5vtIOQkt03VaXbvQtcAgd0w1o7tJkYBbxyfts7Pzi5PL7umlNcFOlpuY-YSPyTsLkxDy5xN5pYXAs659-S2WKoKMZYOeWoXeMknrowaCBx9ALYmI62s3hg38jkRB3_cT2Oc3hVftziLyNaJx7Jq-aeCOwFh3mDVs5f4V0t5H_uGtGAmfI5lOxsnlczqFsMazxgunjohCRJocShtuq1rUgkapvI2bjR4o9ZffwXcgCrzttpsUq-ii0rBIWzZsJdM9hrWz3wbUMBMC95upXb071zbUbMUkc5qTodyjfw1MDROMIioXm9mSUR447FAl6sxmA7Jy0R9WQBnttBK2xdVazmVobW_hhlpX3prE5a3m5IApDLlbPFBOKQACunvyt1cX4r9YW_B6sL4MRSIdnWmInRTIdklTWU1pkPhu23JeIt1wqAZd1chRME_Oa0H7ShH_dSiChbPRtJBaiO35zZLVCuIWV4MrAzwAwCbISue4r6cO1I-wlJ2iFc8K7gIKamcB-enHXcoOxF0XPMHsiHEhdhaQu3MMqSKEtKs7AmNRytxW10DR6lSBakLHSngi3mDmS2y6xPWo4Zx3uEdwK2n0z8aZ_xa5k4BRFMCZEQLBWcYuYp-Ym2Q-jz0fKnmiHsC9142G9wLPsms4p8bU3NxKqJC8GyBNsU8shBQcx0OiiBekRcVPIhmJVEc3p2JKpL9E-C3h_AVyCPIsnuo73dC6ZVxROYRnOGFUapdjO1swvabuueHVfbgSUnn0HX9NiFSb68ac8JgaQv0E-MSKRbqtAZmM84Y3W4q3frBGSU9C8DgDeWS1olGwxeNJUuqRLC_5OAmtPN54IYlh1huz1GPUptTruw-0GpGACWDldNq9RN2xfiVy098mjBjMS4GsnX5gwQilfuk9Tx_0xZelUqv4qtl8e3s7XhG1FHP6DhvbMbiyuQIQzPdr_Mo4_4pcm334d7Po63-aUTPj1DMdxbhp7jC-JYMpGzE9SP2SvSSKZgNgz_cfRqeGxyKVX8dKZtcpr-YWs14TbaYdiEbFix9CmTF8mN30ZjjtGBaGVN9pGN9sIL5v8cBStJx0xKdeQeoZVWbBlTFZ2zSgc5JwfP6vhHCGi6RVfvpgmreRkGFesgIrWCS4CRmOT5sVatZ_eEjdn0r1WJAtifSh7tL2i6kNCPdjPTkW-TwJoIpK81u-7Dh5wQlgzxkroKDc7y1xygV96cGMdJDDDO4jcEi6gAz-OxcvhHcyLmlvurs93M6G1ya8cJHNEuAFBx29booHJrE0vL9L1lvQEAnGVJEAwr95r8DqTTR9U88VrjJuEQnT0Mme7KjpiyRK3VdSKbUb6pUtJ835_8DUndZhW-tsqpNpYe782QctXuJZGL2Utj9v-PQSSHUcm0jFSw3SFPfRKlFa_nUjZLH_G7cTfEOhM4R-oTK6vR0Nnu5_jtKNpAzRxvgdJeGLXjv6d3FUmFF9RPbi5CU2l9eNn4y-6YkMwTSMx6gX52QV0zyT6yhNZ84BV8FNU0E1lL3u2M-rILBzGr1TCRvP4hfsdpJR67zy8QOTMgKx7sKN18YNXyHYGZmD_AC2rSlRVh7m3Y2dC74_saqDgxVY2LIJt0pORw9YQmEyhsXN5szH8061yzF1G6oKu-QNOau_0yrEzuOG6zde-xmYQTt4IliMpd9-dDpaYdVFxOz-TEft8CH1iVV3M2gH520EEekuwn4uOVUFpx8i0oscgqbPONYMVs-OOM1J7Awf1ZLK9HRm4zSGHJWRVAaOOQZZ-ZQoKmylO64WC-GYHWp6ihYdcKwiaNIumy3aWXXIbvfCLP4o09hZmRrSasO0Hq1wQ9qKsbjAjFZoknWjLEqkwxWBonNwfy1YYHoSlpDZIatKGnD6_jwb3Wj5PJvdzsvnOd5CAfNq9Xc6aoc_K4YHoD1czAnGiQkG1uc4YHx9jgOW4OGH0dPdo0iBnVYfQvJmwV5wNloV-2kP4cMcTKfjw3DdiPkwWm8AQzqnoEHlDpDTVASHSqIhGENVBIYjKz2t_Vmk0K4WL7MX7tW0NkcT3ek7zaoEYEgOMILN_K7iuOjGKW8m3lHC1XIiBP8cwz_e3X6GGb4OSVYkCjJ2j_sO6YUfHK0nVAw8dbNriG9dPmvDiIabPYzs8-o1s7JOt8Gw0EqbdzMlsYj-R4jwP7o6xau0j3KS9k7gyD1k4Dep11smBwn_nTUte7qITRs5eJ33cewMkpiaj0B-UbISkUYYW5haEriUmzJTKLnV5sqb9qejIzg1YpgQ7rXvvDHx6dHofQVVmncj2QJsbZ4NJJkrGlx5KPBoIumcvV95-NFexc0MqlyHm7QDdeV1WkfaXlP695V3fn4ElQ9nPgTKldfShTYqkmuEnSa74ttNKC6UB8f9cPLyPH1AL5nC-juH0hE8j0Omo9isBhgxXruAtA9B9EZWRhwU0g8TTlUNgN5IvZPaiDqTMmp06tuqDuSGcvUBb3izN3z74oybQv6tNy8RbLzsnF3bAB-aXru2N-sodEdhb1S1LCDUn4FiItJ0vjAfkgDCEXPhL4qv4GKTMHVC0w0xEc3ZIk1t5iZNbhqfP_EUU5xila3b0duxXG6MYeQzzOQ6jxsH3UihN68X2A8pidIUmao34ZDMloIHVKYsKCLTD3Ozztp5q3UAsPWmMIMdAuWvJbM-Wga8zD7rscsrfcuboSowsyVUUDNsa8V_9AvtMuBJ_ZnhK-P6KJ3mC0D2CfA--jD_KPkXw2MdDbRiA-zTziiflxTsOmi467Sus9cmuKoy2IkrqrY8NGgtUdufTNRaVbiKd2EnF2cOM6ytVvYas4B0XNxVyxIYJWgJSLz6a7_dCOi0nJYZ9p43z3AOhDMsnIz4ximGYrZg_HGuazMQrAtMB9jMF_rsWDNWZdGNz61zyAXZBpYLaXc7Zy4WwSovqmkO43TzFQ-cq_XffZQz7AFk3pXKU8RphfcHS3yNsd-GcGDP9hVzfNd33456zT_-cuV_q-SYXw==

### Before screenshot:
![image](https://github.com/user-attachments/assets/5f0df524-1102-44d7-bb8a-1e98c1f6d1b4)

### After screenshot:
![image](https://github.com/user-attachments/assets/4be9050d-33ee-4228-b35f-fe0652451c90)
