### PR TITLE
Add support for "Hazard" related mods

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -3731,9 +3731,8 @@ c["Enemies Hitting you have 10% chance to gain an Endurance,  Frenzy or Power Ch
 c["Enemies Ignited by you have -5% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Ignited"},flags=0,keywordFlags=0,name="FireResist",type="BASE",value=-5}}}},nil}
 c["Enemies Ignited by you take Chaos Damage instead of Fire Damage from Ignite"]={{[1]={flags=0,keywordFlags=0,name="IgniteToChaos",type="FLAG",value=true}},nil}
 c["Enemies Immobilised by you take 25% less Damage"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Immobilised"},flags=0,keywordFlags=0,name="DamageTaken",type="MORE",value=-25}}}},nil}
-c["Enemies affected by your Hazards Recently have 25% reduced Armour"]={nil,"your Hazards Recently have 25% reduced Armour "}
-c["Enemies affected by your Hazards Recently have 25% reduced Armour Enemies affected by your Hazards Recently have 25% reduced Evasion Rating"]={nil,"your Hazards Recently have 25% reduced Armour Enemies affected by your Hazards Recently have 25% reduced Evasion Rating "}
-c["Enemies affected by your Hazards Recently have 25% reduced Evasion Rating"]={nil,"your Hazards Recently have 25% reduced Evasion Rating "}
+c["Enemies affected by your Hazards Recently have 25% reduced Armour"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="ActorCondition",var="AffectedByHazardRecently"},flags=0,keywordFlags=0,name="Armour",type="INC",value=-25}}}},nil}
+c["Enemies affected by your Hazards Recently have 25% reduced Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="ActorCondition",var="AffectedByHazardRecently"},flags=0,keywordFlags=0,name="Evasion",type="INC",value=-25}}}},nil}
 c["Enemies are Culled on Block"]={nil,"Enemies are Culled on Block "}
 c["Enemies have Maximum Concentration equal to 40% of their Maximum Life"]={nil,"Enemies have Maximum Concentration equal to 40% of their Maximum Life "}
 c["Enemies have Maximum Concentration equal to 40% of their Maximum Life Break enemy Concentration on Hit equal to 100% of Damage Dealt"]={nil,"Enemies have Maximum Concentration equal to 40% of their Maximum Life Break enemy Concentration on Hit equal to 100% of Damage Dealt "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4036,8 +4036,8 @@ c["Has 2 Charm Slots"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BAS
 c["Has 3 Charm Slot"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BASE",value=3}},nil}
 c["Has 3 Charm Slots"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BASE",value=3}},nil}
 c["Has 6 Rune Sockets"]={nil,"Has 6 Rune Sockets "}
-c["Hazards have 15% chance to rearm after they are triggered"]={nil,"Hazards have 15% chance to rearm after they are triggered "}
-c["Hazards have 5% chance to rearm after they are triggered"]={nil,"Hazards have 5% chance to rearm after they are triggered "}
+c["Hazards have 15% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Multiplier:ChanceToRearm",type="BASE",value=15}},nil}
+c["Hazards have 5% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Multiplier:ChanceToRearm",type="BASE",value=5}},nil}
 c["Herald Skills deal 20% increased Damage"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=20}},nil}
 c["Herald Skills deal 30% increased Damage"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=30}},nil}
 c["Herald Skills have 30% increased Area of Effect"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=30}},nil}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4035,8 +4035,8 @@ c["Has 2 Charm Slots"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BAS
 c["Has 3 Charm Slot"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BASE",value=3}},nil}
 c["Has 3 Charm Slots"]={{[1]={flags=0,keywordFlags=0,name="CharmLimit",type="BASE",value=3}},nil}
 c["Has 6 Rune Sockets"]={nil,"Has 6 Rune Sockets "}
-c["Hazards have 15% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Multiplier:ChanceToRearm",type="BASE",value=15}},nil}
-c["Hazards have 5% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Multiplier:ChanceToRearm",type="BASE",value=5}},nil}
+c["Hazards have 15% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="HazardRearmChance",type="BASE",value=15}},nil}
+c["Hazards have 5% chance to rearm after they are triggered"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="HazardRearmChance",type="BASE",value=5}},nil}
 c["Herald Skills deal 20% increased Damage"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=20}},nil}
 c["Herald Skills deal 30% increased Damage"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=30}},nil}
 c["Herald Skills have 30% increased Area of Effect"]={{[1]={[1]={skillType=52,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=30}},nil}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1374,7 +1374,7 @@ c["16% increased Cast Speed if you've dealt a Critical Hit Recently"]={{[1]={[1]
 c["16% increased Critical Damage Bonus with Bows"]={{[1]={flags=131076,keywordFlags=0,name="CritMultiplier",type="INC",value=16}},nil}
 c["16% increased Critical Hit Chance for Spells"]={{[1]={flags=2,keywordFlags=0,name="CritChance",type="INC",value=16}},nil}
 c["16% increased Damage with Warcries"]={{[1]={flags=0,keywordFlags=4,name="Damage",type="INC",value=16}},nil}
-c["16% increased Hazard Damage"]={{[1]={flags=0,keywordFlags=0,name="Damage",type="INC",value=16}}," Hazard  "}
+c["16% increased Hazard Damage"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=16}},nil}
 c["16% increased Mana Regeneration Rate while not on Low Mana"]={{[1]={[1]={neg=true,type="Condition",var="LowMana"},flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=16}},nil}
 c["16% increased Mana Regeneration Rate while stationary"]={{[1]={[1]={type="Condition",var="Stationary"},flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=16}},nil}
 c["16% increased Melee Damage"]={{[1]={flags=256,keywordFlags=0,name="Damage",type="INC",value=16}},nil}
@@ -1523,7 +1523,7 @@ c["20% increased Freeze Buildup with Quarterstaves"]={{}," Freeze Buildup  "}
 c["20% increased Freeze Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyFreezeDuration",type="INC",value=20}},nil}
 c["20% increased Frenzy Charge Duration"]={{[1]={flags=0,keywordFlags=0,name="FrenzyChargesDuration",type="INC",value=20}},nil}
 c["20% increased Global Physical Damage"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=20}},nil}
-c["20% increased Hazard Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=20}}," Hazard  "}
+c["20% increased Hazard Duration"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
 c["20% increased Hinder Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=20}}," Hinder  "}
 c["20% increased Ignite Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=20}},nil}
 c["20% increased Knockback Distance"]={{[1]={flags=0,keywordFlags=0,name="EnemyKnockbackDistance",type="INC",value=20}},nil}
@@ -2282,7 +2282,7 @@ c["5% increased Cast Speed"]={{[1]={flags=16,keywordFlags=0,name="Speed",type="I
 c["5% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=5}},nil}
 c["5% increased Cooldown Recovery Rate"]={{[1]={flags=0,keywordFlags=0,name="CooldownRecovery",type="INC",value=5}},nil}
 c["5% increased Critical Hit Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="INC",value=5}},nil}
-c["5% increased Damage for each Hazard triggered Recently, up to 50%"]={{[1]={flags=0,keywordFlags=0,name="Damage",type="INC",value=5}},"  for each Hazard triggered Recently, up to 50% "}
+c["5% increased Damage for each Hazard triggered Recently, up to 50%"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=5}},"  for each  triggered Recently, up to 50% "}
 c["5% increased Damage taken while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=5}},nil}
 c["5% increased Dexterity"]={{[1]={flags=0,keywordFlags=0,name="Dex",type="INC",value=5}},nil}
 c["5% increased Duration of Damaging Ailments on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=5},[2]={flags=0,keywordFlags=0,name="EnemyBleedDuration",type="INC",value=5},[3]={flags=0,keywordFlags=0,name="EnemyPoisonDuration",type="INC",value=5}},nil}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2282,7 +2282,7 @@ c["5% increased Cast Speed"]={{[1]={flags=16,keywordFlags=0,name="Speed",type="I
 c["5% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=5}},nil}
 c["5% increased Cooldown Recovery Rate"]={{[1]={flags=0,keywordFlags=0,name="CooldownRecovery",type="INC",value=5}},nil}
 c["5% increased Critical Hit Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="INC",value=5}},nil}
-c["5% increased Damage for each Hazard triggered Recently, up to 50%"]={{[1]={[1]={skillType=203,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=5}},"  for each  triggered Recently, up to 50% "}
+c["5% increased Damage for each Hazard triggered Recently, up to 50%"]={{[1]={[1]={globalLimit=50,globalLimitKey="DmgPerHazardRecently",type="Multiplier",var="HazardsTriggeredRecently"},flags=0,keywordFlags=0,name="Damage",type="INC",value=5}},nil}
 c["5% increased Damage taken while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=5}},nil}
 c["5% increased Dexterity"]={{[1]={flags=0,keywordFlags=0,name="Dex",type="INC",value=5}},nil}
 c["5% increased Duration of Damaging Ailments on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=5},[2]={flags=0,keywordFlags=0,name="EnemyBleedDuration",type="INC",value=5},[3]={flags=0,keywordFlags=0,name="EnemyPoisonDuration",type="INC",value=5}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -302,7 +302,7 @@ return {
 	flag("NoRepeatBonuses"),
 },
 ["hazard_rearm_%_chance"] = {
-	mod("Multiplier:ChanceToRearm", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Hazard } ),
+	mod("HazardRearmChance", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Hazard } ),
 },
 --
 -- Defensive modifiers
@@ -1384,9 +1384,6 @@ return {
 },
 ["is_hazard"] = {
 	flag("CanCreateHazards"),
-	skill("isHazard", "FLAG", nil),
-	{ mod("DPS", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChanceToRearm" }, { type = "SkillType", skillType = SkillType.Hazard }),
-	value = 1 }
 },
 -- Other effects
 ["enemy_phys_reduction_%_penalty_vs_hit"] = {

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1383,7 +1383,9 @@ return {
 	flag("LightningCanElectrocute"),
 },
 ["is_hazard"] = {
-	flag("CanCreateHazards")
+	flag("CanCreateHazards"),
+	{ mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChanceToRearm" }, { type = "SkillType", skillType = SkillType.Hazard }),
+	value = 1 }
 },
 -- Other effects
 ["enemy_phys_reduction_%_penalty_vs_hit"] = {

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1382,6 +1382,9 @@ return {
 ["base_lightning_damage_can_electrocute"] = {
 	flag("LightningCanElectrocute"),
 },
+["is_hazard"] = {
+	flag("CanCreateHazards")
+},
 -- Other effects
 ["enemy_phys_reduction_%_penalty_vs_hit"] = {
 	mod("EnemyPhysicalDamageReduction", "BASE", nil),

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1385,7 +1385,7 @@ return {
 ["is_hazard"] = {
 	flag("CanCreateHazards"),
 	skill("isHazard", "FLAG", nil),
-	{ mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChanceToRearm" }, { type = "SkillType", skillType = SkillType.Hazard }),
+	{ mod("DPS", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChanceToRearm" }, { type = "SkillType", skillType = SkillType.Hazard }),
 	value = 1 }
 },
 -- Other effects

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1384,6 +1384,7 @@ return {
 },
 ["is_hazard"] = {
 	flag("CanCreateHazards"),
+	skill("isHazard", "FLAG", nil),
 	{ mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "ChanceToRearm" }, { type = "SkillType", skillType = SkillType.Hazard }),
 	value = 1 }
 },

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -302,7 +302,7 @@ return {
 	flag("NoRepeatBonuses"),
 },
 ["hazard_rearm_%_chance"] = {
-	mod("DPS", "INC", nil),
+	mod("Multiplier:ChanceToRearm", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Hazard } ),
 },
 --
 -- Defensive modifiers

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -6981,6 +6981,8 @@ skills["SpearfieldPlayer"] = {
 				["spearfield_spear_damage_+%_final_after_half_seconds"] = {
 					mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "SpearOlderThanHalfSecond" }),
 				},
+				["base_skill_show_average_damage_instead_of_dps"] = {
+				},
 			},
 			baseFlags = {
 				attack = true,

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -7063,6 +7063,9 @@ skills["IceShardsPlayer"] = {
 				projectile = true,
 				area = true,
 			},
+			baseMods = {
+				flag("CanCreateHazards"),
+			},
 			constantStats = {
 				{ "action_required_target_facing_angle_tolerance_degrees", 60 },
 				{ "active_skill_base_physical_damage_%_to_convert_to_cold", 60 },

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -460,6 +460,8 @@ statMap = {
 	["spearfield_spear_damage_+%_final_after_half_seconds"] = {
 		mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "SpearOlderThanHalfSecond" }),
 	},
+	["base_skill_show_average_damage_instead_of_dps"] = {
+	},
 },
 #mods
 #skillEnd

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -426,6 +426,7 @@ statMap = {
 #mods
 #set IceShardsShardPlayer
 #flags attack projectile area
+#baseMod flag("CanCreateHazards")
 #mods
 #skillEnd
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1281,6 +1281,13 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	if skillModList:Flag(skillCfg, "CanCreateHazards") then
+		output.HazardRearmChance = m_min(skillModList:Sum("BASE", skillCfg, "HazardRearmChance"), 100)
+		skillModList:NewMod("DPS", "MORE", output.HazardRearmChance, "Chance To Rearm")
+		if breakdown then
+			output.HazardRearmChance = skillModList:Sum("BASE", skillCfg, "HazardRearmChance")
+		end
+	end
 	if activeSkill.skillTypes[SkillType.Link] then
 		output.LinkEffectMod = calcLib.mod(skillModList, skillCfg, "LinkEffect", "BuffEffect")
 		if breakdown then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1405,6 +1405,7 @@ return {
 	{ label = "Presence Mod", haveOutput = "PresenceMod", { format = "{2:output:PresenceMod}", { breakdown = "PresenceMod" }, { modName = "PresenceRadius", cfg = "skill" }} , },
 	{ label = "Presence Radius", haveOutput = "PresenceRadius", { format = "{1:output:PresenceRadiusMetres}m", { breakdown = "PresenceRadius" }, { modName = "PresenceArea", cfg = "skill"} }, },
 	{ label = "Chance to Blind", { format = "{0:mod:1}%", { modName = "BlindChance", modType = "BASE", cfg = "skill" }, }, },
+	{ label = "Chance to Rearm", skillData = "isHazard", { format = "{2:mod:1}%", { modName = "Multiplier:ChanceToRearm", modType = "BASE", cfg = "skill"}, }, },
 	{ label = "Inc. Quiver Effect", { format = "{0:mod:1}%", { modName="EffectOfBonusesFromQuiver", modType= "INC", cfg = "skill" }, }, },
 	{ label = "Inc. Item Quantity", { format = "{0:mod:1}%", { modName = "LootQuantity", modType = "INC", cfg = "skill" }, }, },
 	{ label = "IIQ for Normal Mobs", haveOutput = "LootQuantityNormalEnemies", { format = "{0:output:LootQuantityNormalEnemies}%", { modName = { "LootQuantityNormalEnemies", "LootQuantity" } }, }, },

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1405,7 +1405,7 @@ return {
 	{ label = "Presence Mod", haveOutput = "PresenceMod", { format = "{2:output:PresenceMod}", { breakdown = "PresenceMod" }, { modName = "PresenceRadius", cfg = "skill" }} , },
 	{ label = "Presence Radius", haveOutput = "PresenceRadius", { format = "{1:output:PresenceRadiusMetres}m", { breakdown = "PresenceRadius" }, { modName = "PresenceArea", cfg = "skill"} }, },
 	{ label = "Chance to Blind", { format = "{0:mod:1}%", { modName = "BlindChance", modType = "BASE", cfg = "skill" }, }, },
-	{ label = "Chance to Rearm", skillData = "isHazard", { format = "{2:mod:1}%", { modName = "Multiplier:ChanceToRearm", modType = "BASE", cfg = "skill"}, }, },
+	{ label = "Chance to Rearm", haveOutput = "HazardRearmChance", { format = "{2:mod:1}%", { modName = "HazardRearmChance", modType = "BASE", cfg = "skill"}, }, },
 	{ label = "Inc. Quiver Effect", { format = "{0:mod:1}%", { modName="EffectOfBonusesFromQuiver", modType= "INC", cfg = "skill" }, }, },
 	{ label = "Inc. Item Quantity", { format = "{0:mod:1}%", { modName = "LootQuantity", modType = "INC", cfg = "skill" }, }, },
 	{ label = "IIQ for Normal Mobs", haveOutput = "LootQuantityNormalEnemies", { format = "{0:output:LootQuantityNormalEnemies}%", { modName = { "LootQuantityNormalEnemies", "LootQuantity" } }, }, },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1622,6 +1622,9 @@ Huge sets the radius to 11.
 	{ var = "conditionEnemyPacified", type = "check", label = "Is the enemy Pacified?", ifSkill = "Pacify", tooltip = "Enemies are Pacified after 60% of Pacify's duration has expired", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Pacified", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
+	{ var = "conditionEnemyAffectedByHazardRecently", type = "check", label = "Enemy affected by Hazard recently?", ifEnemyCond = "AffectedByHazardRecently", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Condition:AffectedByHazardRecently", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+	end },
 	{ var = "conditionEnemyBurning", type = "check", label = "Is the enemy ^xB97123Burning?", ifEnemyCond = "Burning", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Burning", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1493,6 +1493,9 @@ Huge sets the radius to 11.
 	{ var = "reservedDarkness", type = "count", label = "Reserved Darkness:", ifFlag = "PlayerHasDarkness", apply = function(val, modList, enemyModList)
 		modList:NewMod("ReservedDarkness", "BASE", val, "Config")
 	end },
+	{ var = "multiplierHazardsTriggeredRecently", type = "count", label = "# of Hazards triggered recently:", ifMult = "HazardsTriggeredRecently", ifFlag = "CanCreateHazards", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:HazardsTriggeredRecently", "BASE", m_max(val,0), "Config", { type = "Condition", var = "Combat" })
+	end },
 	-- Section: Effective DPS options
 	{ section = "For Effective DPS", col = 1 },
 	{ var = "skillForkCount", type = "count", label = "# of times Skill has Forked:", ifFlag = "forking", apply = function(val, modList, enemyModList)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4114,6 +4114,7 @@ local specialModList = {
 	} end,
 	-- Hazards
 	["(%d+)%% increased damage for each hazard triggered recently, up to (%d+)%%"] = function(num, _, limit) return { mod("Damage", "INC", tonumber(num), { type = "Multiplier", var = "HazardsTriggeredRecently", globalLimit = tonumber(limit), globalLimitKey = "DmgPerHazardRecently" }) } end,
+	["hazards have (%d+)%% chance to rearm after they are triggered"] = function(num) return { mod("Multiplier:ChanceToRearm", "BASE", tonumber(num), { type = "SkillType", skillType = SkillType.Hazard })} end,
 	-- Totems
 	["can have up to (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num) } end,
 	["attack skills can have (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num, nil, 0, KeywordFlag.Attack) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4115,7 +4115,7 @@ local specialModList = {
 	} end,
 	-- Hazards
 	["(%d+)%% increased damage for each hazard triggered recently, up to (%d+)%%"] = function(num, _, limit) return { mod("Damage", "INC", tonumber(num), { type = "Multiplier", var = "HazardsTriggeredRecently", globalLimit = tonumber(limit), globalLimitKey = "DmgPerHazardRecently" }) } end,
-	["hazards have (%d+)%% chance to rearm after they are triggered"] = function(num) return { mod("Multiplier:ChanceToRearm", "BASE", tonumber(num), { type = "SkillType", skillType = SkillType.Hazard })} end,
+	["hazards have (%d+)%% chance to rearm after they are triggered"] = function(num) return { mod("HazardRearmChance", "BASE", tonumber(num), { type = "SkillType", skillType = SkillType.Hazard })} end,
 	-- Totems
 	["can have up to (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num) } end,
 	["attack skills can have (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num, nil, 0, KeywordFlag.Attack) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -977,6 +977,7 @@ local modFlagList = {
 	["that throw traps"] = { keywordFlags = KeywordFlag.Trap },
 	["grenade"] = { tag = { type = "SkillType", skillType = SkillType.Grenade } },
 	["for grenade skills"] = { tag = { type = "SkillType", skillType = SkillType.Grenade } },
+	["hazard"] = { tag = { type = "SkillType", skillType = SkillType.Hazard } },
 	["brand"] = { tag = { type = "SkillType", skillType = SkillType.Brand } },
 	["totem"] = { keywordFlags = KeywordFlag.Totem },
 	["with totem skills"] = { keywordFlags = KeywordFlag.Totem },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4112,6 +4112,8 @@ local specialModList = {
 		mod("TrapThrowCount", "BASE", tonumber(num) * tonumber(chance) / 100.0),
 		mod("MineThrowCount", "BASE", tonumber(num) * tonumber(chance) / 100.0),
 	} end,
+	-- Hazards
+	["(%d+)%% increased damage for each hazard triggered recently, up to (%d+)%%"] = function(num, _, limit) return { mod("Damage", "INC", tonumber(num), { type = "Multiplier", var = "HazardsTriggeredRecently", globalLimit = tonumber(limit), globalLimitKey = "DmgPerHazardRecently" }) } end,
 	-- Totems
 	["can have up to (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num) } end,
 	["attack skills can have (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num, nil, 0, KeywordFlag.Attack) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1256,6 +1256,7 @@ local preFlagList = {
 	["^hits against you "] = { applyToEnemy = true, flags = ModFlag.Hit },
 	["^hits against you [hd][ae][va][el] "] = { applyToEnemy = true, flags = ModFlag.Hit },
 	["^enemies near your totems deal "] = { applyToEnemy = true },
+	["^enemies affected by your hazards recently [hgd][ae][via][enl] "] = { applyToEnemy = true, tag = { type = "ActorCondition", var = "AffectedByHazardRecently" } },
 	-- Other
 	["^your flasks grant "] = { },
 	["^when hit, "] = { },


### PR DESCRIPTION
Fixes #1117 .

### Description of the problem being solved:
- Add support for generic "hazard"-related mod parsing (damage & duration)
- Add support for Hazard x% chance to rearm (tree nodes were not supported, and the `SkillStatMap` used `"DPS"` and `"INC"` , which didn't apply to the explosion, which is the actual hazard, and was also harder to analyze in the breakdown). It's now using a `"MORE"` damage mod with an additive multiplier of "`ChanceToRearm"`
- Add support for "x% damage per Hazard triggered recently" ("Escalating Mayhem")
- Add support for "Enemies affected by your Hazards recently have ..." ("Shredding Contraptions")

### Steps taken to verify a working solution:
- Mods get parsed correctly
- Only applies to Hazard skills (Spearfield and Caltrops)
- "More" damage from Rearm Chance is additive with itself
- "Escalating Mayhem" adheres to globalLimit
- "Chance to Rearm" only shown for the "hazard" part a the skill
- Config options only appear if relevant

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/2j6yp0ju

### After screenshot:
Inc dmg
![image](https://github.com/user-attachments/assets/6ae0e61d-fa34-4e63-85dc-b4fab9a27670)
Rearm dmg
![image](https://github.com/user-attachments/assets/01556b8f-f28e-40fb-924d-e65e75edf8f9)
Rearm chance
![image](https://github.com/user-attachments/assets/8ba52768-e04b-4bf8-a90e-3b8383af509f)
Hazard duration
![image](https://github.com/user-attachments/assets/8f9c1ee7-1e67-4816-8800-68a22555df8d)
Shredding Contraptions
![image](https://github.com/user-attachments/assets/d615fd09-e472-4950-8133-4b8e1dfa8f6a)
num. of Hazards triggered config
![image](https://github.com/user-attachments/assets/2e5a2ce0-c736-44a9-9887-b53f2d5f4acd)
Enemy affected by hazard recently config
![image](https://github.com/user-attachments/assets/30e02260-59fd-4410-907f-c5c0a2f03265)



