### PR TITLE
Fix Against the Darkness using Medium radius instead of small

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -33,7 +33,7 @@ do
 	local variantCount = #against
 	table.insert(against, "Selected Variant: 1")
 	table.insert(against, "Selected Alt Variant: 2")
-	table.insert(against, "Radius: Medium")
+	table.insert(against, "Radius: Small")
 	table.insert(against, "Implicits: 0")
 	local smallLine = "Small Passive Skills in Radius also grant "
 	local notableLine = "Notable Passive Skills in Radius also grant "


### PR DESCRIPTION
The patch notes for 0.2.0 were wrong and it was meant to say that the jewel now uses a small radius instead of large
Fixes #1109