### PR TITLE
Fix "Could not generate search" error when using only full dps as a weight and not using full dps

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -170,6 +170,9 @@ function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, st
 		end
 	end
 	for _, statTable in ipairs(statWeights) do
+		if statTable.stat == "FullDPS" and not (baseOutput["FullDPS"] and newOutput["FullDPS"]) then
+			meanStatDiff = meanStatDiff + ratioModSums("TotalDPS", "TotalDotDPS", "CombinedDPS") * statTable.weightMult
+		end
 		meanStatDiff = meanStatDiff + ratioModSums(statTable.stat) * statTable.weightMult
 	end
 	return meanStatDiff


### PR DESCRIPTION
Fixes issue mentioned on discord
Fixes #925
### Description of the problem being solved:

#8247 removed handling for this case. My intention was to make it so that when fulldps is the only weight and it is not set then it is effectively ignored but that caused this issue. This pr re-adds the if check that handles this situation as before.

### Steps taken to verify a working solution:
- Test by attempting to find best Weapon 1 in test build

### Link to a build that showcases this PR:
https://pobb.in/AGQ1ldvG_rUz 

