### PR TITLE
Add support for Ambrosia and Concoct Support

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -453,6 +453,9 @@ function ModStoreClass:EvalMod(mod, cfg)
 			end
 			local percent = tag.percent or self:GetMultiplier(tag.percentVar, cfg)
 			local mult = base * (percent and percent / 100 or 1)
+			if tag.floor then
+				mult = m_floor(mult)
+			end
 			local limitTotal
 			if tag.limit or tag.limitVar then
 				local limit = tag.limit or self:GetMultiplier(tag.limitVar, cfg)

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -119,6 +119,14 @@ skills["SupportAmbrosiaPlayer"] = {
 			label = "Ambrosia",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["consume_%_of_maximum_mana_flask_charges_on_skill_use"] = {
+					mod("Multiplier:ManaFlaskMaxChargesPercent", "BASE", nil),
+				},
+				["gain_%_damage_as_lighting_per_mana_flask_charge_consumed"] = {
+					mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "PercentStat", stat = "ManaFlaskMaxCharges", percentVar = "ManaFlaskMaxChargesPercent", floor = true }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -608,10 +608,10 @@ skills["SupportConcoctPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_concoct_bleed_effect_+%_final_per_life_flask_charge_consumed"] = {
-					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "Multiplier", var = "LifeFlaskChargesUsed"}),
+					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "PercentStat", stat = "LifeFlaskMaxCharges", percentVar = "LifeFlaskMaxChargesPercent", floor = true }),
 				},
 				["consume_%_of_maximum_life_flask_charges_on_skill_use"] = {
-					-- Display only
+					mod("Multiplier:LifeFlaskMaxChargesPercent", "BASE", nil),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -27,6 +27,14 @@ statMap = {
 
 #skill SupportAmbrosiaPlayer
 #set SupportAmbrosiaPlayer
+statMap = {
+	["consume_%_of_maximum_mana_flask_charges_on_skill_use"] = {
+		mod("Multiplier:ManaFlaskMaxChargesPercent", "BASE", nil),
+	},
+	["gain_%_damage_as_lighting_per_mana_flask_charge_consumed"] = {
+		mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "PercentStat", stat = "ManaFlaskMaxCharges", percentVar = "ManaFlaskMaxChargesPercent", floor = true }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -132,10 +132,10 @@ statMap = {
 #set SupportConcoctPlayer
 statMap = {
 	["support_concoct_bleed_effect_+%_final_per_life_flask_charge_consumed"] = {
-		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "Multiplier", var = "LifeFlaskChargesUsed"}),
+		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "PercentStat", stat = "LifeFlaskMaxCharges", percentVar = "LifeFlaskMaxChargesPercent", floor = true }),
 	},
 	["consume_%_of_maximum_life_flask_charges_on_skill_use"] = {
-		-- Display only
+		mod("Multiplier:LifeFlaskMaxChargesPercent", "BASE", nil),
 	},
 },
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -571,6 +571,8 @@ function calcs.offence(env, actor, activeSkill)
 
 	-- set flask scaling
 	output.LifeFlaskRecovery = env.itemModDB.multipliers["LifeFlaskRecovery"]
+	output.LifeFlaskMaxCharges = env.itemModDB.multipliers["LifeFlaskMaxCharges"]
+	output.ManaFlaskMaxCharges = env.itemModDB.multipliers["ManaFlaskMaxCharges"]
 
 	if modDB.conditions["AffectedByEnergyBlade"] then
 		local dmgMod = calcLib.mod(skillModList, skillCfg, "EnergyBladeDamage")

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -906,7 +906,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 				items[slot] = nil
 			end
 		end
-
+		
+		local maxLifeCharges, maxManaCharges= 0, 0
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
 			local item = items[slotName]
@@ -919,6 +920,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 					if item.flaskData.lifeTotal > highestLifeRecovery then
 						env.itemModDB.multipliers["LifeFlaskRecovery"] = item.flaskData.lifeTotal
 					end
+					maxLifeCharges = maxManaCharges + item.flaskData.chargesMax
+					env.itemModDB.multipliers["LifeFlaskMaxCharges"] = maxLifeCharges + item.flaskData.chargesMax
+				end
+				if item.base.subType == "Mana" then
+					maxManaCharges = maxManaCharges + item.flaskData.chargesMax
+					env.itemModDB.multipliers["ManaFlaskMaxCharges"] = maxManaCharges
 				end
 				item = nil
 			elseif item and item.type == "Charm" then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -288,10 +288,6 @@ local configSettings = {
 	{ var = "ColdSnapBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Cold Snap", includeTransfigured = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillName = "Cold Snap", includeTransfigured = true })
 	end },
-	{ label = "Concoct:", ifSkill = "Concoct" },
-	{ var = "concoctLifeFlaskChargesUsed", type = "count", label = "# of Life Flask charges used:", ifSkill = "Concoct", apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:LifeFlaskChargesUsed", "BASE", val, "Config")
-	end },
 	{ label = "Consecrated Path of Endurance:", ifSkill = "Consecrated Path of Endurance" },
 	{ var = "ConcPathBypassCD", type = "check", label = "Bypass CD?", ifSkill = "Consecrated Path of Endurance", defaultState = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("CooldownRecovery", "OVERRIDE", 0, "Config", { type = "SkillName", skillName = "Consecrated Path of Endurance" })


### PR DESCRIPTION
Now automatically grabs the max flask charges and uses that for the mod without the need to manually input a value
Calc Setup has the local variable before the slots loop so when we add support for Waistgate, it properly adds together the flask charges from both flasks
