### PR TITLE
Add support for Derange support gem

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1464,6 +1464,9 @@ return {
 ["link_buff_effect_on_self_+%"] = {
 	mod("LinkEffectOnSelf", "INC", nil),
 },
+["gain_energy_shield_cost_equal_to_intelligence"] = {
+	mod("ESCostNoMult", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Int", percent = 100 }),
+},
 -- Projectiles
 ["base_projectile_speed_+%"] = {
 	mod("ProjectileSpeed", "INC", nil),

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -1374,6 +1374,12 @@ skills["SupportDerangePlayer"] = {
 			label = "Derange",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_shield_sacrifice_damage_over_time_+%_final_per_100_intelligence"] = {
+					mod("Damage", "MORE", nil, ModFlag.Dot, 0, { type = "PerStat", stat = "Int", div = 100 }),
+				},
+			},
+
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -297,6 +297,12 @@ statMap = {
 
 #skill SupportDerangePlayer
 #set SupportDerangePlayer
+statMap = {
+	["support_shield_sacrifice_damage_over_time_+%_final_per_100_intelligence"] = {
+		mod("Damage", "MORE", nil, ModFlag.Dot, 0, { type = "PerStat", stat = "Int", div = 100 }),
+	},
+},
+
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:

This PR adds support for [Derang](https://poe2db.tw/us/Derange). 

I wasn't sure which ESCost mod I should be adding here, so I just went with the no mult one since theres no ES cost multi in game afaik.

The build provided has +1000 int jewel to demonstate scaling. I also added some fire mult to test non-ailment damage scaling (non expected).

### Steps taken to verify a working solution:
- Give +1000 int to character
- Add Essence Drain + Derange -> See 80% more damage from Derange
- Give lots of fire damage mult to character
- Add Fireball + Derange -> See no damage scaling for fireball Ignite
- Verify that ES cost is equal to intelligence 
- 
### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/chkb200k

### Before screenshot:

No parsing
![image](https://github.com/user-attachments/assets/e9e47fdd-536c-4a72-a1f5-0498dedbe5fb)

Fireball ignite damage
![image](https://github.com/user-attachments/assets/09ab763e-9eb7-4b64-a540-5644fb1a900f)


### After screenshot:

+80% more damage (1015 int * 8%) on Essence Drain dot

![image](https://github.com/user-attachments/assets/7957cbd3-9fe4-47fd-a51c-9f0829334c5d)

+1015 ES cost (1015 int)
![image](https://github.com/user-attachments/assets/9a3e318e-3f27-41ec-aeca-b80039365916)

No Change to fireball ignite damage

![image](https://github.com/user-attachments/assets/d71cbb53-c3c5-4e73-b0ec-0f464936ee35)
