### PR TITLE
Fix Stomping Ground not scaling with Melee Damage

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -3048,6 +3048,7 @@ skills["StompingGroundShockwavePlayer"] = {
 			baseFlags = {
 				nonWeaponAttack = true,
 				area = true,
+				melee = true,
 			},
 			baseMods = {
 				skill("showAverage", true),

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -728,7 +728,7 @@ statMap = {
 
 #skill StompingGroundShockwavePlayer
 #set StompingGroundShockwavePlayer
-#flags nonWeaponAttack area
+#flags nonWeaponAttack area melee
 statMap = {
 	["attack_minimum_added_physical_damage_as_%_of_strength"] = {
 		skill("PhysicalMin", nil, { type = "PercentStat", stat = "Str", percent = 1 }),


### PR DESCRIPTION
Confirmed by GGG that it should be scaling with melee damage and that its a bug in the game files that we can see that it isn't currently included.
A future patch to the game will probably add a skilltype flag for the skill so I'm not going to add anything myself for now
Fixes #1141