### PR TITLE
Fix Cursecarver variants

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -627,7 +627,13 @@ c["+36 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",v
 c["+37% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=37}},nil}
 c["+39 to Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",type="BASE",value=39}},nil}
 c["+4 to Ailment Threshold per Dexterity"]={{[1]={[1]={stat="Dex",type="PerStat"},flags=0,keywordFlags=0,name="AilmentThreshold",type="BASE",value=4}},nil}
-c["+4 to Level of Hypothermia Skills"]={{}," Level ofSkills "}
+c["+4 to Level of Conductivity Skills"]={{[1]={[1]={skillName="Conductivity",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Despair Skills"]={{[1]={[1]={skillName="Despair",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Enfeeble Skills"]={{[1]={[1]={skillName="Enfeeble",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Flammability Skills"]={{[1]={[1]={skillName="Flammability",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Hypothermia Skills"]={{[1]={[1]={skillName="Hypothermia",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Temporal Chains Skills"]={{[1]={[1]={skillName="Temporal chains",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
+c["+4 to Level of Vulnerability Skills"]={{[1]={[1]={skillName="Vulnerability",type="SkillName"},flags=0,keywordFlags=0,name="SupportedGemProperty",type="LIST",value={key="level",keyword="grants_active_skill",value=4}}},nil}
 c["+4 to Level of all Chaos Spell Skills"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keywordList={[1]="chaos",[2]="spell"},value=4}}},nil}
 c["+4 to Level of all Elemental Skills"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keyword="elemental",value=4}}},nil}
 c["+4 to Level of all Fire Skills"]={{[1]={flags=0,keywordFlags=0,name="GemProperty",type="LIST",value={key="level",keyOfScaledMod="value",keyword="fire",value=4}}},nil}
@@ -773,6 +779,7 @@ c["+85 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",v
 c["+85 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",value=85}},nil}
 c["+86 to maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="BASE",value=86}},nil}
 c["+9% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=9}},nil}
+c["+90 to all Attributes"]={{[1]={flags=0,keywordFlags=0,name="Str",type="BASE",value=90},[2]={flags=0,keywordFlags=0,name="Dex",type="BASE",value=90},[3]={flags=0,keywordFlags=0,name="Int",type="BASE",value=90},[4]={flags=0,keywordFlags=0,name="All",type="BASE",value=90}},nil}
 c["+90 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=90}},nil}
 c["+90 to maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="BASE",value=90}},nil}
 c["+92 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=92}},nil}

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -5,13 +5,26 @@ return {
 [[
 Cursecarver
 Acrid Wand
+Variant: Flammability
+Variant: Hypothermia
+Variant: Conductivity
+Variant: Vulnerability
+Variant: Despair
+Variant: Enfeeble
+Variant: Temporal Chains
 Implicits: 1
 Grants Skill: Level (1-20) Decompose
 (80-100)% increased Spell Damage
 (10-20)% increased Cast Speed
 Lose 10 Life per Enemy Killed
 (30-50)% increased Mana Regeneration Rate
-+4 to Level of Hypothermia Skills
+{variant:3}+4 to Level of Conductivity Skills
+{variant:5}+4 to Level of Despair Skills
+{variant:6}+4 to Level of Enfeeble Skills
+{variant:1}+4 to Level of Flammability Skills
+{variant:2}+4 to Level of Hypothermia Skills
+{variant:7}+4 to Level of Temporal Chains Skills
+{variant:4}+4 to Level of Vulnerability Skills
 ]],[[
 Enezun's Charge
 Volatile Wand

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -5,13 +5,26 @@ return {
 [[
 Cursecarver
 Acrid Wand
+Variant: Flammability
+Variant: Hypothermia
+Variant: Conductivity
+Variant: Vulnerability
+Variant: Despair
+Variant: Enfeeble
+Variant: Temporal Chains
 Implicits: 1
 Grants Skill: Level (1-20) Decompose
 UniqueSpellDamageOnWeapon8
 UniqueIncreasedCastSpeed15
 UniqueManaRegeneration30
 UniqueLifeGainedFromEnemyDeath10
-UniqueHypothermiaGemLevel1
+{variant:1}UniqueFlammabilityGemLevel1
+{variant:2}UniqueHypothermiaGemLevel1
+{variant:3}UniqueConductivityGemLevel1
+{variant:4}UniqueVulnerabilityGemLevel1
+{variant:5}UniqueDespairGemLevel1
+{variant:6}UniqueEnfeebleGemLevel1
+{variant:7}UniqueTemporalChainsGemLevel1
 ]],[[
 Enezun's Charge
 Volatile Wand

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3062,6 +3062,7 @@ local specialModList = {
 	["(%d+)%% of recovery applied instantly"] = function(num) return { mod("FlaskInstantRecovery", "BASE", num) } end,
 	["has no attribute requirements"] = { flag("NoAttributeRequirements") },
 	-- Skill modifiers
+	["([%+%-]%d+)%%? to level of ([%a%s]+) skills"] = function(num, _, name) return { mod("SupportedGemProperty", "LIST", { keyword = "grants_active_skill", key = "level", value = num }, 0, 0, { type = "SkillName", skillName = firstToUpper(name) } ),} end,
 	["([%+%-]%d+)%% to quality of all skills"] = function(num) return { mod("GemProperty", "LIST", { keyword = "grants_active_skill", key = "quality", value = num, keyOfScaledMod = "value"  }) } end,
 	["([%+%-]%d+)%%? to (%a+) of all ?([%a%-' ]*) skills? ?w?i?t?h? ?a?n? ?(%a+) ?r?e?q?u?i?r?e?m?e?n?t?"] = function(num, _, property, type, gemReq)
 		if type == "" then type = "all" end


### PR DESCRIPTION
### Description of the problem being solved:
When I first added the new unique, I didn't realize it could have multiple versions of the +4 mod. The mod wasn't getting parsed as it's a skill name, not a Skill Type, so I added a separate line for it. It seems to function properly, it gives +4 to the proper curse no matter if it's the active skill or not, and taking the tree node **Endless Blizzard** correctly still applies +4 to cold skills. So Hypothermia was +5 total.

However, if someone could implement this into the line just 2 below, and have it look for Skill Name as well as skill type, maybe that would be better? Didn't try myself, looked a little complicated and not sure if we'd want to complicate it more or have a separate line.

### After screenshot:
![image](https://github.com/user-attachments/assets/5e506960-f79b-4d26-9ee3-9bbd24363b21)
![image](https://github.com/user-attachments/assets/c7edbe32-f823-45f6-ad8a-21af014e1108)
