### PR TITLE
Fix crash due to outdated state of sub skill dropdown

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1394,12 +1394,12 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 	for i, socketGroup in pairs(self.skillsTab.socketGroupList) do
 		controls.mainSocketGroup.list[i] = { val = i, label = socketGroup.displayLabel }
 	end
-  controls.mainSocketGroup:CheckDroppedWidth(true)
+	controls.mainSocketGroup:CheckDroppedWidth(true)
 	if controls.warnings then controls.warnings.shown = #controls.warnings.lines > 0 end
+	controls.statSet.shown = false
 	if #controls.mainSocketGroup.list == 0 then
 		controls.mainSocketGroup.list[1] = { val = 1, label = "<No skills added yet>" }
 		controls.mainSkill.shown = false
-		controls.statSet.shown = false
 		controls.mainSkillPart.shown = false
 		controls.mainSkillMineCount.shown = false
 		controls.mainSkillStageCount.shown = false


### PR DESCRIPTION
Fixes #1076

### Description of the problem being solved:
The only logic handling hiding of the sub skill dropdown was for when there are no skill groups. Otherwise it was always set to true after being set for the first time.

This pr makes the sub skill drop down default to false inside of the `buildMode:RefreshSkillSelectControls` function.
