### PR TITLE
Fix Arc skill on Storm Mages not working

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -335,10 +335,10 @@ skills["ArcSkeletonMageMinion"] = {
 				"disable_visual_hit_effect",
 			},
 			levels = {
-				[1] = { 1, 9, 2, statInterpolation = { 1, 1, 1, }, actorLevel = 1, },
-				[2] = { 5, 103, 3, statInterpolation = { 1, 1, 1, }, actorLevel = 20, },
-				[3] = { 21, 408, 4, statInterpolation = { 1, 1, 1, }, actorLevel = 40, },
-				[4] = { 66, 1260, 5, statInterpolation = { 1, 1, 1, }, actorLevel = 60, },
+				[1] = { 0.10000000149012, 1.8999999761581, 2, statInterpolation = { 3, 3, 1, }, actorLevel = 1, },
+				[2] = { 0.10000000149012, 1.8999999761581, 3, statInterpolation = { 3, 3, 1, }, actorLevel = 20, },
+				[3] = { 0.10000000149012, 1.8999999761581, 4, statInterpolation = { 3, 3, 1, }, actorLevel = 40, },
+				[4] = { 0.10000000149012, 1.8999999761581, 5, statInterpolation = { 3, 3, 1, }, actorLevel = 60, },
 			},
 		},
 	}

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -733,7 +733,7 @@ directiveTable.set = function(state, args, out)
 					statMapOrderIndex = statMapOrderIndex + 1
 				end
 			end
-			if resolveInterpolation and #statsPerLevel > 1 then -- Don't resolve values for minion skills as it will break them
+			if resolveInterpolation and #statsPerLevel > 5 then -- Don't resolve values for minion skills as it will break them
 				table.insert(level, statRow.BaseResolvedValues[i])
 				if state.skill.setIndex ~= 1 then
 					-- Modify the correct statInterpolation value in the current set by offsetting the value from the count in the base set

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -148,7 +148,7 @@ function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet)
 			if statSetLevel.statInterpolation[index] == 3 then
 				-- Effectiveness interpolation
 				if not availableEffectiveness then
-					actorLevel = #statSet.levels == 1 and skillInstance.actorLevel or statSetLevel.actorLevel
+					actorLevel = #statSet.levels < 5 and skillInstance.actorLevel or statSetLevel.actorLevel
 					availableEffectiveness =
 						data.gameConstants["SkillDamageBaseEffectiveness"] * (statSet.baseEffectiveness or 1)
 							* (1 + (statSet.incrementalEffectiveness or 0) * (actorLevel - 1)) 


### PR DESCRIPTION
This is a temporary fix for the skill to work again. We should identify minion skills in a better way instead of counting the maximum number of levels
