### PR TITLE
Added area tag to flicker strike

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -7590,6 +7590,7 @@ skills["FlickerStrikePlayer"] = {
 			baseFlags = {
 				attack = true,
 				melee = true,
+				area = true,
 			},
 			constantStats = {
 				{ "flicker_strike_additional_flickers_from_power_charges", 2 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -488,7 +488,7 @@ statMap = {
 
 #skill FlickerStrikePlayer
 #set FlickerStrikePlayer
-#flags attack melee
+#flags attack melee area
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #1027 

### Description of the problem being solved:
in PoB conc effect didnt work on flicker strike because it was missing the "area" tag in the template file.

### Steps taken to verify a working solution:
- checked in pob
- export skillgems works without errors

### Link to a build that showcases this PR:
https://pobb.in/6KsPwgiyZpU6

### Before screenshot:
![image](https://github.com/user-attachments/assets/f04583b7-b140-41ce-a12a-d89ac4b241c8)

### After screenshot:
![image](https://github.com/user-attachments/assets/cd6d5d4d-6b80-44e7-b520-f33b96550c24)
