### PR TITLE
Add support for Burgeon, Pinpoint Critical, Warm Blooded, and other partial gems

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -1030,6 +1030,14 @@ skills["SupportDelayedReactionPlayer"] = {
 			label = "Delayed Reaction",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_sunblast_hazard_hazard_damage_+%_final"] = {
+					mod("Damage", "MORE", nil),
+				},
+				["support_sunblast_hazard_hazard_duration_+%_final"] = {
+					mod("Duration", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3118,6 +3118,11 @@ skills["SupportWarmbloodedPlayer"] = {
 			label = "Warm Blooded",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_freeze_protection_spirit_cost_freeze_duration_on_self_+%_final"] = {
+					mod("SelfFreezeDuration", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Warm Blooded" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -1345,6 +1345,11 @@ skills["SupportGambleshotPlayer"] = {
 			label = "Gambleshot",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				[ "support_gambleshot_projectile_damage_+%_final"] = {
+					mod("Damage", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -3159,6 +3159,14 @@ skills["SupportPinpointCriticalPlayer"] = {
 			label = "Pinpoint Critical",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_pinpoint_critical_strike_chance_+%_final"] = {
+					mod("CritChance", "MORE", nil),
+				},
+				["support_pinpoint_critical_strike_multiplier_+%_final"] = {
+					mod("CritMultiplier", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -410,6 +410,14 @@ skills["SupportBurgeonPlayer"] = {
 			label = "Burgeon",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_chanelling_damage_+%_final_per_second_channelling"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "Channelling" }, { type = "Multiplier", var = "ChannellingTime", limitVar = "BurgeonDamageCap", limitTotal = true }),
+				},
+				["support_channelling_damage_cap"] = {
+					mod("Multiplier:BurgeonDamageCap", "BASE"),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -229,6 +229,14 @@ statMap = {
 
 #skill SupportDelayedReactionPlayer
 #set SupportDelayedReactionPlayer
+statMap = {
+	["support_sunblast_hazard_hazard_damage_+%_final"] = {
+		mod("Damage", "MORE", nil),
+	},
+	["support_sunblast_hazard_hazard_duration_+%_final"] = {
+		mod("Duration", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -298,6 +298,11 @@ statMap = {
 
 #skill SupportGambleshotPlayer
 #set SupportGambleshotPlayer
+statMap = {
+	[ "support_gambleshot_projectile_damage_+%_final"] = {
+		mod("Damage", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -673,6 +673,11 @@ statMap = {
 
 #skill SupportWarmbloodedPlayer
 #set SupportWarmbloodedPlayer
+statMap = {
+	["support_freeze_protection_spirit_cost_freeze_duration_on_self_+%_final"] = {
+		mod("SelfFreezeDuration", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Warm Blooded" }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -734,6 +734,14 @@ statMap = {
 
 #skill SupportPinpointCriticalPlayer
 #set SupportPinpointCriticalPlayer
+statMap = {
+	["support_pinpoint_critical_strike_chance_+%_final"] = {
+		mod("CritChance", "MORE", nil),
+	},
+	["support_pinpoint_critical_strike_multiplier_+%_final"] = {
+		mod("CritMultiplier", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -92,6 +92,14 @@ statMap = {
 
 #skill SupportBurgeonPlayer
 #set SupportBurgeonPlayer
+statMap = {
+	["support_chanelling_damage_+%_final_per_second_channelling"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "Channelling" }, { type = "Multiplier", var = "ChannellingTime", limitVar = "BurgeonDamageCap", limitTotal = true }),
+	},
+	["support_channelling_damage_cap"] = {
+		mod("Multiplier:BurgeonDamageCap", "BASE"),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1131,7 +1131,7 @@ local preFlagList = {
 	["^summoned sentinels have "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillNameList = { "Herald of Purity", "Dominating Blow", "Absolution" }, includeTransfigured = true } },
 	["^raised zombies' slam attack has "] = { addToMinion = true, tag = { type = "SkillId", skillId = "ZombieSlam" } },
 	["^raised spectres, raised zombies, and summoned skeletons have "] = { addToMinion = true, addToMinionTag = { type = "SkillName", skillNameList = { "Raise Spectre", "Raise Zombie", "Summon Skeletons" }, includeTransfigured = true } },
-	["companions [hd][ae][va][el] "] = { addToMinion = true, addToMinionTag = { type = "SkillType", skillType = SkillType.Companion } },
+	["^companions [hd][ae][va][el] "] = { addToMinion = true, addToMinionTag = { type = "SkillType", skillType = SkillType.Companion } },
 	-- Totem/trap/mine
 	["^attacks used by totems have "] = { flags = ModFlag.Attack, keywordFlags = KeywordFlag.Totem },
 	["^spells cast by totems [hd][ae][va][el] "] = { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Totem },


### PR DESCRIPTION
Fixes #984 

### Description of the problem being solved:
Gambleshot still needs the 1/3 chance to fork, chain, and pierce mod.
Delayed Reaction trigger mod might not be worth implementing, but left it as red for now.

Burgeon caps at 4 seconds channelling, for 40% more damage. It doesn't "need" the Channelling Condition, but it felt better to have the Channelling box pop up along with the Seconds spent Channelling

EDIT: The stat itself has the spelling error.
![image](https://github.com/user-attachments/assets/55d8c4bf-e36a-467f-b07c-343fff88fbce)