### PR TITLE
Add support for "Critical Strike" (Amazon Ascendancy Notable)

### DIFF
--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -33,6 +33,7 @@ local displayStats = {
 	{ stat = "CritMultiplier", label = "Crit Multiplier", fmt = "d%%", pc = true, condFunc = function(v,o) return (o.CritChance or 0) > 0 end },
 	{ stat = "HitChance", label = "Hit Chance", fmt = ".0f%%", flag = "attack" },
 	{ stat = "HitChance", label = "Hit Chance", fmt = ".0f%%", condFunc = function(v,o) return o.enemyHasSpellBlock end },
+	{ stat = "AccuracyHitChanceUncapped", label = "Uncap. Hit Chance", fmt = ".0f%%", flag = "attack", condFunc = function(v,o) if o.AccuracyHitChanceUncapped then return o.AccuracyHitChanceUncapped > 100 end end },
 	{ stat = "TotalDPS", label = "Hit DPS", fmt = ".1f", compPercent = true, flag = "notAverage" },
 	{ stat = "PvpTotalDPS", label = "PvP Hit DPS", fmt = ".1f", compPercent = true, flag = "notAveragePvP" },
 	{ stat = "TotalDPS", label = "Hit DPS", fmt = ".1f", compPercent = true, flag = "showAverage", condFunc = function(v,o) return (o.TriggerTime or 0) ~= 0 end },

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -36,6 +36,14 @@ function calcs.hitChance(evasion, accuracy)
 	return m_max(m_min(round(rawChance), 100), 5)	
 end
 
+-- Calculate uncapped hit chance for mods that enable "Chance to hit with Attacks can exceed 100%"
+function calcs.hitChanceUncapped(evasion, accuracy)
+	if accuracy < 0 then
+		return 5
+	end
+	local rawChance = ( accuracy * 1.5 ) / ( accuracy + evasion ) * 100
+	return m_max(round(rawChance), 5)	
+end
 -- Calculate damage reduction from armour, float
 function calcs.armourReductionF(armour, raw)
 	if armour == 0 and raw == 0 then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2369,6 +2369,8 @@ local specialModList = {
 	["leeche?s? ([%d%.]+)%% of (%a+) attack damage as life"] = function(num, _, dmgType) return {
 		mod(firstToUpper(dmgType) .. "DamageLifeLeech", "BASE", num, nil, ModFlag.Attack, 0),
 	} end,
+	-- Amazon
+	["chance to hit with attacks can exceed 100%%"] = {flag("Condition:HitChanceCanExceed100", { type = "Skilltype", skillType = SkillType.Attack})},
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2371,6 +2371,7 @@ local specialModList = {
 	} end,
 	-- Amazon
 	["chance to hit with attacks can exceed 100%%"] = {flag("Condition:HitChanceCanExceed100", { type = "Skilltype", skillType = SkillType.Attack})},
+	["gain additional critical hit chance equal to (%d+)%% of excess chance to hit with attacks"] = function(num) return { mod("CritChance", "BASE", 0.01, { type = "Multiplier", var = "ExcessHitChance", div = 1 / num   }, { type = "SkillType", skillType = SkillType.Attack})} end,
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2371,7 +2371,7 @@ local specialModList = {
 	} end,
 	-- Amazon
 	["chance to hit with attacks can exceed 100%%"] = {flag("Condition:HitChanceCanExceed100", { type = "Skilltype", skillType = SkillType.Attack})},
-	["gain additional critical hit chance equal to (%d+)%% of excess chance to hit with attacks"] = function(num) return { mod("CritChance", "BASE", 0.01, { type = "Multiplier", var = "ExcessHitChance", div = 1 / num   }, { type = "SkillType", skillType = SkillType.Attack})} end,
+	["gain additional critical hit chance equal to (%d+)%% of excess chance to hit with attacks"] = function(num) return { mod("CritChance", "BASE", 0.01 * num, { type = "Multiplier", var = "ExcessHitChance" }, { type = "SkillType", skillType = SkillType.Attack})} end,
 	-- Ascendant
 	["grants (%d+) passive skill points?"] = function(num) return { mod("ExtraPoints", "BASE", num) } end,
 	["can allocate passives from the %a+'s starting point"] = { },


### PR DESCRIPTION
### Description of the problem being solved:
- Add support for "Critical Strike" (Amazon Ascendancy Notable)
    - Chance to hit with Attacks can exceed 100%
    - Gain additional Critical Hit Chance equal to 25% of excess chance to hit with Attacks
 
### Steps taken to verify a working solution:
- Mod gets parsed correctly
- Only applies to attacks
- Values for mainhand and offhand are calculated separately
- Works with different weapon types, including unarmed
- Uncapped hit chance is only displayed if above 100%
- Works with "Hits can't be evaded"

### Limitations:
- It's currently possible to benefit from the mod twice if you also enter it manually in the config, but that's basically deliberate user interference. Might have to look at it again if we ever get the same mod on an item.
- **Impact of distance on accuracy is not yet accounted for** in PoB calculation (out of scope for this PR), so added crit chance will be overestimated for ranged attacks

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/7l6ey00t

### After screenshot:
![image](https://github.com/user-attachments/assets/77ec4fb5-560a-4978-9de7-a8d3c1aba12f)
![image](https://github.com/user-attachments/assets/b7703c7f-4aee-4469-855c-db51f244111e)
![image](https://github.com/user-attachments/assets/0f642ab8-0f25-4460-b786-bc1c2e2f317a)
![image](https://github.com/user-attachments/assets/bbd77b86-8fe7-4511-bfee-3cf1d308cbd1)
