### PR TITLE
Fix crash when importing 0.1 characters that used old jewel sockets

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -986,7 +986,11 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		else
 			self.build.itemsTab:AddItem(item, true)
 		end
-		self.build.itemsTab.slots[slotName]:SetSelItemId(item.id)
+		if self.build.itemsTab.slots[slotName] then
+			self.build.itemsTab.slots[slotName]:SetSelItemId(item.id)
+		else
+			ConPrintf("Unrecognised slot name in imported item: %s", slotName)
+		end
 	end
 end
 


### PR DESCRIPTION
Fixes #906 

In Poe 0.2 have less jewel sockets, this PR enable importing builds from version 0.1 without error

![image](https://github.com/user-attachments/assets/4dc9e1d9-3a1d-43fa-82b1-3addfed4e34d)
![image](https://github.com/user-attachments/assets/1b7c50e1-e2ca-4357-b693-8db9a2613665)
