### PR TITLE
Relocate code for addition of base weapon stats to CalcPerform

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -527,22 +527,6 @@ function calcs.offence(env, actor, activeSkill)
 			func(activeSkill, output, breakdown)
 		end
 	end
-	-- Checks if a given item is classified as a martial weapon base on global data.weaponTypeInfo table
-	-- Note: long-term it might be better to add "MartialWeapon" flags to items instead potentially once PR #688 is complete
-	---@param item table @item as contained in actor.itemList
-	---@return boolean
-	local function isMartialWeapon(item)
-		local itemType = item.type or "None"
-		if itemType == "Staff" and not (item.base.subType == "Warstaff" or (item.baseName and item.baseName:find("Quarterstaff"))) then return false end -- Workaround to rule out caster staves
-		local nonMartialWeapons = {"None", "Wand", "Fishing Rod" } -- filter out other non-martial bases
-		for _, val in pairs(nonMartialWeapons) do
-			if val == itemType then return false end
-		end
-		for key, _ in pairs(data.weaponTypeInfo) do
-			if itemType == key then return true end
-		end
-		return false
-	end
 
 	runSkillFunc("initialFunc")
 
@@ -637,7 +621,7 @@ function calcs.offence(env, actor, activeSkill)
 	-- Note: This might run into issues with Energy Blade or similar mechanics that could "replace" the weapon items, but it's hard to test because PoE2 doesn't have those mechanics yet
 	for i in pairs({ "1", "2" }) do
 		-- Section for martial weapons only for now
-		if actor.itemList["Weapon " .. i] and isMartialWeapon(actor.itemList["Weapon " .. i]) then
+		if actor.itemList["Weapon " .. i] and actor.itemList["Weapon " .. i].base and actor.itemList["Weapon " .. i].base.weapon then
 			-- Add base min and max damage
 			for _, damageType in ipairs(dmgTypeList) do
 				if actor.itemList["Weapon " .. i] and actor["weaponData" .. i][damageType .. "Min"] then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -617,24 +617,6 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
-	-- Add weapon base stats to output for use in mods like Tactician's ""Watch How I Do It" Ascendancy notable" and Amazon's "Penetrate"
-	-- Note: This might run into issues with Energy Blade or similar mechanics that could "replace" the weapon items, but it's hard to test because PoE2 doesn't have those mechanics yet
-	for i in pairs({ "1", "2" }) do
-		-- Section for martial weapons only for now
-		if actor.itemList["Weapon " .. i] and actor.itemList["Weapon " .. i].base and actor.itemList["Weapon " .. i].base.weapon then
-			-- Add base min and max damage
-			for _, damageType in ipairs(dmgTypeList) do
-				if actor.itemList["Weapon " .. i] and actor["weaponData" .. i][damageType .. "Min"] then
-					output[damageType .. "Min" .. "OnWeapon " .. i] = actor["weaponData" .. i][damageType .. "Min"]
-				end
-				if actor["weaponData" .. i][damageType .. "Max"] then
-					output[damageType .. "Max" .. "OnWeapon " .. i] = actor["weaponData" .. i][damageType .. "Max"]
-				end
-			end
-			-- Add total local accuracy
-			output["AccuracyOnWeapon " .. i] = actor.itemList["Weapon " .. i].baseModList:Sum("BASE", nil, "Accuracy")
-		end
-	end
 	-- Add bonus mods for Tactician's "Watch How I Do It" (technically this could be done in ModParser, but it would always add 10 mods instead of just the necessary ones)
 	if actor.parent and actor.modDB:Flag(nil, "GainMainHandDmgFromParent") and actor.parent.itemList["Weapon 1"] then
 		local modSource = ""

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -74,6 +74,29 @@ local function mergeKeystones(env)
 		end
 	end
 end
+-- Add certain weapon base stats to output for use as "Stat" in mods like Tactician's ""Watch How I Do It" Ascendancy notable" and Amazon's "Penetrate"
+-- Note: This might run into issues with Energy Blade, Shapeshifting or similar mechanics that could "replace" the weapon items, but it's hard to test because PoE2 doesn't have those mechanics yet
+---@param actor table
+local function addWeaponBaseStats(actor)
+	local output = actor.output
+	local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"} -- Note: we're using local dmgTypeList vars a lot, might be better to eventually just use a global since it presumably won't change
+	for i in pairs({ "1", "2" }) do
+		-- Section for martial weapons only for now
+		if actor.itemList["Weapon " .. i] and actor.itemList["Weapon " .. i].base and actor.itemList["Weapon " .. i].base.weapon then
+			-- Add base min and max damage
+			for _, damageType in ipairs(dmgTypeList) do
+				if actor.itemList["Weapon " .. i] and actor["weaponData" .. i][damageType .. "Min"] then
+					output[damageType .. "Min" .. "OnWeapon " .. i] = actor["weaponData" .. i][damageType .. "Min"]
+				end
+				if actor["weaponData" .. i][damageType .. "Max"] then
+					output[damageType .. "Max" .. "OnWeapon " .. i] = actor["weaponData" .. i][damageType .. "Max"]
+				end
+			end
+			-- Add total local accuracy
+			output["AccuracyOnWeapon " .. i] = actor.itemList["Weapon " .. i].baseModList:Sum("BASE", nil, "Accuracy")
+		end
+	end
+end
 
 -- Calculate attributes, and set conditions
 ---@param env table
@@ -129,6 +152,7 @@ local function doActorAttribsConditions(env, actor)
 		if (weapon1Base and weapon1Base.weapon) or (weapon2Base and weapon2Base.weapon) then -- technically checking weapon2 is unnecessary as there is currently no way to only attack with off-hand, but maybe it will come
 			condList["UsingMartialWeapon"] = true
 		end
+		addWeaponBaseStats(actor)
 	end
 	local armourSlots = { "Helmet", "Body Armour", "Gloves", "Boots" }
 	for _, slotName in ipairs(armourSlots) do


### PR DESCRIPTION
### Description of the problem being solved:
- `isMartialWeapon` function I introduced in #931 turned out to be unnecessary so I removed it
- Having the base weapon stats added to output in `CalcOffence`  instead of in `CalcPerform` where a lot of the other weapon checks are done, didn't make much sense, so I moved it there. I also intend to move the Tactician mod from #931 to `CalcPerform` eventually

### Steps taken to verify a working solution:
- Tactician mod from #931 still works as intended
- Amazon mod from #932 still works as intended
- (nothing else was using this section of the code for now)