### PR TITLE
Fix modifers to Blashpemy Spirit reservation applying to supported curses

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -866,7 +866,7 @@ skills["BlasphemyPlayer"] = {
 			statDescriptionScope = "skill_stat_descriptions",
 			statMap = {
 				["blasphemy_base_spirit_reservation_per_socketed_curse"] = {
-					mod("SkillData", "LIST", { key = "spiritReservationFlat", value = nil })
+					mod("SkillData", "LIST", { key = "blasphemyReservationFlatSpirit", value = nil })
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -80,7 +80,7 @@ statMap = {
 #flags area
 statMap = {
 	["blasphemy_base_spirit_reservation_per_socketed_curse"] = {
-		mod("SkillData", "LIST", { key = "spiritReservationFlat", value = nil })
+		mod("SkillData", "LIST", { key = "blasphemyReservationFlatSpirit", value = nil })
 	},
 },
 #mods

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -210,7 +210,7 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 				if activeSkill.skillData[name.."ReservationFlatForced"] then
 					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
 				else
-					local baseFlatVal = values.baseFlat
+					local baseFlatVal = values.baseFlat * mult
 					values.reservedFlat = 0
 					if values.more > 0 and values.inc > -100 and baseFlatVal ~= 0 then
 						values.reservedFlat = m_max(m_ceil(baseFlatVal * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
@@ -232,17 +232,19 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 				if activeSkill.skillTypes[SkillType.MultipleReservation] then
 					local activeSkillCount, enabled = calcs.getActiveSkillCount(activeSkill)
 					local minionFreeSpiritCount = skillModList:Sum("BASE", skillCfg, "MinionFreeSpiritCount")
-					values.reservedFlat = values.reservedFlat * mult * m_max(activeSkillCount - minionFreeSpiritCount, 0)
+					values.reservedFlat = values.reservedFlat * m_max(activeSkillCount - minionFreeSpiritCount, 0)
 				end
-				
-				if activeSkill.skillTypes[SkillType.IsBlasphemy] and activeSkill.activeEffect.srcInstance.supportEffect and activeSkill.activeEffect.srcInstance.supportEffect.isSupporting then
+				if activeSkill.skillTypes[SkillType.IsBlasphemy] and activeSkill.activeEffect.srcInstance.supportEffect and activeSkill.activeEffect.srcInstance.supportEffect.isSupporting and activeSkill.skillData["blasphemyReservationFlat" .. name] then
 					-- Sadly no better way to get key/val table element count in lua.
 					local instances = 0
 					for _ in pairs(activeSkill.activeEffect.srcInstance.supportEffect.isSupporting) do
 						instances = instances + 1
 					end
-					values.reservedFlat = values.reservedFlat * instances * mult
-					values.reservedPercent = values.reservedPercent * instances * mult
+
+					-- Extra reservation of blasphemy needs to be seperated from the reservation caused by curses
+					local blashpemyFlat = activeSkill.skillData["blasphemyReservationFlat" .. name]
+					local blasphemyEffectiveFlat = m_max(m_ceil(blashpemyFlat * mult * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
+					values.reservedFlat = values.reservedFlat + blasphemyEffectiveFlat * instances
 				end
 					-- Blood Sacrament increases reservation per stage channelled
 				if activeSkill.skillCfg.skillName == "Blood Sacrament" and activeSkill.activeStageCount then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -241,9 +241,9 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 						instances = instances + 1
 					end
 
-					-- Extra reservation of blasphemy needs to be seperated from the reservation caused by curses
-					local blashpemyFlat = activeSkill.skillData["blasphemyReservationFlat" .. name]
-					local blasphemyEffectiveFlat = m_max(m_ceil(blashpemyFlat * mult * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
+					-- Extra reservation of blasphemy needs to be separated from the reservation caused by curses
+					local blasphemyFlat = activeSkill.skillData["blasphemyReservationFlat" .. name]
+					local blasphemyEffectiveFlat = m_max(m_ceil(blasphemyFlat * mult * (100 + values.inc) / 100 * values.more / (1 + values.efficiency / 100), 0), 0)
 					values.reservedFlat = values.reservedFlat + blasphemyEffectiveFlat * instances
 				end
 					-- Blood Sacrament increases reservation per stage channelled


### PR DESCRIPTION
Fixes #934

### Description of the problem being solved:

Modifiers to base blasphemy reservation such as the one from clarity were applying to the reservation caused by supported curses. Additionally this makes the reservation multiplier apply to all reservationFlat values without the need for special handling.

### Link to a build that showcases this PR:
```
eNq9G2tv2zjyc_MrCAMLtNhL_EicNoHThWMnTYA8XDtp7z4VjETbvFCSK1FJvIv97zdDUg-7pkwlh-2HVhbnzZnhzFDt_fESCPLE4oRH4UmjvddqEBZ6kc_D2Unj_u5891Pjj887vRGV89vpacoFrnQ-77zrqR9EsCcmALFBPEGT5IYG7KQxpuGMxQ1CE4-F_qBYuIlC1iCSxjMmv2VMWz8Qe05j6kkWXyHBfiqj68gHDBmngBFQHk4i75HJL3GULhS_J86eNczl9eh2fNcAod71RoIuWTyRVJIE_jpp9EE5OmMXXAIKFSnAtxrNStjTNE7kkAbwuB1nsmDM3w42iLm8ToXkC8HRNAa-Y4MHeQdzGnqFBO2WlfhdJKkYjibbxdCQkYMtvnM5PxWgmxNdhL6chVwyZ_BRxJMorCW1E_AgFQJ81Al2zBIWP1HJHQUZRMEDDx1tck1DOogS6QY5YjEEi6yFMGFeBPFVl0dNzCs-Ze6QtfQwCHWleZ0eZxNXuNqEXyfQGBKMG-QkSoUjpCySy0cb0JC9FGmlaw-On2XAfSu5y1Bu5wnUynCdVtcu3VOEEemYF84uRjlkt7W33z48_Php_6h7cHRowxvNlwn3qLimLzxIA8i1d_SRFQwPu3bvm81lCOnFhnpgZXrOY1YfaxAJ_xVYcxol9bUb0vgxZEnimjghETpjYNw6iADHqXeMsJehV2xrFdH7MDbCOO3flI0hRPGgfxDMEaNgYQLd5VDWrGYsNPyWbja6Ysybf4F6Z0wlc0vrhUN8qjQrwpbNWkl0g1nt5FcRahgJETcbaX-vXYVU00yTBY-5k0QacoP2R64Y6-pbEc9CFs-WkzlnwqGCLENn1hrQhVOF6h2XsZ18YJVdLTcuo9bcJzwS63J7okn5tNjfYggN7hYHDApgQPDZWi1uxRjF0X-ZJ7moh9aPgyiNHbdSAzspkB10upkZMz_13E7Ws-kU1XhipwLaLlc1ciyQU4haqH0pqfc4jPyZs9EUk1oYq_JN0sUCYha9wZUAnuFw9PFSJbZ74AB9C67sFKt43LszKKCdGeQFjDuXNRR3XbAIWWPjAuzMIN_Oa0gVAaRc1YtfR0UytR4h59AkOjVxCtCx8xxFzyD5HKcbST1oKNWK_GUVJWbhn0tn-ivgTgzOQj-NMRCceaxjbGJzmk6nCfGgc6byCrb3pNEgD_BOPw8EhcMT0ryXxgnT74YsWVAe_4sMoJXCjPWEEJraHQ8gKSfJkEpKfNMpfAMaNJQdNRdKGI29OVI6p0I8QFZBjsVb_LWG2M48pddUUy18ugwWUSwJe8F_RjSWy5PGlIqEaUD1BugkkodqfgApTIgGmcyj577_hDa5iyKRZEiELhYs9Fdo3MWMEZolJA-FUDriDxLQRML5p308QaFL07RLHzeFhBEIgF3PQfcIVcTWk8bL_ipgyEEuCbxKE7eOmddpQsj1Xe9-fKUe3s2lXCTHzebz8_Pegsp5NGUvcKLtwR42F4AE8u4mj1yIXaTa7MOf01lf_VGEmhmlnp7ZJU39CwM75iCyZtODnB_zh1SybAHs-XKjdWoQHsr8OZFx9mxoNVeI9ZpoM7WBaFR8uImkXsOX2Y_eBMVOSAJ7-oUFyekSAvsc65S12Y7ZFYSeMKn9qoyTDSZ9NqWpwPdfUyo4Okmr_PZKj0fDKA7ydhNIgZPg6aMp3i0XqFn_6spsv-FKuJ-5hHmp5qD9QrQBFV6ihOOhJ1IfmiaT2MyuC_qA7HGmi-2OX56nlujkbN71QB4D_EVED1R0MhQz6O20Givr7Wz9SYcSOtQpeNZizgKIauUmK-90DmmQnyV7zViAMNdMUh_iunkpwc5NNHZTyQdPJZohDUy8lF6uKehFaSjz_P9_0svkpZJW5s0rdcrpFRrlr96qT3u7Oib1GkcsaWXemPW6yuV-naf2Qr381T-hHh4oOn3aVSxgXq3mBcP6iEHmUNTK6hZLxKz9E266cmoWKpdfv9JhVymXtnXlfbWOPU3NZG2T6lTm1rkZH1VeUxCX4SKVitNJI-CJ9wMrB7z1UWeCuqQ6Oz8_G9xdfjszFUIZRSn_I0yDB9RW_1tUhROmuiGSpA-JfjxpfOPsWQkyBDtwkaD8QtBFwvKzW-VlI7kAvApqCuqC55dJm2kVAHZKZy8shlJj9h3KmJgzq1z5-hahNENssbGislHDmyI7Id2zDaBQ0c29xVLqgsxOBW_GrOrgYgUuFGlUWDmb1S2WkHj8ghvzKfewtK3ecjysNVSFXTwoZqm3rNhv03DaaairNxsBvWhH1ldrNmyzWmFVdZFntapetaMPmUetuutFO3I-L4pCdWW7mUoOVUHpJgqVk0PQ9LnA9tC6s2eC5SB2grdyzmJTj9soXUOOykAqA0cXvlY6JYgKW6mRusVCuGZH1WNjiw64VhE0ZpRqi3ZeHbKrQ0_LfpRh7KT0uMBqQzN6qNgGM3WzbIFerdAkGzxalDDLFYGicnD_KeK-Hj9ZQmYNrCppQL_1djJqpvZ2MutDtrdTPId6_9G632bVjn4vOVY7G6joSsWJCAbW2yhgfL2NAk5bgldjj9dLkQJ3XF2E5HOhjcjZalXsm3HRqynoodar0dXM7dXY6gAYsikDDSpPgBymIjhkGg7BGLIiMBxJKbE2Z5FCu1q09Fm4UdPaFHV0mxvoqgSgQbYQgsP8oqJcdKOUz40vGBX4IVIk3kbwl5v2txDDm690QUM_I3e7qUgv9sHRepFMgKYabw7xgu2tNgxZsNxAyC5Xr5m1dWrwiY2WmcpOZIwzqj-jKPiPakXxyUzO9s20DEruIYd9i5W_ZXwQ8N_ZfLqnOlYzusPnfHJnJ5AmTH-x853RRRQqDJyc6U4SaGSNNX6qVx7IjdUg45jc31x-vT_buYaOYEl3BnDU4d0v-ZrSWLI4kXQ63TFT5mMyihlp7bX32sWrQRqDRHJHt5LMJ_lKZ8eMFOGxtaPMMWY_1Q9obAT3IA6OSWvnLyPhcefvv2L88PK4tdf9u-_7CXl_uHv0gciIvG-3dtvdDwQvjIjemCq8tsY52u0Aen79kyMW0L-_39_tfvgNwbFTw6tGAm5LdHtThnzf7u52WgDKQy9mFHyF6PaRqP5wBbTT3T1YBcUjk6h7YaZTJsGOc8dMc83FO-m2fiN4N0B0EaqmDdeRr75GJYo-uMpeN9tHM4-wQnS2QuxvhTjYCtHdCpF95aMmMrlj4oDY5r2rk2MRSQIdWzB6uB9fYaDp2cgXAd0_BC8u6WuAZjWCZkLaBUrbEaVTg8sYPW2_BsJpFMnXqEEmz3jJ6IzXD1LBZF1N6qiuyrpaumuM-jza9e3VqWuvUybqWEuVrbUEu2BQptTekHYt1_KXJOsSa2ry66boAM6mneqwUsPOKJzymTm29A9zcCmk_M1KUI8E9dgcsjmLDVeGB7L5GD0bdH5s5cJaEFbu6DO0bUj5iZCNNTPEo8PuNn5x8V17hlWBM5lDQzvBYyL5ZXxr5wFv6kuGH2vUx1LHcoHwqWOHD_Kv__Hrd6hDfKXYAMfjcPpPSwp2HTRc37Su866NsELN0PZdsWrzy8cjuXEOtjFb_Vypll-hH6-j7X86dHBHZAg5Tn3Guu5qnW1KDsEmq968FQU3z3ULCp_BfjFk-OEfVIti6RQNJY_DW4HlfVKTQB4YdTZ_4kWqpncO2oTPuLidqt4c0NSAwVW4LDnnPtY63OZk5ls4aFlUuVXOlg7e8ouPtRzM57rdgzleKm22HLRP2Umgmyn16_NOr_nL_836H-MWh-Q=
```