### PR TITLE
Fix Dauntless max damage stacking

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -740,7 +740,7 @@ skills["SupportDauntlessPlayer"] = {
 					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Condition", var = "Stationary" }, { type = "Multiplier", var = "StationarySeconds", div = 0.25, limitVar = "DauntlessMaxDamage", limitTotal = true }),
 				},
 				["support_unmoving_damage_multiplier_cap"] = {
-					mod("Multiplier:DauntlessMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+					mod("Multiplier:DauntlessMaxDamage", "BASE", nil),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -186,7 +186,7 @@ statMap = {
 		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Condition", var = "Stationary" }, { type = "Multiplier", var = "StationarySeconds", div = 0.25, limitVar = "DauntlessMaxDamage", limitTotal = true }),
 	},
 	["support_unmoving_damage_multiplier_cap"] = {
-		mod("Multiplier:DauntlessMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff"}),
+		mod("Multiplier:DauntlessMaxDamage", "BASE", nil),
 	},
 },
 #mods


### PR DESCRIPTION
Fixes #1013 .

### Description of the problem being solved:
Dauntless had a GlobalEffect "Buff" for the multiplier. Because of that, it stacked per skill. The issue linked used a crossbow skill which has 2 parts, **Load Fragmentation Rounds** and **Fragmentation Rounds**. If you add another skill like **Arc** with dauntless supporting it, it will further increase the maximum buff for all skills. Removing GlobalEffect makes it just apply locally, and still shows up in the breakdown for more damage. It just doesn't show in the Aura and Buff skills, which it probably shouldn't anyway.

### Before screenshot:
![image](https://github.com/user-attachments/assets/a7f2d42a-1215-4ad4-9a73-9ab435132cf9)
![image](https://github.com/user-attachments/assets/59bd4b53-4078-4562-a143-f75709a9eb25)