### PR TITLE
Add support for Voltaic Mark shock effect

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -9121,7 +9121,10 @@ skills["VoltaicMarkPlayer"] = {
 			statDescriptionScope = "thaumaturgist_mark",
 			statMap = {
 				["thaumaturgist_mark_enemies_shocked_chance_+%_final"] = {
-					mod("EnemyShockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+					mod("SelfShockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+				},
+				["thaumaturgist_mark_enemy_shock_effect_+%_taken"] = {
+					mod("SelfShockMagnitude", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -609,7 +609,10 @@ statMap = {
 #flags spell
 statMap = {
 	["thaumaturgist_mark_enemies_shocked_chance_+%_final"] = {
-		mod("EnemyShockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+		mod("SelfShockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+	},
+	["thaumaturgist_mark_enemy_shock_effect_+%_taken"] = {
+		mod("SelfShockMagnitude", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
 	},
 },
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4640,8 +4640,8 @@ function calcs.offence(env, actor, activeSkill)
 			local hitAvg = hitMin + (hitMax - hitMin) / 2
 			local critAvg = critMin + (critMax - critMin) / 2
 			local base = skillModList:Sum("BASE", cfg, "Enemy"..ailment.."Chance", "AilmentChance") + enemyDB:Sum("BASE", nil, "Self"..ailment.."Chance")
-			local inc = skillModList:Sum("INC", cfg, "Enemy"..ailment.."Chance", "AilmentChance")
-			local more = skillModList:More(cfg, "Enemy"..ailment.."Chance", "AilmentChance")
+			local inc = skillModList:Sum("INC", cfg, "Enemy"..ailment.."Chance", "AilmentChance") + enemyDB:Sum("INC", nil, "Self"..ailment.."Chance")
+			local more = skillModList:More(cfg, "Enemy"..ailment.."Chance", "AilmentChance") * enemyDB:More(nil, "Self"..ailment.."Chance")
 			local hitElementalAilmentChance = hitAvg / enemyThreshold * data.gameConstants[ailment .. "ChanceMultiplier"]
 			hitElementalAilmentChance = (hitElementalAilmentChance + base) * (1 + inc / 100) * more
 			local critElementalAilmentChance = critAvg / enemyThreshold * data.gameConstants[ailment .. "ChanceMultiplier"]
@@ -4742,7 +4742,7 @@ function calcs.offence(env, actor, activeSkill)
 					local incDur = skillModList:Sum("INC", cfg, "Enemy"..ailment.."Duration", "EnemyElementalAilmentDuration", "EnemyAilmentDuration") + enemyDB:Sum("INC", nil, "Self"..ailment.."Duration", "SelfElementalAilmentDuration", "SelfAilmentDuration")
 					local moreDur = skillModList:More(cfg, "Enemy"..ailment.."Duration", "EnemyElementalAilmentDuration", "EnemyAilmentDuration") * enemyDB:More(nil, "Self"..ailment.."Duration", "SelfElementalAilmentDuration", "SelfAilmentDuration")
 					output[ailment.."Duration"] = ailmentData[ailment].duration * (1 + incDur / 100) * moreDur * debuffDurationMult
-					output[ailment.."EffectMod"] = calcLib.mod(skillModList, cfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude")
+					output[ailment.."EffectMod"] = calcLib.mod(skillModList, cfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, cfg, "Self"..ailment.."Magnitude", "AilmentMagnitude")
 					if breakdown then
 						local maximum = globalOutput["Maximum"..ailment] or ailmentData[ailment].max
 						local current = m_max(m_min(globalOutput["Current"..ailment] or 0, maximum), 0)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2813,9 +2813,9 @@ function calcs.perform(env, skipEHP)
 					-- if not, use the generic modifiers
 					-- Scorch/Sap/Brittle do not have guaranteed sources from hits, and therefore will only end up in this bit of code if it's not supposed to apply the skillModList, which is bad
 					if ailment ~= "Scorch" and ailment ~= "Sap" and ailment ~= "Brittle" and not env.player.mainSkill.skillModList:Flag(nil, "Cannot"..ailment) and hitFlag and modDB:Flag(nil, "ChecksHighestDamage") then
-						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude")
+						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self"..ailment.."Magnitude", "AilmentMagnitude")
 					else
-						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude")
+						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self"..ailment.."Magnitude", "AilmentMagnitude")
 					end
 					modDB:NewMod(ailment.."Override", "BASE", effect, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 					if mod.name == ailment.."Minimum" then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1289,7 +1289,7 @@ return {
 		{ label = "Player modifiers", notFlag = "attack", modName = { "EnemyShockMagnitude", "AilmentMagnitude", "ShockAsThoughDealing" }, cfg = "skill" },
 		{ label = "Main hand modifiers", flag = "weapon1Attack", modName = { "EnemyShockMagnitude", "AilmentMagnitude", "ShockAsThoughDealing" }, cfg = "weapon1" },
 		{ label = "Off hand modifiers", flag = "weapon2Attack", modName = { "EnemyShockMagnitude", "AilmentMagnitude", "ShockAsThoughDealing" }, cfg = "weapon2" },
-		{ label = "Enemy modifiers", modName = "SelfShockEffect", enemy = true },
+		{ label = "Enemy modifiers", modName = "SelfShockMagnitude", enemy = true },
 	}, },
 	{ label = "Chance to Shock", bgCol = colorCodes.SHOCKBG, flag = "shock", { format = "{0:output:ShockChance}%",
 		{ breakdown = "MainHand.ShockChance" },


### PR DESCRIPTION
Fixes #1060.

### Description of the problem being solved:
Voltaic Mark shock effect mod was not yet implemented, and the Shock Chance mod was not applying. Had to make a few changes to calcs with help from @LocalIdentity.

![image](https://github.com/user-attachments/assets/b87276e1-ab44-4002-b7db-d60c6898c6bf)
![image](https://github.com/user-attachments/assets/6ab90f79-b55a-4027-b79d-3b6ebd2cb14b)
![image](https://github.com/user-attachments/assets/b9f402de-01b6-4515-9596-8ce1e587f390)

Wish they would decide on magnitude or effect. Kinda awkward with mod names at the moment. I didn't touch SelfShockEffect for the player as they seem to use effect more often in that case.

### After screenshot:
![image](https://github.com/user-attachments/assets/c89287d1-fb87-4a33-8216-ebc96599b840)
![image](https://github.com/user-attachments/assets/12cb50d2-4205-4fb2-a973-e949c1e8d97a)
