### PR TITLE
Fix Wiki hotkey (F1) not working correctly for relic items

### DIFF
--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -351,7 +351,7 @@ itemLib.wiki = {
 		itemLib.wiki.open(name)
 	end,
 	openItem = function(item)
-		local name = item.rarity == "UNIQUE" and item.title or item.baseName
+		local name = (item.rarity == "UNIQUE" or item.rarity == "RELIC") and item.title or item.baseName
 
 		itemLib.wiki.open(name)
 	end,


### PR DESCRIPTION
From PoB 1 https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8609
