### PR TITLE
Add nil check that causes load build to fail after corrupt build loaded

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -789,7 +789,8 @@ function buildMode:SyncLoadouts()
 
 	-- Try to select loadout in dropdown based on currently selected tree
 	if self.treeTab then
-		local treeName = self.treeTab.specList[self.treeTab.activeSpec].title or "Default"
+		local spec = self.treeTab.specList[self.treeTab.activeSpec]
+		local treeName = spec and spec.title or "Default"
 		for i, loadout in ipairs(filteredList) do
 			if loadout == treeName then
 				local linkMatch = string.match(treeName, "%{(%w+)%}") or treeName


### PR DESCRIPTION
Fixes bricked pob after loading a corrupt build causing all build loads after that to fail.

### Description of the problem being solved:

Add additional nil check for specList entry when activeSpec value does not exist in the table. This happens sometimes after corrupt builds, like in 0.2 before the Huntress class was added.

### Steps taken to verify a working solution:
- Tested with poe2.ninja headless runner.

### Link to a build that showcases this PR:
https://poe2.ninja/pob/15eb

### Before screenshot:

### After screenshot:
