### PR TITLE
Fix a crash when importing a character with tree version 0_1 selected

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -598,8 +598,11 @@ function ImportTabClass:ImportPassiveTreeAndJewels(charData)
 		end
 	end
 
+	self.build.spec:ImportFromNodeList(charData.class, nil, nil, charPassiveData.alternate_ascendancy or 0, hashes, weaponSets, {}, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
+
+	-- workaround to update the ui to last option
+	self.build.treeTab.controls.versionSelect.selIndex = #self.build.treeTab.treeVersions
 	-- attributes nodes
-	self.build.spec.hashOverrides = {}
 	for skillId, nodeInfo in pairs(charPassiveData.skill_overrides) do
 		local changeAttributeId = 0
 		if nodeInfo.name == "Intelligence" then
@@ -611,13 +614,16 @@ function ImportTabClass:ImportPassiveTreeAndJewels(charData)
 		end
 
 		if changeAttributeId > 0 then
-			self.build.spec:SwitchAttributeNode(tonumber(skillId), changeAttributeId)
+			local id = tonumber(skillId)
+			self.build.spec:SwitchAttributeNode(id, changeAttributeId)
+			local node = self.build.spec.nodes[id]
+
+			if node then
+				self.build.spec:ReplaceNode(node, self.build.spec.hashOverrides[id])
+			end
 		end
 	end
 
-	local attributesOverrides = copyTable(self.build.spec.hashOverrides, true)
-
-	self.build.spec:ImportFromNodeList(charData.class, nil, nil, charPassiveData.alternate_ascendancy or 0, hashes, weaponSets, attributesOverrides, charPassiveData.mastery_effects or {}, latestTreeVersion .. (charData.league:match("Ruthless") and "_ruthless" or ""))
 	self.build.spec:AddUndoState()
 	self.build.characterLevel = charData.level
 	self.build.characterLevelAutoMode = false


### PR DESCRIPTION
Fixes #968

Previous code had issues when the end user have selected previous tree instead of last one.

This PR fix that and also update the ui to select the last version

<img width="503" alt="image" src="https://github.com/user-attachments/assets/30758502-a409-4f9a-b956-0b0277f8d6bc" />
