### PR TITLE
Add support for Unerring Power

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3013,6 +3013,14 @@ skills["SupportUnerringPowerPlayer"] = {
 			label = "Unerring Power",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_discount_skill_cost_+%_final_if_empowered"] = {
+					mod("Cost", "MORE", nil, 0, 0, { type = "Condition", var = "Empowered" } )
+				},
+				["support_discount_accuracy_rating_+%_final_if_empowered"] = {
+					mod("Accuracy", "MORE", nil, 0, 0, { type = "Condition", var = "Empowered" } )
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -645,6 +645,14 @@ statMap = {
 
 #skill SupportUnerringPowerPlayer
 #set SupportUnerringPowerPlayer
+statMap = {
+	["support_discount_skill_cost_+%_final_if_empowered"] = {
+		mod("Cost", "MORE", nil, 0, 0, { type = "Condition", var = "Empowered" } )
+	},
+	["support_discount_accuracy_rating_+%_final_if_empowered"] = {
+		mod("Accuracy", "MORE", nil, 0, 0, { type = "Condition", var = "Empowered" } )
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
![image](https://github.com/user-attachments/assets/d26d28db-e3d8-4284-b8b8-eb90de147a20)
Skill cost is lowered when the Empowered config is set to true. Not specific to Mana cost, so it applies to Life cost with blood Magic too.
Accuracy is given 30% MORE when Empowered config selected.
### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/e9e425e7-c004-4257-8b7c-daca288fbbd1)
With Blood Magic
![image](https://github.com/user-attachments/assets/93eef3ac-9b78-4695-948f-3c904d44fa07)
