### PR TITLE
Fix crash when deleting newly created config set

### DIFF
--- a/src/Classes/ConfigSetListControl.lua
+++ b/src/Classes/ConfigSetListControl.lua
@@ -52,7 +52,7 @@ function ConfigSetListClass:RenameSet(configSet, addOnName)
 		if addOnName then
 			t_insert(self.list, configSet.id)
 			self.selIndex = #self.list
-			self.selValue = configSet
+			self.selValue = configSet.id
 		end
 		self.configTab:AddUndoState()
 		self.configTab.build:SyncLoadouts()


### PR DESCRIPTION
Fixes #1077

### Description of the problem being solved:

Creating a new config set would save the entire table into self.selValue which is then later used as an index. Since the configSets table is indexed by ids instead it returns null and causes a crash.

This pr simply makes the save button function save the id instead of the full table. This also makes the newly created config set highlight nicely.

### Link to a build that showcases this PR:

See reproduction steps in issue

### Before screenshot:

![obraz](https://github.com/user-attachments/assets/ee5c4c4c-e017-4938-a0a8-bef85e08eec3)

### After screenshot:

![obraz](https://github.com/user-attachments/assets/b71e2e24-24a3-458b-a1f5-3a4924219979)
