### PR TITLE
Fix damage flags on Considered Casting and Controlled Destruction

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1019,7 +1019,7 @@ skills["SupportConsideredCastingPlayer"] = {
 					mod("Speed", "MORE", nil, ModFlag.Cast),
 				},
 				["support_slow_cast_spell_damage_+%_final"] = {
-					mod("Damage", "MORE", nil, OR64(ModFlag.Hit, ModFlag.Spell)),
+					mod("Damage", "MORE", nil),
 				},
 			},
 			baseFlags = {
@@ -1054,7 +1054,7 @@ skills["SupportControlledDestructionPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_controlled_destruction_spell_damage_+%_final"] = {
-					mod("Damage", "MORE", nil, ModFlag.Spell),
+					mod("Damage", "MORE", nil, ModFlag.Hit),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -212,7 +212,7 @@ statMap = {
 		mod("Speed", "MORE", nil, ModFlag.Cast),
 	},
 	["support_slow_cast_spell_damage_+%_final"] = {
-		mod("Damage", "MORE", nil, OR64(ModFlag.Hit, ModFlag.Spell)),
+		mod("Damage", "MORE", nil),
 	},
 },
 #mods
@@ -222,7 +222,7 @@ statMap = {
 #set SupportControlledDestructionPlayer
 statMap = {
 	["support_controlled_destruction_spell_damage_+%_final"] = {
-		mod("Damage", "MORE", nil, ModFlag.Spell),
+		mod("Damage", "MORE", nil, ModFlag.Hit),
 	},
 },
 #mods


### PR DESCRIPTION
Both skills had the wrong flags on their damage buff stats
