### PR TITLE
Fix Stomping Ground damage calculatiion

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3019,7 +3019,8 @@ skills["SupportStompingGroundPlayer"] = {
 			},
 		},
 	}
-}skills["StompingGroundShockwavePlayer"] = {
+}
+skills["StompingGroundShockwavePlayer"] = {
 	name = "Stomping Ground Shockwave",
 	hidden = true,
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.UseGlobalStats] = true, [SkillType.NoAttackOrCastTime] = true, },
@@ -3043,8 +3044,11 @@ skills["SupportStompingGroundPlayer"] = {
 				},
 			},
 			baseFlags = {
-				attack = true,
+				nonWeaponAttack = true,
 				area = true,
+			},
+			baseMods = {
+				skill("showAverage", true),
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 20 },

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -725,9 +725,10 @@ statMap = {
 #set SupportStompingGroundPlayer
 #mods
 #skillEnd
+
 #skill StompingGroundShockwavePlayer
 #set StompingGroundShockwavePlayer
-#flags attack area
+#flags nonWeaponAttack area
 statMap = {
 	["attack_minimum_added_physical_damage_as_%_of_strength"] = {
 		skill("PhysicalMin", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
@@ -736,6 +737,7 @@ statMap = {
 		skill("PhysicalMax", nil, { type = "PercentStat", stat = "Str", percent = 1 }),
 	},
 },
+#baseMod skill("showAverage", true)
 #mods
 #skillEnd
 


### PR DESCRIPTION
The damage calculation was using your weapon when it should only be using the damage from the strength mod
Fixes #918