### PR TITLE
Add support for Retreat, Pursuit, and Blindside

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -774,6 +774,7 @@ c["+85 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",v
 c["+85 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",value=85}},nil}
 c["+86 to maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="BASE",value=86}},nil}
 c["+9% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=9}},nil}
+c["+90 to all Attributes"]={{[1]={flags=0,keywordFlags=0,name="Str",type="BASE",value=90},[2]={flags=0,keywordFlags=0,name="Dex",type="BASE",value=90},[3]={flags=0,keywordFlags=0,name="Int",type="BASE",value=90},[4]={flags=0,keywordFlags=0,name="All",type="BASE",value=90}},nil}
 c["+90 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=90}},nil}
 c["+90 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",value=90}},nil}
 c["+92 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=92}},nil}

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -186,6 +186,14 @@ skills["SupportBlindsidePlayer"] = {
 			label = "Blindside",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_unseen_critical_damage_multiplier_+%_final_vs_blinded_enemies"] = {
+					mod("CritMultiplier", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Blinded" } ),
+				},
+				["support_unseen_critical_strike_chance_+%_final_vs_blinded_enemies"] = {
+					mod("CritChance", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Blinded" } ),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -2474,6 +2482,14 @@ skills["SupportPursuitPlayer"] = {
 			label = "Pursuit",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_advancing_assault_melee_damage_+%_final_if_projectile_attack_damage_hit_in_past_8_seconds"] = {
+					mod("Damage", "MORE", nil, ModFlag.Melee, 0, { type = "Condition", var = "HitProjectileRecently" } ),
+				},
+				["support_advancing_assault_projectile_damage_+%_final"] = {
+					mod("Damage", "MORE", nil, ModFlag.Projectile),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -2601,6 +2617,14 @@ skills["SupportRetreatPlayer"] = {
 			label = "Retreat",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_retreating_assault_projectile_damage_+%_final_if_melee_hit_in_past_8_seconds"] = {
+					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Condition", var = "HitMeleeRecently" } ),
+				},
+				["support_retreating_assault_melee_damage_+%_final"] = {
+					mod("Damage", "MORE", nil, ModFlag.Melee),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -46,6 +46,14 @@ statMap = {
 
 #skill SupportBlindsidePlayer
 #set SupportBlindsidePlayer
+statMap = {
+	["support_unseen_critical_damage_multiplier_+%_final_vs_blinded_enemies"] = {
+		mod("CritMultiplier", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Blinded" } ),
+	},
+	["support_unseen_critical_strike_chance_+%_final_vs_blinded_enemies"] = {
+		mod("CritChance", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Blinded" } ),
+	},
+},
 #mods
 #skillEnd
 
@@ -539,6 +547,14 @@ statMap = {
 
 #skill SupportPursuitPlayer
 #set SupportPursuitPlayer
+statMap = {
+	["support_advancing_assault_melee_damage_+%_final_if_projectile_attack_damage_hit_in_past_8_seconds"] = {
+		mod("Damage", "MORE", nil, ModFlag.Melee, 0, { type = "Condition", var = "HitProjectileRecently" } ),
+	},
+	["support_advancing_assault_projectile_damage_+%_final"] = {
+		mod("Damage", "MORE", nil, ModFlag.Projectile),
+	},
+},
 #mods
 #skillEnd
 
@@ -567,6 +583,14 @@ statMap = {
 
 #skill SupportRetreatPlayer
 #set SupportRetreatPlayer
+statMap = {
+	["support_retreating_assault_projectile_damage_+%_final_if_melee_hit_in_past_8_seconds"] = {
+		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Condition", var = "HitMeleeRecently" } ),
+	},
+	["support_retreating_assault_melee_damage_+%_final"] = {
+		mod("Damage", "MORE", nil, ModFlag.Melee),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1013,6 +1013,14 @@ Huge sets the radius to 11.
 		modList:NewMod("Condition:HitSpellRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:HitRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "conditionHitMeleeRecently", type = "check", label = "Have you Melee Hit Recently?", ifCond = "HitMeleeRecently", implyCond = "HitRecently", tooltip = "This also implies that you have Hit Recently.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:HitMeleeRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("Condition:HitRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
+	{ var = "conditionHitProjectileRecently", type = "check", label = "Have you Hit with a Proj. Att. Recently?", ifCond = "HitProjectileRecently", implyCond = "HitRecently", tooltip = "This also implies that you have Hit Recently.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:HitProjectileRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+		modList:NewMod("Condition:HitRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionCritRecently", type = "check", label = "Have you Crit Recently?", ifCond = "CritRecently", implyCondList = { "SkillCritRecently", "CritInPast8Sec" }, tooltip = "This also implies that your Skills have Crit Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:CritRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:SkillCritRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })


### PR DESCRIPTION
### Description of the problem being solved:
Added two configs, one for melee hit recently, and one for projectile attack hit recently. The gems look for 8 seconds, but I think we decided to implement anything from 8 seconds as recent for now. I abbreviated Projectile Attacks so that the line fit in the box. But maybe different wording would be fine? Kept it consistent for now.
![image](https://github.com/user-attachments/assets/e4256782-0738-43b2-938e-2ef92a5b4fe8)

Blindside gives MORE crit bonus and crit chance against blinded enemies.
![image](https://github.com/user-attachments/assets/2253e46d-0942-4d0c-b51c-67aabb345a33)
![image](https://github.com/user-attachments/assets/a94b17d2-1ef9-4351-a10a-7242d4da6ad9)

Retreat and Pursuit use the new configs. They also prevent the skill from dealing melee or projectile damage. Equipping both gems on **Falling Thunder** makes it deal no damage at all, as it has a Melee and Projectile portion.
