### PR TITLE
Add support for bleed and poison chance on critical hit calculation

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4603,12 +4603,15 @@ function calcs.offence(env, actor, activeSkill)
 				output[flatAilment.."ChanceOnCrit"] = 0
 				skillFlags["inflict"..flatAilment] = false
 			else
-				local base = skillModList:Sum("BASE", cfg, flatAilment.."Chance", "AilmentChance") + enemyDB:Sum("BASE", nil, "Self"..flatAilment.."Chance")
-				local inc = skillModList:Sum("INC", cfg, flatAilment.."Chance", "AilmentChance")
-				local more = skillModList:More(cfg, flatAilment.."Chance", "AilmentChance")
-				local chance = m_min(100, base * (1 + inc / 100) * more)
-				output[flatAilment.."ChanceOnHit"] = chance
-				output[flatAilment.."ChanceOnCrit"] = chance
+				for _, val in pairs({"OnHit", "OnCrit"}) do
+					local critCfg = cfg
+					critCfg.skillCond.CriticalStrike = val == "OnCrit" -- force crit config to be true for "OnCrit" chance calculation
+					local base = skillModList:Sum("BASE", critCfg, flatAilment.."Chance", "AilmentChance") + enemyDB:Sum("BASE", nil, "Self"..flatAilment.."Chance")
+					local inc = skillModList:Sum("INC", critCfg, flatAilment.."Chance", "AilmentChance")
+					local more = skillModList:More(critCfg, flatAilment.."Chance", "AilmentChance")
+					local chance = m_min(100, skillModList:Override(critCfg, flatAilment .. "Chance") or (base * (1 + inc / 100) * more))
+					output[flatAilment.."Chance" .. val] = chance
+				end
 				skillFlags["inflict"..flatAilment] = true
 			end
 		end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4604,7 +4604,7 @@ function calcs.offence(env, actor, activeSkill)
 				skillFlags["inflict"..flatAilment] = false
 			else
 				for _, val in pairs({"OnHit", "OnCrit"}) do
-					local critCfg = cfg
+					local critCfg = copyTable(cfg,true)
 					critCfg.skillCond.CriticalStrike = val == "OnCrit" -- force crit config to be true for "OnCrit" chance calculation
 					local base = skillModList:Sum("BASE", critCfg, flatAilment.."Chance", "AilmentChance") + enemyDB:Sum("BASE", nil, "Self"..flatAilment.."Chance")
 					local inc = skillModList:Sum("INC", critCfg, flatAilment.."Chance", "AilmentChance")


### PR DESCRIPTION
### Description of the problem being solved:
- Mods that grant ailment chance for critical strikes only, were previously parsed, but not actually accounted for in chance calculations for poison and bleed. Now they are accounted for.
- Example: "10% chance to inflict Bleeding on Critical Hit with Attacks" from "Perfectly Placed Knife" passive tree cluster
- Also keeps the `"OVERRIDE"` check for ailment (bleed/poison) chance that is introduced in #1054 

### Steps taken to verify a working solution:
- Only counted on Crit
- Correctly displayed in breakdown

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/yj1he083

### After screenshot:
Bleed
![image](https://github.com/user-attachments/assets/31a99251-09d3-402f-b297-22fd1eaa1242)

Poison
![image](https://github.com/user-attachments/assets/a0a9f956-6957-4c28-a564-1225bd7b6399)
