### PR TITLE
Rite of Passage and unique fixes

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -23,6 +23,7 @@ do
 	local against = {
 		"Against the Darkness",
 		"Time-Lost Diamond",
+		"Source: Drops from unique{Zarokh, the Temporal}",
 		"Limited to: 1",
 		"Has Alt Variant: true",
 	}

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -181,6 +181,7 @@ Gain an additional Charge when you gain a Charge
 ]],[[
 Stone of Lazhwar
 Lapis Amulet
+League: Dawn of the Hunt
 Implicits: 1
 {tags:attribute}+(10-15) to Intelligence
 {tags:mana}+(50-100) to maximum Mana
@@ -221,6 +222,7 @@ Enemies in your Presence have Fire Exposure
 ]],[[
 Yoke of Suffering
 Bloodstone Amulet
+League: Dawn of the Hunt
 Implicits: 1
 {tags:life}+(30-40) to maximum Life
 {tags:fire,cold,lightning}+(10-15)% to all Elemental Resistances

--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -5,6 +5,7 @@ return {
 [[
 Bijouborne
 Double Belt
+League: Dawn of the Hunt
 Implicits: 2
 +(50-100) to maximum Mana
 Has (1-3) Charm Slot
@@ -49,6 +50,7 @@ You are considered on Low Life while at 75% of maximum Life or below instead
 ]],[[
 The Gnashing Sash
 Wide Belt
+League: Dawn of the Hunt
 Requires Level 60
 Implicits: 2
 Has (1-3) Charm Slot
@@ -60,6 +62,7 @@ Life Recovery from Flasks can Overflow Maximum Life
 ]],[[
 Goregirdle
 Plate Belt
+League: Dawn of the Hunt
 Implicits: 2
 +(100-140) to Armour
 Has (1-3) Charm Slot
@@ -172,6 +175,7 @@ Excess Life Recovery from Leech is applied to Energy Shield
 ]],[[
 Waistgate Heavy Belt
 Heavy Belt
+League: Dawn of the Hunt
 Implicits: 2
 (20-30)% increased Stun Threshold
 Has (1-3) Charm Slot

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -311,6 +311,7 @@ Current Energy Shield also grants Elemental Damage reduction
 ]],[[
 Temporalis
 Silk Robe
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Pre 0.2.0
 Variant: Current
 +(100-150) to maximum Energy Shield

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -158,6 +158,7 @@ Quilted Vest
 ]],[[
 Hyrri's Ire
 Armoured Vest
+League: Dawn of the Hunt
 Implicits: 1
 (30-40)% increased Elemental Ailment Threshold
 (100-130)% increased Evasion Rating
@@ -199,6 +200,7 @@ Scout's Vest
 ]],[[
 Sands of Silk
 Shrouded Vest
+League: Dawn of the Hunt
 (50-100)% increased Evasion Rating
 +(50-80) to maximum Mana
 +(10-20) to Dexterity
@@ -208,6 +210,7 @@ Shrouded Vest
 ]],[[
 Yriel's Fostering
 Strider Vest
+League: Dawn of the Hunt
 (100-150)% increased Evasion Rating
 +(80-120) to maximum Life
 +(10-30) to Spirit
@@ -237,6 +240,7 @@ While not on Full Life, Sacrifice 10% of maximum Mana per Second to Recover that
 ]],[[
 Cloak of Defiance
 Havoc Raiment
+League: Dawn of the Hunt
 (50-100)% increased Energy Shield
 +(100-150) to maximum Mana
 50% increased Mana Regeneration Rate
@@ -267,6 +271,7 @@ Variant: Current
 ]],[[
 Gloamgown
 Elementalist Robe
+League: Dawn of the Hunt
 (100-140)% increased Energy Shield
 +(30-40) to Spirit
 +(25-35)% to Cold Resistance
@@ -294,7 +299,8 @@ Variant: Current
 Energy Shield Recharge is not interrupted by Damage if Recharge began Recently
 ]],[[
 Silks of Veneration
-Havoc Raiment
+Enlightened Robe
+League: Dawn of the Hunt
 Implicits: 1
 (40-50)% increased Mana Regeneration Rate
 +(30-50) to Spirit
@@ -326,6 +332,7 @@ Life Recharges
 ]],[[
 Vis Mortis
 Plated Raiment
+League: Dawn of the Hunt
 (70-100)% increased Energy Shield
 +(70-100) to maximum Mana
 Minions have 50% reduced maximum Life
@@ -362,6 +369,7 @@ Chain Mail
 ]],[[
 The Coming Calamity
 Heroic Armour
+League: Dawn of the Hunt
 Implicits: 4
 Grants Skill: Level (1-20) Herald of Ash
 Grants Skill: Level (1-20) Herald of Ice
@@ -380,6 +388,7 @@ Lightning Resistance does not affect Lightning damage taken
 ]],[[
 The Fallen Formation
 Lamellar Mail
+League: Dawn of the Hunt
 (100-200)% increased Armour and Evasion
 +(20-30) to Strength
 +(20-30) to Dexterity
@@ -425,6 +434,7 @@ Charms use no Charges
 ]],[[
 Widow's Reign
 Knight Armour
+League: Dawn of the Hunt
 (100-150)% increased Armour and Evasion
 +(100-150) to maximum Life
 +(17-23)% to Chaos Resistance
@@ -469,6 +479,7 @@ Freeze as though dealing Cold damage equal to 10% of your maximum Mana when Hit
 ]],[[
 The Mutable Star
 Cleric Vestments
+League: Dawn of the Hunt
 (100-150)% increased Armour and Energy Shield
 (50-100)% increased Energy Shield Recharge Rate
 (25-35) Life Regeneration per second
@@ -478,6 +489,7 @@ Defend against Hits as though you had 1% more Armour per 1% current Energy Shiel
 ]],[[
 Sacrosanctum
 Corvus Mantle
+League: Dawn of the Hunt
 Implicits: 1
 +(20-30) to Spirit
 (80-120)% increased Armour and Energy Shield
@@ -489,6 +501,7 @@ Damage taken Recouped as Life is also Recouped as Energy Shield
 ]],[[
 Soul Mantle
 Sacrificial Mantle
+League: Dawn of the Hunt
 (80-120)% increased Armour and Energy Shield
 +10 to Strength
 +15 to Intelligence
@@ -507,6 +520,7 @@ Variant: Current
 ]],[[
 Waveshaper
 Tideseer Mantle
+League: Dawn of the Hunt
 +(100-200) to maximum Energy Shield
 +(20-40) to Spirit
 +(25-35)% to Fire Resistance
@@ -565,6 +579,7 @@ The Effect of Chill on you is reversed
 ]],[[
 Zerphi's Serape
 Scalper's Jacket
+League: Dawn of the Hunt
 (60-80)% increased Evasion and Energy Shield
 +(40-60) to maximum Mana
 50% increased Attribute Requirements
@@ -630,6 +645,7 @@ Evasion Rating is increased by Overcapped Lightning Resistance
 ]],[[
 Tabula Rasa
 Garment
+League: Dawn of the Hunt
 Sockets: S S S S S S
 Has 6 Rune Sockets
 ]],

--- a/src/Data/Uniques/bow.lua
+++ b/src/Data/Uniques/bow.lua
@@ -17,6 +17,7 @@ Gain (12-18) Mana per Enemy Killed
 ]],[[
 Doomfletch
 Composite Bow
+League: Dawn of the Hunt
 Adds (5-7) to (10-12) Physical Damage
 +10 to Dexterity
 (30-50)% increased Mana Regeneration Rate
@@ -31,6 +32,7 @@ Shortbow
 ]],[[
 Slivertongue
 Zealot Bow
+League: Dawn of the Hunt
 Adds (40-48) to (65-72) Physical Damage
 +(4-6)% to Critical Hit Chance
 Leeches (5-8)% of Physical Damage as Life
@@ -50,6 +52,7 @@ Projectiles Split towards +2 targets
 ]],[[
 Voltaxic Rift
 Fanatic Bow
+League: Dawn of the Hunt
 Adds 1 to (200-300) Lightning Damage
 (10-15)% increased Attack Speed
 100% of Lightning Damage Converted to Chaos Damage

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -27,6 +27,7 @@ Deals 25% of current Mana as Chaos Damage to you when Effect ends
 [[
 Arakaali's Gift
 Antidote Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you become Poisoned
 Recover Life equal to (15-20)% of Mana Flask's Recovery Amount when used
@@ -34,6 +35,7 @@ Recover Mana equal to (15-20)% of Life Flask's Recovery Amount when used
 ]],[[
 Beira's Anguish
 Dousing Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you become Ignited
 (20-25)% Chance to gain a Charge when you Kill an Enemy
@@ -41,6 +43,7 @@ Ignite Enemies in Presence as though dealing Fire damage equal to 500% of your m
 ]],[[
 The Black Cat
 Grounding Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you become Shocked
 (10-20)% increased Duration
@@ -48,6 +51,7 @@ Lightning Damage of Enemies Hitting you is Unlucky during effect
 ]],[[
 Breath of the Mountains
 Sapphire Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you take Cold damage from a Hit
 (10-15)% reduced Charges per use
@@ -55,6 +59,7 @@ Grants a Power Charge on use
 ]],[[
 The Fall of the Axe
 Silver Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you are affected by a Slow
 Grants Onslaught during effect
@@ -67,34 +72,64 @@ Defend with 200% of Armour during effect
 ]],[[
 Forsaken Bangle
 Amethyst Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you take Chaos damage from a Hit
 (15-25)% increased Duration
 50% of Chaos damage you prevent when Hit Recouped as Life and Mana during effect
 ]],[[
 Nascent Hope
-Thawing Charm   
+Thawing Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you become Frozen
 (20-25)% Chance to gain a Charge when you Kill an Enemy
 Energy Shield Recharge starts on use
 ]],[[
 Ngamahu's Chosen
-Ruby Charm   
+Ruby Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you take Fire damage from a Hit
 (30-40)% increased Charges
 Grants up to your maximum Rage on use
 ]],[[
+Rite of Passage
+Golden Charm
+League: Dawn of the Hunt
+Variant: Owl
+Variant: Serpent
+Variant: Primate
+Variant: Bear
+Variant: Boar
+Variant: Ox
+Variant: Wolf
+Variant: Stag
+Variant: Cat
+Implicits: 1
+15% increased Rarity of Items found
+Used when you Kill a Rare or Unique Enemy
+{variant:4}Possessed by Spirit Of The Bear for (10-20) seconds on use
+{variant:5}Possessed by Spirit Of The Boar for (10-20) seconds on use
+{variant:9}Possessed by Spirit Of The Cat for (10-20) seconds on use
+{variant:1}Possessed by Spirit Of The Owl for (10-20) seconds on use
+{variant:6}Possessed by Spirit Of The Ox for (10-20) seconds on use
+{variant:3}Possessed by Spirit Of The Primate for (10-20) seconds on use
+{variant:2}Possessed by Spirit Of The Serpent for (10-20) seconds on use
+{variant:8}Possessed by Spirit Of The Stag for (10-20) seconds on use
+{variant:7}Possessed by Spirit Of The Wolf for (10-20) seconds on use
+]],[[
 Sanguis Heroum
-Staunching Charm   
+Staunching Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you start Bleeding
 Creates Consecrated Ground on use
 Gains (0.15-0.2) Charges per Second
 ]],[[
 Valako's Roar
-Topaz Charm   
+Topaz Charm
+League: Dawn of the Hunt
 Implicits: 1
 Used when you take Lightning damage from a Hit
 (30-40)% increased Charges gained

--- a/src/Data/Uniques/focus.lua
+++ b/src/Data/Uniques/focus.lua
@@ -5,6 +5,7 @@ return {
 [[
 Apep's Supremacy
 Voodoo Focus
+League: Dawn of the Hunt
 (100-200)% increased Energy Shield
 (30-50)% increased Energy Shield Recharge Rate
 (30-50)% faster start of Energy Shield Recharge
@@ -30,6 +31,7 @@ Twig Focus
 ]],[[
 Effigy of Cruelty
 Antler Focus
+League: Dawn of the Hunt
 +(20-30) to maximum Energy Shield
 (60-80)% increased Spell Damage
 +10 to Intelligence
@@ -49,6 +51,7 @@ Variant: Current
 ]],[[
 Rathpith Globe
 Sacred Focus
+League: Dawn of the Hunt
 (60-100)% increased Energy Shield
 +(60-100) to maximum Life
 Non-Channelling Spells cost an additional 6% of your maximum Life

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -15,6 +15,7 @@ Leech from Critical Hits is instant
 ]],[[
 Dreadfist
 Bolstered Mitts
+League: Dawn of the Hunt
 (50-100)% increased Armour
 (20-30)% increased Critical Damage Bonus
 Critical Hits inflict Impale
@@ -40,6 +41,7 @@ Share Charges with Allies in your Presence
 ]],[[
 Empire's Grasp
 Titan Mitts
+League: Dawn of the Hunt
 (150-200)% increased Armour
 +(20-30) to Strength
 Gain (30-50) Life per Enemy Killed
@@ -142,6 +144,7 @@ Variant: Current
 ]],[[
 Essentia Sanguis
 Furtive Wraps
+League: Dawn of the Hunt
 (50-70)% increased Evasion and Energy Shield
 Adds 1 to (30-50) Lightning damage to Attacks
 +(15-25) to Intelligence
@@ -157,6 +160,7 @@ Lightning damage from Hits Contributes to Electrocution Buildup
 ]],[[
 Leopold's Applause
 Embroidered Gloves
+League: Dawn of the Hunt
 (60-100)% increased Energy Shield
 +(60-100) to maximum Mana
 (10-15)% increased Rarity of Items found
@@ -165,6 +169,7 @@ Your Hits can Penetrate Elemental Resistances down to a minimum of -50%
 ]],[[
 Nightscale
 Pauascale Gloves
+League: Dawn of the Hunt
 (60-100)% increased Energy Shield
 (30-50)% increased Critical Hit Chance
 +(10-20) to Intelligence
@@ -203,6 +208,7 @@ Lose 2% of maximum Life on Kill
 ]],[[
 Death Articulated
 Ornate Gauntlets
+League: Dawn of the Hunt
 (100-150)% increased Armour and Evasion
 (5-10)% increased Attack Speed
 +(17-23)% to Chaos Resistance
@@ -232,6 +238,7 @@ Strength can satisfy other Attribute Requirements of Melee Weapons and Melee Ski
 ]],[[
 Valako's Vice
 Plate Gauntlets
+League: Dawn of the Hunt
 (50-100)% increased Armour and Evasion
 (5-10)% increased Attack Speed
 +(20-30) to Strength
@@ -263,6 +270,7 @@ Enemies in your Presence killed by anyone count as being killed by you instead
 ]],[[
 The Prisoner's Manacles
 Diviner Cuffs
+League: Dawn of the Hunt
 (200-300)% increased Armour and Energy Shield
 +100 to maximum Life
 100% increased Attribute Requirements

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -292,6 +292,7 @@ Curses you inflict are reflected back to you
 [[
 Blessed Bonds
 Linen Wraps
+Source: Drops from unique{Zarokh, the Temporal}
 +(60-100) to Evasion Rating
 +(30-50) to maximum Energy Shield
 Gain (25-35) Mana per Enemy Killed

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -173,7 +173,7 @@ League: Dawn of the Hunt
 +(150-200) to Accuracy Rating
 +(10-15) to all Attributes
 -10% to Fire Resistance
-Increases and Reductions to Spell Damage also apply to Attacks at 150% of their value
+Increases and Reductions to Spell damage also apply to Attacks
 ]],[[
 Crown of Thorns
 Twig Circlet

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -219,9 +219,10 @@ Cannot have Energy Shield
 Regenerate 0.05 Life per second per Maximum Energy Shield
 ]],[[
 Sandstorm Visage
+Chain Tiara
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Pre 0.2.0
 Variant: Current
-Chain Tiara
 +(80-120) to maximum Energy Shield
 +(20-30) to Dexterity
 Enemies in your Presence are Blinded

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -13,6 +13,7 @@ Wrapped Greathelm
 ]],[[
 Blood Price
 Fierce Greathelm
+League: Dawn of the Hunt
 (80-120)% increased Armour
 (10-15) Life Regeneration per second
 +(100-150) to Stun Threshold
@@ -85,6 +86,7 @@ Presence Radius is doubled
 ]],[[
 The Black Insignia
 Corsair Cap
+League: Dawn of the Hunt
 (70-100)% increased Evasion Rating
 (10-20)% increased Rarity of Items found
 +(15-25)% to Lightning Resistance
@@ -109,6 +111,7 @@ Felt Cap
 ]],[[
 Heatshiver
 Velvet Cap
+League: Dawn of the Hunt
 (50-70)% increased Evasion Rating
 +(60-100) to maximum Mana
 +(20-30)% to Fire Resistance
@@ -141,6 +144,7 @@ Enemies in your Presence are Ignited as though dealt 100 Base Fire Damage
 ]],[[
 Starkonja's Head
 Leatherbound Hood
+League: Dawn of the Hunt
 (100-200)% increased Evasion Rating
 (15-25)% increased Critical Hit Chance
 +(30-40) to Dexterity
@@ -164,6 +168,7 @@ Variant: Current
 ]],[[
 Crown of Eyes
 Coral Circlet
+League: Dawn of the Hunt
 (100-140)% increased Energy Shield
 +(150-200) to Accuracy Rating
 +(10-15) to all Attributes
@@ -199,6 +204,7 @@ Variant: Current
 ]],[[
 Indigon
 Magus Tiara
+League: Dawn of the Hunt
 (60-100)% increased Energy Shield
 +(80-120) to maximum Mana
 (35-50)% increased Cost of Skills for each 200 total Mana Spent Recently
@@ -224,6 +230,7 @@ Enemies in your Presence are Blinded
 ]],[[
 Scold's Bridle
 Jade Tiara
+League: Dawn of the Hunt
 +(75-150) to maximum Energy Shield
 (60-100)% increased Spell Damage
 +(80-100) to maximum Mana
@@ -252,6 +259,7 @@ Skills have a (100-150)% longer Perfect Timing window
 ]],[[
 The Bringer of Rain
 Decorated Helm
+League: Dawn of the Hunt
 (600-800)% increased Armour and Evasion
 +(200-300) to Accuracy Rating
 (30-60) Life Regeneration per second
@@ -370,6 +378,7 @@ Gain 10 Mana per Enemy Killed
 ]],[[
 The Deepest Tower
 Spiritbone Crown
+League: Dawn of the Hunt
 (70-130)% increased Armour and Energy Shield
 +(70-100) to maximum Life
 +(17-23)% to Chaos Resistance

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -29,6 +29,7 @@ Culling Strike against Frozen Enemies
 ]],[[
 Mjölner
 Torment Club
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Lightning Spell on Hit
 +200 Intelligence Requirement
@@ -39,6 +40,7 @@ Grants Skill: Level (1-20) Lightning Spell on Hit
 ]],[[
 Nebuloch
 Brigand Mace
+League: Dawn of the Hunt
 Adds (39-48) to (69-79) Physical Damage
 +(20-30)% to Critical Damage Bonus
 Adds (25-36) to (44-55) Chaos damage
@@ -59,6 +61,7 @@ the enemy's Power for 6 seconds, up to a total of 500
 ]],[[
 Sculpted Suffering
 Warpick
+League: Dawn of the Hunt
 Implicits: 1
 +(10-15)% to Critical Damage Bonus
 Adds (21-26) to (25-31) Physical Damage
@@ -129,6 +132,7 @@ Increases and Reductions to Minion Damage also affect you
 ]],[[
 The Empty Roar
 Cultist Greathammer
+League: Dawn of the Hunt
 Implicits: 1
 Strikes deal Splash damage to targets within 1.5 metres
 Adds (25-35) to (40-50) Physical Damage
@@ -139,6 +143,7 @@ Cannot use Warcries
 ]],[[
 The Hammer of Faith
 Giant Maul
+League: Dawn of the Hunt
 (200-250)% increased Physical Damage
 10% reduced Attack Speed
 +10% to all Elemental Resistances
@@ -180,6 +185,7 @@ Critical Hits do not deal extra Damage
 ]],[[
 Tidebreaker
 Pointed Maul
+League: Dawn of the Hunt
 (120-150)% increased Physical Damage
 +(2-3) to Level of all Melee Skills
 +(20-30) to Intelligence
@@ -198,6 +204,7 @@ Always deals Critical Hits against Heavy Stunned Enemies
 ]],[[
 Shyaba
 Temple Maul
+League: Dawn of the Hunt
 +50 Dexterity Requirement
 -15 Strength Requirement
 (80-120)% increased Physical Damage

--- a/src/Data/Uniques/quiver.lua
+++ b/src/Data/Uniques/quiver.lua
@@ -39,6 +39,7 @@ Attacks Gain (5-10)% of Damage as Extra Fire Damage
 ]],[[
 The Lethal Draw
 Sacral Quiver
+League: Dawn of the Hunt
 Implicits: 1
 Gain (2-3) Life per Enemy Hit with Attacks
 (5-10)% increased Attack Speed
@@ -48,6 +49,7 @@ Bow Attacks consume 10% of your maximum Life Flask Charges if possible to deal a
 ]],[[
 Rearguard
 Blunt Quiver
+League: Dawn of the Hunt
 Implicits: 1
 (20-30)% reduced Enemy Stun Threshold
 Adds (7-11) to (14-20) Physical Damage to Attacks

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -230,13 +230,16 @@ Implicits: 1
 ]],[[
 Sekhema's Resolve
 Ring
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Ruby
 Variant: Emerald
 Variant: Sapphire
 Requires Level 40
 (10-20)% increased Rarity of Items found
 {tags:attribute}+(10-20) to all Attributes
-Lightning Resistance is unaffected by Area Penalties
+{variant:2}Cold Resistance is unaffected by Area Penalties
+{variant:1}Fire Resistance is unaffected by Area Penalties
+{variant:3}Lightning Resistance is unaffected by Area Penalties
 {variant:2}You can only Socket Emerald Jewels in this item
 {variant:1}You can only Socket Ruby Jewels in this item
 {variant:3}You can only Socket Sapphire Jewels in this item

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -53,16 +53,6 @@ Implicits: 1
 {variant:2}{tags:mana}(30-50)% increased Mana Regeneration Rate
 {tags:lightning}Lightning Damage of Enemies Hitting you is Unlucky
 ]],[[
-Bursting Decay
-Unset Ring
-League: Dawn of the Hunt
-Implicits: 1
-Grants 1 additional Skill Slot
-(15-25)% increased Rarity of Items found
-{tags:chaos}+(17-23)% to Chaos Resistance
-Lose 5% of maximum Life per second
-Attacks have added Physical damage equal to 3% of maximum Life
-]],[[
 Call of the Brotherhood
 Topaz Ring
 Requires Level 32

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -53,6 +53,16 @@ Implicits: 1
 {variant:2}{tags:mana}(30-50)% increased Mana Regeneration Rate
 {tags:lightning}Lightning Damage of Enemies Hitting you is Unlucky
 ]],[[
+Bursting Decay
+Unset Ring
+League: Dawn of the Hunt
+Implicits: 1
+Grants 1 additional Skill Slot
+(15-25)% increased Rarity of Items found
+{tags:chaos}+(17-23)% to Chaos Resistance
+Lose 5% of maximum Life per second
+Attacks have added Physical damage equal to 3% of maximum Life
+]],[[
 Call of the Brotherhood
 Topaz Ring
 Requires Level 32
@@ -102,6 +112,7 @@ You cannot be Chilled or Frozen
 ]],[[
 Evergrasping Ring
 Pearl Ring
+League: Dawn of the Hunt
 Implicits: 1
 {tags:caster,speed}(7-10)% increased Cast Speed
 {tags:mana}+(60-100) to maximum Mana
@@ -110,6 +121,7 @@ Implicits: 1
 ]],[[
 Gifts from Above
 Prismatic Ring
+League: Dawn of the Hunt
 Implicits: 1
 {tags:fire,cold,lightning}+(7-10)% to all Elemental Resistances
 (20-30)% increased Critical Hit Chance
@@ -137,6 +149,7 @@ Minions Revive (10-15)% faster
 ]],[[
 Icefang Orbit
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 36
 Implicits: 1
 {tags:physical,attack}Adds 1 to 4 Physical Damage to Attacks
@@ -197,6 +210,7 @@ Enemies Chilled by your Hits can be Shattered as though Frozen
 ]],[[
 Prized Pain
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 48
 Implicits: 1
 {tags:physical,attack}Adds 1 to 4 Physical Damage to Attacks
@@ -252,6 +266,7 @@ Can't use other Rings
 ]],[[
 Venopuncture
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 36
 Implicits: 1
 {tags:physical,attack}Adds 1 to 4 Physical Damage to Attacks
@@ -279,6 +294,7 @@ Implicits: 1
 ]],[[
 Vigilant View
 Emerald Ring
+League: Dawn of the Hunt
 Requires Level 26
 Implicits: 1
 {tags:attack}+(120-160) to Accuracy Rating

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -5,6 +5,7 @@ return {
 [[
 Chernobog's Pillar
 Blacksteel Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 (100-150)% increased Armour
@@ -52,6 +53,7 @@ Accuracy Rating is Doubled
 ]],[[
 Redblade Banner
 Heraldric Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 (20-30)% increased Block chance
@@ -91,6 +93,7 @@ Cannot use Shield Skills
 ]],[[
 Window to Paradise
 Barricade Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 (60-120)% increased Armour
@@ -112,6 +115,7 @@ Permanently Intimidate enemies on Block
 [[
 Bloodbarrier
 Iron Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 (20-30)% increased Block chance
@@ -122,6 +126,7 @@ your maximum Life as Physical damage per second
 ]],[[
 Calgyra's Arc
 Ornate Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 (60-100)% increased Evasion Rating
@@ -132,6 +137,7 @@ Infinite Projectile Parry Range
 ]],[[
 Dunkelhalt
 Leather Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 (30-50)% increased Block chance
@@ -141,6 +147,7 @@ You take 50% of damage from Blocked Hits
 ]],[[
 Nocturne
 Wooden Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 +(60-80) to maximum Mana
@@ -151,6 +158,7 @@ Parried enemies take more Spell Damage instead of more Attack Damage
 ]],[[
 Rondel de Ezo
 Plated Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 (50-150)% increased Evasion Rating
@@ -161,6 +169,7 @@ Curse Enemies with Enfeeble on Block
 ]],[[
 Silverthorne
 Spiked Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 (50-80)% increased Evasion Rating
@@ -170,6 +179,7 @@ Parrying applies 10 Stacks of Critical Weakness
 ]],[[
 Sunsplinter
 Array Buckler
+League: Dawn of the Hunt
 Has Alt Variant: true
 Selected Variant: 1
 Selected Alt Variant: 7
@@ -317,6 +327,7 @@ Grants Skill: Raise Shield
 ]],[[
 Prism Guardian
 Sectarian Crest Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 (80-150)% increased Armour and Energy Shield

--- a/src/Data/Uniques/spear.lua
+++ b/src/Data/Uniques/spear.lua
@@ -5,6 +5,7 @@ return {
 [[
 Chainsting
 Hunting Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 (15-25)% chance to Maim on Hit
@@ -16,6 +17,7 @@ All Damage from Hits with this Weapon Contributes to Pin Buildup
 ]],[[
 Daevata's Wind
 War Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 (25-35)% increased Projectile Speed with this Weapon
@@ -27,6 +29,7 @@ Adds (10-15) to (21-26) Physical Damage
 ]],[[
 Saitha's Spear
 Barbed Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 Adds (14-26) to (27-32) Physical Damage
@@ -37,6 +40,7 @@ Aggravating any Bleeding with this Weapon also Aggravates all Ignites on the tar
 ]],[[
 Splinter of Loratta
 Hardwood Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 Adds (2-3) to (6-8) Physical Damage
@@ -46,6 +50,7 @@ Always Poison on Hit with this weapon
 ]],[[
 Skysliver
 Winged Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 No Physical Damage
@@ -56,6 +61,7 @@ Rolls only the minimum or maximum Damage value for each Damage Type
 ]],[[
 Spire of Ire
 Helix Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 Grants Skill: Level (1-20) Chaotic Infusion
@@ -67,6 +73,7 @@ Life Leech recovers based on your Chaos damage instead of Physical damage
 ]],[[
 Tangletongue
 Forked Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 Adds (14-18) to (30-36) Physical Damage
@@ -77,6 +84,7 @@ Forks Critical Hits
 ]],[[
 Tyranny's Grip
 Ironhead Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 (150-200)% increased Physical Damage

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -43,6 +43,7 @@ Grants Skill: Level (1-20) Living Bomb
 ]],[[
 Sire of Shards
 Chiming Staff
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Sigil of Power
 (80-120)% increased Spell Damage

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -5,6 +5,7 @@ return {
 [[
 Cursecarver
 Acrid Wand
+League: Dawn of the Hunt
 Variant: Flammability
 Variant: Hypothermia
 Variant: Conductivity
@@ -55,6 +56,7 @@ Gain (10-15) Life per Enemy Killed
 ]],[[
 The Wicked Quill
 Withered Wand
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Chaos Bolt
 (60-100)% increased Spell Damage

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -181,6 +181,7 @@ UniqueAdditionalChargeGeneration1
 ]],[[
 Stone of Lazhwar
 Lapis Amulet
+League: Dawn of the Hunt
 Implicits: 1
 AmuletImplicitIntelligence1
 UniqueIncreasedMana3
@@ -221,6 +222,7 @@ UniqueEnemiesInPresenceFireExposure1
 ]],[[
 Yoke of Suffering
 Bloodstone Amulet
+League: Dawn of the Hunt
 Implicits: 1
 AmuletImplicitIncreasedLife1
 UniqueAllResistances19

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -5,6 +5,7 @@ return {
 [[
 Bijouborne
 Double Belt
+League: Dawn of the Hunt
 Implicits: 2
 BeltImplicitCharmSlots3
 UniqueIncreasedMana51
@@ -49,6 +50,7 @@ UniqueLowLifeThreshold1
 ]],[[
 The Gnashing Sash
 Wide Belt
+League: Dawn of the Hunt
 Requires Level 60
 Implicits: 2
 BeltImplicitCharmSlots3
@@ -60,6 +62,7 @@ UniqueLifeFlasksOvercapLife1
 ]],[[
 Goregirdle
 Plate Belt
+League: Dawn of the Hunt
 Implicits: 2
 BeltImplicitCharmSlots3
 BeltImplicitPhysicalDamageReductionRating1
@@ -172,6 +175,7 @@ UniqueLifeLeechExcessToEnergyShield1
 ]],[[
 Waistgate Heavy Belt
 Heavy Belt
+League: Dawn of the Hunt
 Implicits: 2
 BeltImplicitCharmSlots3
 BeltImplicitIncreasedStunThreshold1

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -304,6 +304,7 @@ UniqueEnergyShieldAppliesElementalReduction1
 ]],[[
 Temporalis
 Silk Robe
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Pre 0.2.0
 Variant: Current
 UniqueLocalIncreasedEnergyShield9

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -154,6 +154,7 @@ UniqueGlobalEvasionOnFullLife1
 ]],[[
 Hyrri's Ire
 Armoured Vest
+League: Dawn of the Hunt
 Implicits: 1
 BodyArmourImplicitIncreasedAilmentThreshold1
 UniqueLocalIncreasedEvasionRatingPercent33
@@ -193,6 +194,7 @@ UniqueFireDamageTakenAsPhysical1
 ]],[[
 Sands of Silk
 Shrouded Vest
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent20
 UniqueIncreasedMana38
 UniqueDexterity2
@@ -202,6 +204,7 @@ GlobalCooldownRecoveryUnique__2
 ]],[[
 Yriel's Fostering
 Strider Vest
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent32
 UniqueIncreasedLife53
 UniqueIncreasedSpirit12
@@ -230,6 +233,7 @@ UniqueDrainManaHealLife1
 ]],[[
 Cloak of Defiance
 Havoc Raiment
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent14
 UniqueIncreasedMana20
 UniqueManaRegeneration29
@@ -260,6 +264,7 @@ UniqueChaosResist4
 ]],[[
 Gloamgown
 Elementalist Robe
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent16
 UniqueIncreasedSpirit10
 UniqueColdResist31
@@ -287,7 +292,8 @@ UniqueEnergyShieldDelay2
 UniqueRechargeNotInterruptedRecently1
 ]],[[
 Silks of Veneration
-Havoc Raiment
+Enlightened Robe
+League: Dawn of the Hunt
 Implicits: 1
 BodyArmourImplicitManaRegeneration1
 UniqueIncreasedSpirit11
@@ -319,6 +325,7 @@ UniqueLifeRecharge1
 ]],[[
 Vis Mortis
 Plated Raiment
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent22
 UniqueIncreasedMana43
 UniqueMinionLife5
@@ -355,6 +362,7 @@ UniqueReceiveBleedingWhenHit1
 ]],[[
 The Coming Calamity
 Heroic Armour
+League: Dawn of the Hunt
 Implicits: 4
 Grants Skill: Level (1-20) Herald of Ash
 Grants Skill: Level (1-20) Herald of Ice
@@ -373,6 +381,7 @@ UniqueLightningResistNoReduction1
 ]],[[
 The Fallen Formation
 Lamellar Mail
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEvasion29
 UniqueStrength20
 UniqueDexterity37
@@ -418,6 +427,7 @@ UniqueCharmsNoCharges1
 ]],[[
 Widow's Reign
 Knight Armour
+League: Dawn of the Hunt
 (100-150)% increased Armour and Evasion
 +(100-150) to maximum Life
 +(17-23)% to Chaos Resistance
@@ -462,6 +472,7 @@ UniqueFreezeDamageMaximumMana1
 ]],[[
 The Mutable Star
 Cleric Vestments
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEnergyShield20
 UniqueEnergyShieldRechargeRate5
 UniqueLifeRegeneration22
@@ -471,6 +482,7 @@ UniqueDefendWithArmourPerEnergyShield1
 ]],[[
 Sacrosanctum
 Corvus Mantle
+League: Dawn of the Hunt
 Implicits: 1
 BodyArmourImplicitIncreasedSpirit1
 UniqueLocalIncreasedArmourAndEnergyShield23
@@ -482,6 +494,7 @@ UniqueLifeRecoupAppliesToEnergyShield1
 ]],[[
 Soul Mantle
 Sacrificial Mantle
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEnergyShield12
 UniqueStrength42
 UniqueIntelligence40
@@ -500,6 +513,7 @@ UniquePowerChargeOnCritChance1
 ]],[[
 Waveshaper
 Tideseer Mantle
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShield16
 UniqueIncreasedSpirit9
 UniqueFireResist30
@@ -557,6 +571,7 @@ UniqueReverseChill1
 ]],[[
 Zerphi's Serape
 Scalper's Jacket
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionAndEnergyShield11
 UniqueIncreasedMana7
 UniqueReducedLocalAttributeRequirements4
@@ -622,6 +637,7 @@ UniqueEvasionOvercappedLightningResistance1
 ]],[[
 Tabula Rasa
 Garment
+League: Dawn of the Hunt
 Sockets: S S S S S S
 Has 6 Rune Sockets
 ]],

--- a/src/Export/Uniques/bow.lua
+++ b/src/Export/Uniques/bow.lua
@@ -17,6 +17,7 @@ UniqueManaGainedFromEnemyDeath6
 ]],[[
 Doomfletch
 Composite Bow
+League: Dawn of the Hunt
 UniqueLocalAddedPhysicalDamage7
 UniqueDexterity4
 UniqueManaRegeneration3
@@ -31,6 +32,7 @@ UniqueWeaponDamageFinalPercent1
 ]],[[
 Slivertongue
 Zealot Bow
+League: Dawn of the Hunt
 UniqueLocalAddedPhysicalDamage14
 UniqueLocalCriticalStrikeChance6
 UniqueLifeLeechLocal1
@@ -50,6 +52,7 @@ UniqueProjectilesSplitCount1
 ]],[[
 Voltaxic Rift
 Fanatic Bow
+League: Dawn of the Hunt
 UniqueLocalAddedLightningDamage6
 UniqueLocalIncreasedAttackSpeed17
 UniqueLightningDamageConvertToChaos1

--- a/src/Export/Uniques/flask.lua
+++ b/src/Export/Uniques/flask.lua
@@ -26,6 +26,7 @@ UniqueFlaskTakeDamageWhenEnds1
 [[
 Arakaali's Gift
 Antidote Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnPoison1
 UniqueCharmRecoverLifeBasedOnManaFlask1
@@ -33,6 +34,7 @@ UniqueCharmRecoverManaBasedOnLifeFlask1
 ]],[[
 Beira's Anguish
 Dousing Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnIgnite1
 UniqueFlaskChanceRechargeOnKill2
@@ -40,6 +42,7 @@ UniqueCharmIgniteEnemiesInPresence1
 ]],[[
 The Black Cat
 Grounding Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnShock1
 UniqueCharmIncreasedDuration2
@@ -47,6 +50,7 @@ UniqueCharmEnemyExtraLightningDamageRoll1
 ]],[[
 Breath of the Mountains
 Sapphire Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnColdDamage1
 UniqueFlaskChargesUsed2
@@ -54,6 +58,7 @@ UniqueCharmGrantsPowerCharge1
 ]],[[
 The Fall of the Axe
 Silver Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnSlow1
 UniqueCharmOnslaughtDuringEffect1
@@ -66,34 +71,64 @@ UniqueCharmDoubleArmourEffect1
 ]],[[
 Forsaken Bangle
 Amethyst Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnChaosDamage1
 UniqueCharmIncreasedDuration1
 UniqueCharmRecoupChaosDamagePrevented1
 ]],[[
 Nascent Hope
-Thawing Charm   
+Thawing Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnFreeze1
 UniqueFlaskChanceRechargeOnKill1
 UniqueCharmStartEnergyShieldRecharge1
 ]],[[
 Ngamahu's Chosen
-Ruby Charm   
+Ruby Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnFireDamage1
 UniqueFlaskExtraCharges1
 UniqueCharmGrantsMaximumRage1
 ]],[[
+Rite of Passage
+Golden Charm
+League: Dawn of the Hunt
+Variant: Owl
+Variant: Serpent
+Variant: Primate
+Variant: Bear
+Variant: Boar
+Variant: Ox
+Variant: Wolf
+Variant: Stag
+Variant: Cat
+Implicits: 1
+15% increased Rarity of Items found
+CharmImplicitUseOnRareUniqueKill1
+{variant:1}UniqueCharmOwlPossess1
+{variant:2}UniqueCharmSerpentPossess1
+{variant:3}UniqueCharmPrimatePossess1
+{variant:4}UniqueCharmBearPossess1
+{variant:5}UniqueCharmBoarPossess1
+{variant:6}UniqueCharmOxPossess1
+{variant:7}UniqueCharmWolfPossess1
+{variant:8}UniqueCharmStagPossess1
+{variant:9}UniqueCharmCatPossess1
+]],[[
 Sanguis Heroum
-Staunching Charm   
+Staunching Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnBleed1
 UniqueCharmCreateConsecratedGround1
 UniqueFlaskFillChargesPerMinute1
 ]],[[
 Valako's Roar
-Topaz Charm   
+Topaz Charm
+League: Dawn of the Hunt
 Implicits: 1
 CharmImplicitUseOnLightningDamage1
 UniqueFlaskChargesAddedPercent1

--- a/src/Export/Uniques/focus.lua
+++ b/src/Export/Uniques/focus.lua
@@ -5,6 +5,7 @@ return {
 [[
 Apep's Supremacy
 Voodoo Focus
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent13
 UniqueEnergyShieldRechargeRate7
 UniqueEnergyShieldDelay5
@@ -30,6 +31,7 @@ UniqueEnergyShieldRechargeOnKill1
 ]],[[
 Effigy of Cruelty
 Antler Focus
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShield14
 UniqueSpellDamageOnWeapon5
 UniqueIntelligence41
@@ -49,6 +51,7 @@ RingImplicitLightningResistance1
 ]],[[
 Rathpith Globe
 Sacred Focus
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent21
 UniqueIncreasedLife50
 UniqueNonChannellingSpellLifeCost1

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -292,6 +292,7 @@ UniqueReflectCurseToSelf1
 [[
 Blessed Bonds
 Linen Wraps
+Source: Drops from unique{Zarokh, the Temporal}
 UniqueLocalBaseEvasionRatingAndEnergyShield1
 UniqueManaGainedFromEnemyDeath8
 UniqueColdExposureOnIgnite1

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -15,6 +15,7 @@ UniqueCriticalStrikesLeechIsInstant1
 ]],[[
 Dreadfist
 Bolstered Mitts
+League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent10
 UniqueCriticalMultiplier2
 UniqueImpaleOnCriticalHit1
@@ -40,6 +41,7 @@ UniqueShareChargesWithAllies1
 ]],[[
 Empire's Grasp
 Titan Mitts
+League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent30
 UniqueStrength23
 UniqueLifeGainedFromEnemyDeath11
@@ -142,6 +144,7 @@ AmuletImplicitIntelligence1
 ]],[[
 Essentia Sanguis
 Furtive Wraps
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionAndEnergyShield17
 UniqueAddedLightningDamage3
 UniqueIntelligence31
@@ -157,6 +160,7 @@ UniqueLightningDamageCanElectrocute1
 ]],[[
 Leopold's Applause
 Embroidered Gloves
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent1
 UniqueIncreasedMana12
 UniqueItemFoundRarityIncrease21
@@ -165,6 +169,7 @@ UniqueElementalPenetrationBelowZero1
 ]],[[
 Nightscale
 Pauascale Gloves
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent26
 UniqueCriticalStrikeChance14
 UniqueIntelligence29
@@ -203,6 +208,7 @@ UniqueMaximumLifeOnKillPercent1
 ]],[[
 Death Articulated
 Ornate Gauntlets
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEvasion26
 UniqueIncreasedAttackSpeed8
 UniqueChaosResist25
@@ -232,6 +238,7 @@ UniqueStrengthSatisfiesAllWeaponRequirements1
 ]],[[
 Valako's Vice
 Plate Gauntlets
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEvasion23
 UniqueIncreasedAttackSpeed9
 UniqueStrength41
@@ -263,6 +270,7 @@ UniqueEnemiesKilledCountAsYours1
 ]],[[
 The Prisoner's Manacles
 Diviner Cuffs
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEnergyShield21
 UniqueIncreasedLife54
 UniqueReducedLocalAttributeRequirements5

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -13,6 +13,7 @@ UniquePercentageIntelligence1
 ]],[[
 Blood Price
 Fierce Greathelm
+League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent29
 UniqueEnemiesInPresenceReservesLife1
 UniqueLifeRegeneration18
@@ -85,6 +86,7 @@ UniqueDoublePresenceRadius1
 ]],[[
 The Black Insignia
 Corsair Cap
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent24
 UniqueItemFoundRarityIncrease14
 UniqueLightningResist24
@@ -109,6 +111,7 @@ UniqueAllResistances1
 ]],[[
 Heatshiver
 Velvet Cap
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent31
 UniqueIncreasedMana45
 UniqueFireResist33
@@ -141,6 +144,7 @@ UniqueIgniteEnemiesInPresence1
 ]],[[
 Starkonja's Head
 Leatherbound Hood
+League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent26
 UniqueCriticalStrikeChance13
 UniqueDexterity38
@@ -164,6 +168,7 @@ Variant: Current
 ]],[[
 Crown of Eyes
 Coral Circlet
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent23
 UniqueIncreasedAccuracy9
 UniqueAllAttributes7
@@ -199,6 +204,7 @@ UniqueLightRadius1
 ]],[[
 Indigon
 Magus Tiara
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent20
 UniqueIncreasedMana49
 UniqueSpellDamagePerManaSpent1
@@ -224,6 +230,7 @@ UniqueEnemiesInPresenceBlinded1
 ]],[[
 Scold's Bridle
 Jade Tiara
+League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShield17
 UniqueSpellDamage3
 UniqueIncreasedMana28
@@ -252,6 +259,7 @@ UniquePerfectTimingWindow1
 ]],[[
 The Bringer of Rain
 Decorated Helm
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEvasion27
 UniqueIncreasedAccuracy11
 UniqueLifeRegeneration16
@@ -370,6 +378,7 @@ UniqueGlobalSkillGemLevel1
 ]],[[
 The Deepest Tower
 Spiritbone Crown
+League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEnergyShield18
 UniqueIncreasedLife46
 UniqueChaosResist14

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -173,7 +173,7 @@ UniqueLocalIncreasedEnergyShieldPercent23
 UniqueIncreasedAccuracy9
 UniqueAllAttributes7
 UniqueFireResist9
-SpellDamageModifiersApplyToAttackDamageUniqueHelmetInt7
+UniqueSpellDamageModifiersApplyToAttackDamage1
 ]],[[
 Crown of Thorns
 Twig Circlet

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -219,9 +219,10 @@ UniqueCannotGainEnergyShield1
 UniqueLifeRegenPerEnergyShield1
 ]],[[
 Sandstorm Visage
+Chain Tiara
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Pre 0.2.0
 Variant: Current
-Chain Tiara
 UniqueLocalIncreasedEnergyShield8
 UniqueDexterity3
 UniqueEnemiesInPresenceBlinded1

--- a/src/Export/Uniques/mace.lua
+++ b/src/Export/Uniques/mace.lua
@@ -29,6 +29,7 @@ UniqueLocalCullingStrikeFrozenEnemies1
 ]],[[
 Mjölner
 Torment Club
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Lightning Spell on Hit
 UniqueIntelligenceRequirements2
@@ -39,6 +40,7 @@ UniqueGlobalLightningGemLevel2
 ]],[[
 Nebuloch
 Brigand Mace
+League: Dawn of the Hunt
 UniqueLocalAddedPhysicalDamage17
 UniqueLocalCriticalMultiplier2
 UniqueLocalChaosDamage1
@@ -58,6 +60,7 @@ UniqueMaximumLightningDamagePerPower1
 ]],[[
 Sculpted Suffering
 Warpick
+League: Dawn of the Hunt
 Implicits: 1
 MaceImplicitCriticalMultiplier1
 UniqueLocalAddedPhysicalDamage18
@@ -128,6 +131,7 @@ UniqueMinionDamageAffectsYou1
 ]],[[
 The Empty Roar
 Cultist Greathammer
+League: Dawn of the Hunt
 Implicits: 1
 MaceImplicitSplashDamage1
 UniqueLocalAddedPhysicalDamage15
@@ -138,6 +142,7 @@ UniqueCannotUseWarcries1
 ]],[[
 The Hammer of Faith
 Giant Maul
+League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamagePercent9
 UniqueLocalIncreasedAttackSpeed14
 UniqueAllResistances21
@@ -179,6 +184,7 @@ UniqueLocalNoCriticalStrikeMultiplier1
 ]],[[
 Tidebreaker
 Pointed Maul
+League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamagePercent13
 UniqueGlobalIncreaseMeleeSkillGemLevel1
 UniqueIntelligence39
@@ -197,6 +203,7 @@ UniqueAlwaysCritHeavyStun1
 ]],[[
 Shyaba
 Temple Maul
+League: Dawn of the Hunt
 UniqueDexterityRequirements1
 UniqueStrengthRequirements1
 UniqueLocalIncreasedPhysicalDamagePercent5

--- a/src/Export/Uniques/quiver.lua
+++ b/src/Export/Uniques/quiver.lua
@@ -39,6 +39,7 @@ UniqueDamageAddedAsFireAttacks1
 ]],[[
 The Lethal Draw
 Sacral Quiver
+League: Dawn of the Hunt
 Implicits: 1
 QuiverImplicitLifeGainPerTarget1
 UniqueIncreasedAttackSpeed5
@@ -48,6 +49,7 @@ UniqueBowDamageFromLifeFlaskCharges1
 ]],[[
 Rearguard
 Blunt Quiver
+League: Dawn of the Hunt
 Implicits: 1
 QuiverImplicitStunThresholdReduction1
 UniqueAddedPhysicalDamage5

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -53,6 +53,16 @@ UniqueLightningResist4
 {variant:2}UniqueManaRegeneration27
 UniqueEnemyExtraDamageRollsWithLightningDamage1
 ]],[[
+Bursting Decay
+Unset Ring
+League: Dawn of the Hunt
+Implicits: 1
+RingImplicitAdditionalSkillSlots1
+UniqueItemFoundRarityIncrease22
+UniqueChaosResist17
+UniqueLifeDegenerationPercentGracePeriod3
+UniquePhysicalDamageMaximumLife1
+]],[[
 Call of the Brotherhood
 Topaz Ring
 Requires Level 32
@@ -102,6 +112,7 @@ UniqueCannotBeChilledOrFrozen1
 ]],[[
 Evergrasping Ring
 Pearl Ring
+League: Dawn of the Hunt
 Implicits: 1
 RingImplicitIncreasedCastSpeed1
 UniqueIncreasedMana12
@@ -110,6 +121,7 @@ UniqueEnemiesInPresenceGainedAsChaos1
 ]],[[
 Gifts from Above
 Prismatic Ring
+League: Dawn of the Hunt
 Implicits: 1
 RingImplicitAllResistances1
 UniqueCriticalStrikeChance12
@@ -137,6 +149,7 @@ UniqueMinionReviveSpeed2
 ]],[[
 Icefang Orbit
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 36
 Implicits: 1
 RingImplicitPhysicalDamage1
@@ -197,6 +210,7 @@ UniqueChillHitsCauseShattering1
 ]],[[
 Prized Pain
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 48
 Implicits: 1
 RingImplicitPhysicalDamage1
@@ -252,6 +266,7 @@ UniqueSelfCurseDuration1
 ]],[[
 Venopuncture
 Iron Ring
+League: Dawn of the Hunt
 Requires Level 36
 Implicits: 1
 RingImplicitPhysicalDamage1
@@ -279,6 +294,7 @@ UniqueLightningResist18
 ]],[[
 Vigilant View
 Emerald Ring
+League: Dawn of the Hunt
 Requires Level 26
 Implicits: 1
 RingImplicitIncreasedAccuracy1

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -230,13 +230,16 @@ UniqueManaCostReduction2
 ]],[[
 Sekhema's Resolve
 Ring
+Source: Drops from unique{Zarokh, the Temporal}
 Variant: Ruby
 Variant: Emerald
 Variant: Sapphire
 Requires Level 40
 UniqueItemFoundRarityIncrease20
 UniqueAllAttributes1
-UniqueLightningResistanceNoPenalty1
+{variant:1}UniqueFireResistanceNoPenalty1
+{variant:2}UniqueColdResistanceNoPenalty1
+{variant:3}UniqueLightningResistanceNoPenalty1
 {variant:1}UniqueOnlySocketRubyJewel1
 {variant:2}UniqueOnlySocketEmeraldJewel1
 {variant:3}UniqueOnlySocketSapphireJewel1

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -53,16 +53,6 @@ UniqueLightningResist4
 {variant:2}UniqueManaRegeneration27
 UniqueEnemyExtraDamageRollsWithLightningDamage1
 ]],[[
-Bursting Decay
-Unset Ring
-League: Dawn of the Hunt
-Implicits: 1
-RingImplicitAdditionalSkillSlots1
-UniqueItemFoundRarityIncrease22
-UniqueChaosResist17
-UniqueLifeDegenerationPercentGracePeriod3
-UniquePhysicalDamageMaximumLife1
-]],[[
 Call of the Brotherhood
 Topaz Ring
 Requires Level 32

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -5,6 +5,7 @@ return {
 [[
 Chernobog's Pillar
 Blacksteel Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent28
@@ -52,6 +53,7 @@ UniqueDoubleAccuracyRating1
 ]],[[
 Redblade Banner
 Heraldric Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 UniqueLocalBlockChance14
@@ -91,6 +93,7 @@ UniqueDisableShieldSkills1
 ]],[[
 Window to Paradise
 Barricade Tower Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent25
@@ -111,6 +114,7 @@ UniqueEnemiesBlockedAreIntimidated1
 [[
 Bloodbarrier
 Iron Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueLocalBlockChance14
@@ -120,6 +124,7 @@ UniqueApplyCorruptedBloodOnBlock1
 ]],[[
 Calgyra's Arc
 Ornate Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueLocalIncreasedEvasionRatingPercent28
@@ -130,6 +135,7 @@ UniqueParriedDebuffDuration1
 ]],[[
 Dunkelhalt
 Leather Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueLocalBlockChance9
@@ -139,6 +145,7 @@ UniqueParriedDebuffMagnitude1
 ]],[[
 Nocturne
 Wooden Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueIncreasedMana44
@@ -149,6 +156,7 @@ UniqueParriedDebuffDuration2
 ]],[[
 Rondel de Ezo
 Plated Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueLocalIncreasedEvasionRatingPercent27
@@ -159,6 +167,7 @@ UniqueEnfeebleOnBlockChance1
 ]],[[
 Silverthorne
 Spiked Buckler
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
 UniqueLocalIncreasedEvasionRatingPercent29
@@ -168,6 +177,7 @@ UniqueParryDamage1
 ]],[[
 Sunsplinter
 Array Buckler
+League: Dawn of the Hunt
 Has Alt Variant: true
 Selected Variant: 1
 Selected Alt Variant: 7
@@ -291,6 +301,7 @@ UniqueChaosResist1
 ]],[[
 Prism Guardian
 Sectarian Crest Shield
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Raise Shield
 UniqueLocalIncreasedArmourAndEnergyShield22

--- a/src/Export/Uniques/spear.lua
+++ b/src/Export/Uniques/spear.lua
@@ -5,6 +5,7 @@ return {
 [[
 Chainsting
 Hunting Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 SpearImplicitLocalChanceToMaim1
@@ -16,6 +17,7 @@ UniqueLocalIncreasedProjectileSpeed1
 ]],[[
 Daevata's Wind
 War Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 SpearImplicitLocalProjectileSpeed1
@@ -27,6 +29,7 @@ UniqueProjectileDamageIfMeleeHitRecently1
 ]],[[
 Saitha's Spear
 Barbed Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalAddedPhysicalDamage20
@@ -37,6 +40,7 @@ UniqueLocalChanceToAggravateBleed1
 ]],[[
 Splinter of Loratta
 Hardwood Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalAddedPhysicalDamage3
@@ -46,6 +50,7 @@ UniqueLocalPoisonOnHit1
 ]],[[
 Skysliver
 Winged Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalNoWeaponPhysicalDamage1
@@ -56,6 +61,7 @@ UniqueLocalAlwaysMinimumOrMaximum1
 ]],[[
 Spire of Ire
 Helix Spear
+League: Dawn of the Hunt
 Implicits: 2
 Grants Skill: Spear Throw
 Grants Skill: Level (1-20) Chaotic Infusion
@@ -67,6 +73,7 @@ UniqueLifeLeechChaosDamage1
 ]],[[
 Tangletongue
 Forked Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalAddedPhysicalDamage21
@@ -77,6 +84,7 @@ UniqueLifeCost2
 ]],[[
 Tyranny's Grip
 Ironhead Spear
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalIncreasedPhysicalDamagePercent11

--- a/src/Export/Uniques/staff.lua
+++ b/src/Export/Uniques/staff.lua
@@ -43,6 +43,7 @@ UniqueIgniteEffect2
 ]],[[
 Sire of Shards
 Chiming Staff
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Sigil of Power
 UniqueSpellDamageOnWeapon7

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -5,6 +5,7 @@ return {
 [[
 Cursecarver
 Acrid Wand
+League: Dawn of the Hunt
 Variant: Flammability
 Variant: Hypothermia
 Variant: Conductivity
@@ -55,6 +56,7 @@ UniqueSpellLifeCostPercent1
 ]],[[
 The Wicked Quill
 Withered Wand
+League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Level (1-20) Chaos Bolt
 UniqueSpellDamageOnWeapon6


### PR DESCRIPTION
Fixes #1029
### Description of the problem being solved:
Added two more 0.2.0 Uniques that weren't found until after original PR. Also added League setting for all (I hope) Uniques from 0.2.0. And fixed Silks of Veneration base body armour.

Rite of Passage
15% increased Rarity of Items found
Is not in ModItemExclusive, so it's just kept as pure modifier text for now.

Fixed Sekhema's Resolve rings all using the same area modifier.