### PR TITLE
Fix crash when hovering over some jewel sockets with a 0.1 tree

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1122,7 +1122,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 			self:AddNodeName(tooltip, node, build)
 		end
 		tooltip:AddSeparator(14)
-		if socket:IsEnabled() then
+		if socket ~= nil and socket:IsEnabled() then
 			tooltip:AddLine(14, colorCodes.TIP.."Tip: Right click this socket to go to the items page and choose the jewel for this socket.")
 		end
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Shift or Ctrl to hide this tooltip.")


### PR DESCRIPTION
Fixes #904

this PR check for a valid socket object before call method
![image](https://github.com/user-attachments/assets/1ac4db8c-171d-4237-8c08-2154914f8544)
