### PR TITLE
Add support for Deadly Herald

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -893,6 +893,11 @@ skills["SupportDeadlyHeraldsPlayer"] = {
 			label = "Deadly Herald",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_deadly_heralds_damage_+%_final"] = {
+					mod("Damage", "MORE", nil),
+				}
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -191,6 +191,11 @@ statMap = {
 
 #skill SupportDeadlyHeraldsPlayer
 #set SupportDeadlyHeraldsPlayer
+statMap = {
+	["support_deadly_heralds_damage_+%_final"] = {
+		mod("Damage", "MORE", nil),
+	}
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:

30% MORE damage for heralds. Need a proper weapon equipped for the reservation to activate. Must switch the Stat Set to the actual damage part of the Herald.

### After screenshot:
![image](https://github.com/user-attachments/assets/7bf64f11-c84e-49da-b798-76d884fdcddd)
