### PR TITLE
Fix global attack speed mods not applying to Crossbow reaload speed

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2528,13 +2528,13 @@ function calcs.offence(env, actor, activeSkill)
 					globalBreakdown.ReloadTime = { }
 					local baseReloadTime = source.ReloadTime
 					local incReloadSpeed = skillModList:Sum("INC", skillCfg, "ReloadSpeed")
-					local moreReloadSpeed = (100 + skillModList:Sum("MORE", skillCfg, "ReloadSpeed")) / 100
+					local moreReloadSpeed = skillModList:More("MORE", skillCfg, "ReloadSpeed")
 					t_insert(globalBreakdown.ReloadTime, s_format("  1.00s / %.2f ^8(base reload time)", baseReloadTime))
 					t_insert(globalBreakdown.ReloadTime, s_format("= %.2f ^8(base reload rate)", 1 / baseReloadTime))
 					t_insert(globalBreakdown.ReloadTime, s_format("\n"))
 					t_insert(globalBreakdown.ReloadTime, s_format("^8Note: modifiers to attack speed also affect reload speed"))
 					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(increased/reduced)", 1 + (incReloadSpeed/100) + (inc/100) ))
-					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(more/less)", moreReloadSpeed * (1 + (more/100)) ))
+					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(more/less)",  1 * moreReloadSpeed * more ))
 					t_insert(globalBreakdown.ReloadTime, s_format("= %.2f ^8(reload rate)", output.ReloadRate))
 					t_insert(globalBreakdown.ReloadTime, s_format("\n"))
 					t_insert(globalBreakdown.ReloadTime, s_format("   1.00s / %.2f ^8(reload rate)", output.ReloadRate))

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -280,7 +280,8 @@ end
 ---@return number
 local function calcCrossbowReloadTime(weaponData, boltSkill)
 	local baseReloadTime = weaponData.ReloadTime
-	local reloadTimeMulti = calcLib.mod(boltSkill.skillModList, boltSkill.skillCfg, "ReloadSpeed" )
+
+	local reloadTimeMulti = calcLib.mod(boltSkill.skillModList, boltSkill.skillCfg, "ReloadSpeed", "Speed" )
 	return baseReloadTime / reloadTimeMulti
 end
 -- Calculate stats from parent Ammo skill that are not available on children, such as mana cost and reload speed
@@ -2531,8 +2532,9 @@ function calcs.offence(env, actor, activeSkill)
 					t_insert(globalBreakdown.ReloadTime, s_format("  1.00s / %.2f ^8(base reload time)", baseReloadTime))
 					t_insert(globalBreakdown.ReloadTime, s_format("= %.2f ^8(base reload rate)", 1 / baseReloadTime))
 					t_insert(globalBreakdown.ReloadTime, s_format("\n"))
-					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(increased/reduced)", 1 + incReloadSpeed/100 ))
-					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(more/less)", moreReloadSpeed ))
+					t_insert(globalBreakdown.ReloadTime, s_format("^8Note: modifiers to attack speed also affect reload speed"))
+					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(increased/reduced)", 1 + (incReloadSpeed/100) + (inc/100) ))
+					t_insert(globalBreakdown.ReloadTime, s_format("x %.2f ^8(more/less)", moreReloadSpeed * (1 + (more/100)) ))
 					t_insert(globalBreakdown.ReloadTime, s_format("= %.2f ^8(reload rate)", output.ReloadRate))
 					t_insert(globalBreakdown.ReloadTime, s_format("\n"))
 					t_insert(globalBreakdown.ReloadTime, s_format("   1.00s / %.2f ^8(reload rate)", output.ReloadRate))


### PR DESCRIPTION
### Description of the problem being solved:
- Global modifiers to Skill and Attack Speed now apply to Reload Speed
- Adjusted Reload Time breakdown accordingly

### Steps taken to verify a working solution:
- Tree nodes that provide Attack or Skill Speed affect reload time
- More multipliers to attack time affect reload speed
- Breakdown displays
- Breakdown calculations match displayed end results

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/t4acn00d

### After screenshot:
tree node effect:
![image](https://github.com/user-attachments/assets/ad043787-52f0-47ee-bb31-42a5b7fdc8f5)


breakdown:
![image](https://github.com/user-attachments/assets/89d19c1a-d860-4add-b274-d4945f254261)
