### PR TITLE
Add support for Dread Banner ailment and stun threshold

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -2182,6 +2182,10 @@ skills["DreadBannerPlayer"] = {
 					mod("FlaskChargesGenerated", "BASE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 					div = 60,
 				},
+				["base_skill_buff_stun_and_ailment_threshold_+%_final_to_apply"] = {
+					mod("AilmentThreshold", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+					mod("StunThreshold", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+				},
 			},
 			baseFlags = {
 				duration = true,

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -175,6 +175,10 @@ statMap = {
 		mod("FlaskChargesGenerated", "BASE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
 		div = 60,
 	},
+	["base_skill_buff_stun_and_ailment_threshold_+%_final_to_apply"] = {
+		mod("AilmentThreshold", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+		mod("StunThreshold", "MORE", nil, 0, 0, { type = "Condition", var = "BannerPlanted" }, { type = "GlobalEffect", effectType = "Aura"}),
+	},
 },
 #mods
 #skillEnd


### PR DESCRIPTION
### Description of the problem being solved:
Now that Ailment threshold is in, I added the stun and ailment threshold from Dread Banner.

### After screenshot:
![image](https://github.com/user-attachments/assets/d7c67a38-ffdb-4eaf-92a6-1ce84844883a)
![image](https://github.com/user-attachments/assets/70304b90-edb4-4d32-a034-9f90160fd11d)
