### PR TITLE
Fix Eternal Life chaos damage resource drain breakdown

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -548,7 +548,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 				esPoolRemaining = m_min(esPoolRemaining, energyShield)
 				damageRemainder = damageRemainder - tempDamage
 				resourcesLostToTypeDamage[damageType].energyShield = tempDamage >= 1 and tempDamage * (1 - esBypass) * esDamageTypeMultiplier or nil
-				resourcesLostToTypeDamage[damageType].eternalLifePrevented = tempDamage >= 1 and tempDamage * esBypass * esDamageTypeMultiplier or nil
+				resourcesLostToTypeDamage[damageType].eternalLifePrevented = tempDamage >= 1 and tempDamage * esBypass or nil
 			elseif energyShield > 0 and esBypass < 1 then
 				local MoMEBPool = esBypass > 0 and m_min((MoMPool + lifeHitPool) / esBypass * esDamageTypeMultiplier - (MoMPool + lifeHitPool), energyShield) or energyShield
 				local tempDamage = m_min(damageRemainder * (1 - esBypass), MoMEBPool / esDamageTypeMultiplier)


### PR DESCRIPTION
A breakdown-specific variable was calculated incorrectly (doubled) for chaos damage