### PR TITLE
Fix support gems imported on skills from items causing an error

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -716,10 +716,12 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 			local group = { label = "", enabled = true, gemList = { } }
 			t_insert(group.gemList, gemInstance )
 
-			for _, anotherSkillData in pairs(skillData.socketedItems) do
-				local anotherGemInstance = funcGetGemInstance(anotherSkillData)
-				if anotherGemInstance then
-					t_insert(group.gemList, anotherGemInstance )
+			if skillData.socketedItems then
+				for _, anotherSkillData in pairs(skillData.socketedItems) do
+					local anotherGemInstance = funcGetGemInstance(anotherSkillData)
+					if anotherGemInstance then
+						t_insert(group.gemList, anotherGemInstance )
+					end
 				end
 			end
 


### PR DESCRIPTION
Fixes #1130

This fixes a stack trace that would appear if someone imported a character with a skill from an item that didn't have any support gems
