### PR TITLE
Add proper support for pasting items with lesser and greater runes

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -853,13 +853,17 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								local function checkUnique(result)
 									-- Generate a unique key from the result table this prevents duplicates combinations being searched
 									local key = ""
-									for value, count in ipairs(result) do
+									for value, count in pairs(result) do
 										if count > 0 then
-											key = key .. value .. "x" .. count
+											key = key .. value .. "x" .. count .. " "
 										end
 									end
-									if visited[key] then return end
-									visited[key] = true
+									if visited[key] then 
+										return false 
+									else
+										visited[key] = true
+										return true
+									end
 								end
 								
 								-- Incrementing is done first as to reach the target you will need to add a count as such it should be more efficient.
@@ -873,7 +877,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > -1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
+								if (result[v] or 0) > 1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
 									result[v] = result[v] - 1
 									if checkUnique(result) then
 										adjustCombination(values, target, result, best, visited, sum - v, count - 1)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -870,8 +870,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 									result[v] = result[v] - 1
 								end
 
-								-- Try decreasing (if possible)
-								if (result[v] or 0) > 0 then
+								-- Try decreasing (if possible and only if target is still reachable).
+								if (result[v] or 0) > 0 and (not best or target < sum - v + values[#values] * (best.count - count - 1)) then
 									result[v] = result[v] - 1
 									adjustCombination(values, target, result, best, visited, sum - v, count - 1)
 									result[v] = result[v] + 1

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -868,7 +868,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								
 								-- Incrementing is done first as to reach the target you will need to add a count as such it should be more efficient.
 								-- Try increasing (if it doesn't overshoot or exceed maximum number of remaining runes)
-								if sum + tonumber(v) <= target + 1e-9 and count + 1 < remainingRunes then
+								if sum + tonumber(v) <= target + 1e-9 and count < remainingRunes then
 									result[v] = (result[v] or 0) + 1
 									if checkUnique(result) then
 										checkAndAdjustCombination(values, target, result, best, visited, sum + v, count + 1)
@@ -898,10 +898,10 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						end
 
 						local greedyCount = 0
+						for v, c in pairs(greedySolution) do
+							greedyCount = greedyCount + c
+						end
 						if math.abs(leftover) <= 1e-9 then -- Greedy search found a solution
-							for v, c in pairs(greedySolution) do
-								greedyCount = greedyCount + c
-							end
 							return greedySolution, greedyCount
 						end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -877,7 +877,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[1] * (best.count - count + 1)) then
+								if (result[v] or 0) > 0 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[1] * (best.count - count + 1)) then
 									result[v] = result[v] - 1
 									if checkUnique(result) then
 										adjustCombination(values, target, result, best, visited, sum - v, count - 1)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -870,7 +870,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 0 and (not best or target < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
+								if (result[v] or 0) > 0 and (not best.count or target < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
 									result[v] = result[v] - 1
 									adjustCombination(values, target, result, best, visited, sum - v, count - 1)
 									result[v] = result[v] + 1
@@ -925,7 +925,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					for i, runes in ipairs(groupedRunes) do
 						t_insert(values, runes[2])
 					end
-					local result, numRunes = getNumberOfRunesOfEachType(values, value)
+					local result, numRunes = getNumberOfRunesOfEachType(values, tonumber(value))
 
 					remainingRunes = remainingRunes - numRunes
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -863,14 +863,14 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							for _, v in ipairs(values) do
 								-- Incrementing is done first as to reach the target you will need to add a count as such it should be more efficient.
 								-- Try increasing (if it doesn't overshoot or exceed maximum number of remaining runes)
-								if sum + v <= target and count + 1 < remainingRunes then
+								if sum + tonumber(v) <= target and count + 1 < remainingRunes then
 									result[v] = (result[v] or 0) + 1
 									checkAndAdjustCombination(values, target, result, best, visited, sum + v, count + 1)
 									result[v] = result[v] - 1
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 0 and (not best or target < sum - v + values[#values] * (best.count - count - 1)) then
+								if (result[v] or 0) > 0 and (not best or target < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
 									result[v] = result[v] - 1
 									adjustCombination(values, target, result, best, visited, sum - v, count - 1)
 									result[v] = result[v] + 1
@@ -1249,8 +1249,8 @@ function ItemClass:UpdateRunes()
 				if statOrder[order] then
 					-- Combine stats
 					local start = 1
-					statOrder[order].line = statOrder[order].line:gsub("%d+", function(num)
-						local s, e, other = line:find("(%d+)", start)
+					statOrder[order].line = statOrder[order].line:gsub("(%d%.?%d*)", function(num)
+						local s, e, other = line:find("(%d%.?%d*)", start)
 						start = e + 1
 						return tonumber(num) + tonumber(other)
 					end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -902,7 +902,12 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							if math.abs(ratio - round(ratio)) < 1e-9 then
 								local count = round(ratio)
 								if count >= 0 then
-									return { [v] =  count}, count
+									local solution = {}
+									for _, otherValue in ipairs(values) do
+										if otherValue ~= v then solution[otherValue] = 0 end
+									end
+									solution[v] = count
+									return solution, count
 								end
 							end
 						end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -939,7 +939,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					if result then -- we have found a valid combo for that rune category
 						remainingRunes = remainingRunes - numRunes
 						-- this code should probably be refactored to based off stored self.runes rather than the recomputed amounts off the runeModLines this 
-						-- is too avoid having to run the relatively expensive recompution everytime the item is parsed even if we know the runes on the item already.
+						-- is too avoid having to run the relatively expensive recomputation every time the item is parsed even if we know the runes on the item already.
 						modLine.soulcore = groupedRunes[1][1]:match("Soul Core") ~= nil
 						modLine.runeCount = numRunes
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -889,12 +889,12 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							leftover = leftover - count * v
 						end
 
+						local greedyCount = 0
 						if leftover == 0 then -- Greedy search found a solution
-							local count = 0
 							for v, c in pairs(greedySolution) do
-								count = count + c
+								greedyCount = greedyCount + c
 							end
-							return greedySolution, count
+							return greedySolution, greedyCount
 						end
 
 						-- Try check if only 1 rune type was used.
@@ -912,7 +912,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						local best = {count = nil, solution = nil}
 						local visited = {}
 
-						adjustCombination(values, target, greedySolution, best, visited)
+						adjustCombination(values, target, greedySolution, best, visited, target - leftover, greedyCount)
 
 						return best.solution, best.count
 					end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -877,7 +877,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
+								if (result[v] or 0) > 1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[1] * (best.count - count + 1)) then
 									result[v] = result[v] - 1
 									if checkUnique(result) then
 										adjustCombination(values, target, result, best, visited, sum - v, count - 1)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -828,9 +828,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					local function getNumberOfRunesOfEachType(values, target)
 						local function adjustCombination(values, target, result, best, visited, sum, count)
 							-- This is used to avoid unnecessary checks on decrement.
-							local function checkAndAdjustCombiation(values, target, result, best, visited, sum, count)
-
-								-- Generate a unique key from the result table this prevenents duplicates combinations being searched
+							local function checkAndAdjustCombination(values, target, result, best, visited, sum, count)
+								-- Generate a unique key from the result table this prevents duplicates combinations being searched
 								local key = ""
 								for _, v in ipairs(values) do
 									if result[v] and result[v] > 0 then
@@ -866,7 +865,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								-- Try increasing (if it doesn't overshoot or exceed maximum number of remaining runes)
 								if sum + v <= target and count + 1 < remainingRunes then
 									result[v] = (result[v] or 0) + 1
-									checkAndAdjustCombiation(values, target, result, best, visited, sum + v, count + 1)
+									checkAndAdjustCombination(values, target, result, best, visited, sum + v, count + 1)
 									result[v] = result[v] - 1
 								end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -910,14 +910,12 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							local ratio = target / v
 							if math.abs(ratio - round(ratio)) < 1e-9 then
 								local count = round(ratio)
-								if count >= 0 then
-									local solution = {}
-									for _, otherValue in ipairs(values) do
-										if otherValue ~= v then solution[otherValue] = 0 end
-									end
-									solution[v] = count
-									return solution, count
+								local solution = {}
+								for _, otherValue in ipairs(values) do
+									if otherValue ~= v then solution[otherValue] = 0 end
 								end
+								solution[v] = count
+								return solution, count
 							end
 						end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -808,7 +808,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			end
 
 			-- Sort table to ensure first entries are always largest.
-			for strippedRuneModLine, runes in pairs(statGroupedRunes) do
+			for _, runes in pairs(statGroupedRunes) do
 				table.sort(runes,  function(a, b) return a[2] > b[2] end)
 			end
 
@@ -841,7 +841,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								visited[key] = true
 
 								-- If it's a valid solution, update best
-								if sum == target then
+								if math.abs(sum-target) <  1e-9 then
 									if not best.count or count < best.count then
 										best.count = count
 										-- Copy solution to avoid side effects from continued searching.
@@ -863,14 +863,14 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							for _, v in ipairs(values) do
 								-- Incrementing is done first as to reach the target you will need to add a count as such it should be more efficient.
 								-- Try increasing (if it doesn't overshoot or exceed maximum number of remaining runes)
-								if sum + tonumber(v) <= target and count + 1 < remainingRunes then
+								if sum + tonumber(v) <= target + 1e-9 and count + 1 < remainingRunes then
 									result[v] = (result[v] or 0) + 1
 									checkAndAdjustCombination(values, target, result, best, visited, sum + v, count + 1)
 									result[v] = result[v] - 1
 								end
 
 								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 0 and (not best.count or target < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
+								if (result[v] or 0) > -1e-9 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[#values] * (best.count - count - 1)) then
 									result[v] = result[v] - 1
 									adjustCombination(values, target, result, best, visited, sum - v, count - 1)
 									result[v] = result[v] + 1
@@ -927,9 +927,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					end
 					local result, numRunes = getNumberOfRunesOfEachType(values, tonumber(value))
 
-					remainingRunes = remainingRunes - numRunes
-
 					if result then -- we have found a valid combo for that rune category
+						remainingRunes = remainingRunes - numRunes
 						modLine.soulcore = groupedRunes[1][1]:match("Soul Core") ~= nil
 						modLine.runeCount = numRunes
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -823,9 +823,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				if groupedRunes then -- found the rune category with the relevant stat.
 					-- First a greedy base is found using the runes in the groupedRunes. If this matches the target value then that set of runes is applied.
 					-- If the greedy base isn't a solution we search all the possible combinations that could lead to a valid combination.
-					-- This done by recursing through all combinations that could lead to a a valid value this is done by pruning values that exceed the number
-					-- of runes and solutions that it would be impossible to reach the target value from. Visted combinations are recorded and are used such 
-					-- that candidates are only searched once. This makes for a fairly efficient algorithim that doesn't search unneeded values very much.
+					-- This done by recursing through all combinations that could lead to a valid value and pruning values that exceed the number
+					-- of runes and solutions that it would be impossible to reach the target value from. Visited combinations are recorded and are used such 
+					-- that candidates are only searched once. This makes for a fairly efficient algorithm that doesn't search unneeded values very much.
 					local function getNumberOfRunesOfEachType(values, target)
 						local function adjustCombination(values, target, result, best, visited, sum, count)
 							-- This is used to avoid unnecessary checks on decrement.

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -938,6 +938,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 
 					if result then -- we have found a valid combo for that rune category
 						remainingRunes = remainingRunes - numRunes
+						-- this code should probably be refactored to based off stored self.runes rather than the recomputed amounts off the runeModLines this 
+						-- is too avoid having to run the relatively expensive recompution everytime the item is parsed even if we know the runes on the item already.
 						modLine.soulcore = groupedRunes[1][1]:match("Soul Core") ~= nil
 						modLine.runeCount = numRunes
 


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/992

### Description of the problem being solved:
As there are now multiple runes of different types it becomes harder to guess the runes used on the item.

This PR aims to solve this issue by generating a minimal combination of runes that meets the stats present on the item. This means it will always generate a set of runes that add to the total if it can, otherwise it won't. This does however mean some runes combinations won't be accurately reflexed as they are ingame e.g. 
![image](https://github.com/user-attachments/assets/0383a27f-4a98-48d4-b170-2e884709d5ab)
Will get imported as 
![image](https://github.com/user-attachments/assets/e1209543-46d9-4e99-a1bd-ca0b0ed52498)
But I think this is a minor issue as it should be right in most cases of people using the runes. But will sometimes get it wrong mostly with runes values that linear combinations of others e.g. if some uses 2 lesser +20 life runes it will always be importer as a single greater +40 life rune.

This approach uses a greedy base, and then performs search on top of it this should avoid efficiencies potentially lost due to inefficiencies, avoid searching duplicate combinations and is constrained as better searches are found. This was made using ChatGPT as a base them modifying it to suit the runes as well as a few optimisations and changes.

### Before screenshot:
<img width="362" alt="433126833-1f6c73dd-ef82-4b28-b71f-27eb61a03130" src="https://github.com/user-attachments/assets/d7d542a2-3ff0-4e4a-8b83-6609f4ef2443" />
<img width="362" alt="433126839-70f077a5-680c-4dcc-ae31-337ae4134302" src="https://github.com/user-attachments/assets/8e654be9-728a-4d01-9a69-ef3e2c48665a" />
<img width="360" alt="433126842-1b96938a-9221-4cf0-97ec-033d6c48d0fb" src="https://github.com/user-attachments/assets/a5c3d682-fb9a-4a85-8f4d-7503dea7a407" />

### After screenshot:
![image](https://github.com/user-attachments/assets/fe1bbf27-3066-4ca1-bab9-c77d77d060c0)
![image](https://github.com/user-attachments/assets/e4587313-60ac-4c56-be26-d755bf4fee23)
![image](https://github.com/user-attachments/assets/4e75a883-b9eb-4082-ab03-ce8c301a8bb3)
