### PR TITLE
Add support for Mysticism, Enormity, Strong Hearted, Loyalty, Overextend

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2145,6 +2145,11 @@ skills["SupportOverextendPlayer"] = {
 			label = "Overextend",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_overextend_critical_strike_multiplier_+%_final"] = {
+					mod("CritMultiplier", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1693,6 +1693,14 @@ skills["SupportEnormityPlayer"] = {
 			label = "Enormity",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_titanblood_minion_damage_+%_final"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil) }),
+				},
+				["support_titanblood_minion_life_+%_final"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -2777,6 +2785,11 @@ skills["SupportLoyaltyPlayer"] = {
 			label = "Loyalty",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_trusty_companion_minion_life_+%_final"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -3064,6 +3077,11 @@ skills["SupportMysticismPlayer"] = {
 			label = "Mysticism",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_spell_damage_spirit_cost_spell_damage_+%_on_full_energy_shield"] = {
+					mod("Damage", "INC", nil, ModFlag.Spell, 0, { type = "Condition", var = "FullEnergyShield" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Mysticism" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -3544,6 +3562,11 @@ skills["SupportStrongHeartedPlayer"] = {
 			label = "Strong Hearted",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_shock_protection_spirit_cost_shock_duration_on_self_+%_final"] = {
+					mod("SelfShockDuration", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Strong Hearted" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -470,6 +470,11 @@ statMap = {
 
 #skill SupportOverextendPlayer
 #set SupportOverextendPlayer
+statMap = {
+	["support_overextend_critical_strike_multiplier_+%_final"] = {
+		mod("CritMultiplier", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -369,6 +369,14 @@ statMap = {
 
 #skill SupportEnormityPlayer
 #set SupportEnormityPlayer
+statMap = {
+	["support_titanblood_minion_damage_+%_final"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil) }),
+	},
+	["support_titanblood_minion_life_+%_final"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
+	},
+},
 #mods
 #skillEnd
 
@@ -625,6 +633,11 @@ statMap = {
 
 #skill SupportLoyaltyPlayer
 #set SupportLoyaltyPlayer
+statMap = {
+	["support_trusty_companion_minion_life_+%_final"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }),
+	},
+},
 #mods
 #skillEnd
 
@@ -689,6 +702,11 @@ statMap = {
 
 #skill SupportMysticismPlayer
 #set SupportMysticismPlayer
+statMap = {
+	["support_spell_damage_spirit_cost_spell_damage_+%_on_full_energy_shield"] = {
+		mod("Damage", "INC", nil, ModFlag.Spell, 0, { type = "Condition", var = "FullEnergyShield" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Mysticism" }),
+	},
+},
 #mods
 #skillEnd
 
@@ -795,6 +813,11 @@ statMap = {
 
 #skill SupportStrongHeartedPlayer
 #set SupportStrongHeartedPlayer
+statMap = {
+	["support_shock_protection_spirit_cost_shock_duration_on_self_+%_final"] = {
+		mod("SelfShockDuration", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Strong Hearted" }),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:

Another small PR.

Loyalty isn't fully done. Just the easy less life part was done. It still needs the `10% of Damage from Hits is taken from Supported Companion's Life before you`. We have previous work from Jinxed Juju in PoE1, just needs to be adapted. Would be nice to dynamically grab the Companions life rather than set it in the config.

Overextend needs the `You are Dazed for 5 seconds on Critically Striking with Supported Skill`. I imagine once we add Daze we could just make the player dazed if they Crit Recently?