### PR TITLE
Fix Minions not gaining 10 Accuracy per monster level

### DIFF
--- a/src/Data/Misc.lua
+++ b/src/Data/Misc.lua
@@ -100,6 +100,13 @@ data.gameConstants = {
 	["CullingStrikeRareThreshold"] = 10,
 	["CullingStrikeUniqueThreshold"] = 5,
 }
+-- From PlayerMinionIntrinsicStats.dat
+data.playerMinionIntrinsicStats = {
+	["stun_base_duration_override_ms"] = 500,
+	["accuracy_rating_+%_final_at_max_distance_scaled"] = -90,
+	["accuracy_rating_per_level"] = 10,
+	["base_critical_hit_damage_bonus"] = 70,
+}
 -- From MonsterVarieties.dat combined with SkillTotemVariations.dat
 data.totemLifeMult = { [1] = 1, [2] = 1, [3] = 1, [5] = 1, [12] = 1, [18] = 1, [19] = 1, [22] = 1, [15] = 1.2, [23] = 1, [24] = 1, }
 data.monsterVarietyLifeMult = {

--- a/src/Export/Scripts/miscdata.lua
+++ b/src/Export/Scripts/miscdata.lua
@@ -49,6 +49,13 @@ for row in dat("GameConstants"):Rows() do
 end
 out:write('}\n')
 
+out:write('-- From PlayerMinionIntrinsicStats.dat\n')
+out:write('data.playerMinionIntrinsicStats = {\n')
+for row in dat("PlayerMinionIntrinsicStats"):Rows() do
+	out:write('\t["' .. row.Id.Id .. '"] = ' .. row.Value .. ',\n')
+end
+out:write('}\n')
+
 local totemMult = ""
 local keys = { }
 for var in dat("SkillTotemVariations"):Rows() do

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -895,7 +895,7 @@ function calcs.perform(env, skipEHP)
 		if modDB:Flag(nil, "MinionAccuracyEqualsAccuracy") then
 			env.minion.modDB:NewMod("Accuracy", "BASE", calcLib.val(modDB, "Accuracy") + calcLib.val(modDB, "Dex") * (modDB:Override(nil, "DexAccBonusOverride") or data.misc.AccuracyPerDexBase), "Player")
 		else
-			env.minion.modDB:NewMod("Accuracy", "BASE", round(env.data.monsterAccuracyTable[env.minion.level] * (env.minion.minionData.accuracy or 1)), "Base")
+			env.minion.modDB:NewMod("Accuracy", "BASE", round(env.data.monsterAccuracyTable[env.minion.level] * (env.minion.minionData.accuracy or 1)) + data.playerMinionIntrinsicStats.accuracy_rating_per_level * (env.minion.level - 1), "Base")
 		end
 		env.minion.modDB:NewMod("CritMultiplier", "BASE", 100, "Base")
 		env.minion.modDB:NewMod("FireResist", "BASE", env.minion.minionData.fireResist, "Base")


### PR DESCRIPTION
The PlayerMinionIntrinsicStats contains some stats that only apply to player minions. Need to also export the character.ot and monster.ot files as they contain many base stats for monsters and players that we currently have hardcoded in the data file
