### PR TITLE
Add correct logic for Gemling Integrated Efficency passive

### DIFF
--- a/spec/System/TestAttacks_spec.lua
+++ b/spec/System/TestAttacks_spec.lua
@@ -55,4 +55,48 @@ describe("TestAttacks", function()
 		runCallback("OnFrame")
 		assert.are.equals(22, build.calcsTab.mainEnv.player.mainSkill.skillModList:Sum("INC", { flags = ModFlag.Attack }, "Damage"))
 	end)
+
+
+	local integratedEfficenyLoadout = function(modLine) 
+		-- Activate via custom mod text to simplify testing
+		build.configTab.input.customMods = modLine
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Razor Quarterstaff
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+		-- Add 2 skills with 1 red, 1 blue, 1 green support each
+		-- Test against Quarterstaff Strike (skill slot 1)
+		build.skillsTab:PasteSocketGroup("Quarterstaff Strike 1/0  1\nSplinter 1/0  1\nConduction 1/0  1\nBiting Frost 1/0  1")
+		runCallback("OnFrame")
+		build.skillsTab:PasteSocketGroup("Falling Thunder 1/0  1\nIgnition 1/0  1\nDiscombobulate 1/0  1\nCoursing Current 1/0  1")
+		runCallback("OnFrame")
+		
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		build.calcsTab:BuildOutput()
+		runCallback("OnFrame")
+	end
+	it("correctly calculates increased damage with gemling integrated efficency", function()
+		integratedEfficenyLoadout("skills gain 99% increased damage per socketed red support gem")
+		local incDmg = build.calcsTab.mainEnv.player.activeSkillList[1].skillModList:Sum("INC", nil, "Damage")
+		assert.are.equals(incDmg, 99)
+	end)
+
+	it("correctly calculates crit chance with gemling integrated efficency", function()
+		integratedEfficenyLoadout("skills gain 99% increased critical hit chance per socketed blue support gem")
+		local incCritChance = build.calcsTab.mainEnv.player.activeSkillList[1].skillModList:Sum("INC", nil, "CritChance")
+		assert.are.equals(incCritChance, 99)
+	end)
+
+	it("correctly calculates increased skill speed with gemling integrated efficency", function()
+		integratedEfficenyLoadout("skills gain 99% increased skill speed per socketed green support gem")
+		local incSpeed = build.calcsTab.mainEnv.player.activeSkillList[1].skillModList:Sum("INC", nil, "Speed")
+		assert.are.equals(incSpeed, 99)
+	end)
 end)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4485,9 +4485,9 @@ c["Skills Supported by Unleash have 10% increased Seal gain frequency"]={{[1]={f
 c["Skills Supported by Unleash have 25% increased Seal gain frequency"]={{[1]={flags=0,keywordFlags=0,name="SealGainFrequency",type="INC",value=25}},nil}
 c["Skills fire an additional Projectile"]={{[1]={flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=1}},nil}
 c["Skills gain 1% of Damage as Chaos Damage per 3 Life Cost"]={{[1]={[1]={div=3,stat="LifeCost",type="PerStat"},flags=0,keywordFlags=0,name="DamageAsChaos",type="BASE",value=1}},nil}
-c["Skills gain 20% increased Critical Hit Chance per socketed blue Support Gem"]={{[1]={[1]={type="Multiplier",var="BlueSupportGems"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=20}},nil}
-c["Skills gain 20% increased Damage per socketed red Support Gem"]={{[1]={[1]={type="Multiplier",var="RedSupportGems"},flags=0,keywordFlags=0,name="Damage",type="INC",value=20}},nil}
-c["Skills gain 6% increased Skill Speed per socketed green Support Gem"]={{[1]={[1]={type="Multiplier",var="GreenSupportGems"},flags=0,keywordFlags=0,name="Speed",type="INC",value=6},[2]={[1]={type="Multiplier",var="GreenSupportGems"},flags=0,keywordFlags=0,name="WarcrySpeed",type="INC",value=6}},nil}
+c["Skills gain 20% increased Critical Hit Chance per socketed blue Support Gem"]={{[1]={flags=0,keywordFlags=0,name="SkillCritChanceIncreasedPerBlueSupport",type="FLAG",value=20}},nil}
+c["Skills gain 20% increased Damage per socketed red Support Gem"]={{[1]={flags=0,keywordFlags=0,name="SkillDamageIncreasedPerRedSupport",type="FLAG",value=20}},nil}
+c["Skills gain 6% increased Skill Speed per socketed green Support Gem"]={{[1]={flags=0,keywordFlags=0,name="SkillSpeedIncreasedPerGreenSupport",type="FLAG",value=6}},nil}
 c["Skills gain a Base Life Cost equal to 10% of Base Mana Cost"]={{[1]={flags=0,keywordFlags=0,name="BaseManaCostAsLifeCost",type="BASE",value=10}},nil}
 c["Skills gain a Base Life Cost equal to 50% of Base Mana Cost"]={{[1]={flags=0,keywordFlags=0,name="BaseManaCostAsLifeCost",type="BASE",value=50}},nil}
 c["Skills gain a Base Life Cost equal to Base Mana Cost"]={{[1]={flags=0,keywordFlags=0,name="BaseManaCostAsLifeCost",type="BASE",value=100}},nil}

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -637,6 +637,43 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	-- Apply Gemling's "Integrated Efficency" Passive
+	if skillModList:Flag(nil, "SkillDamageIncreasedPerRedSupport") or
+		skillModList:Flag(nil, "SkillSpeedIncreasedPerGreenSupport") or
+		skillModList:Flag(nil, "SkillCritChanceIncreasedPerBlueSupport") then
+		
+		local redSupportCount = 0
+		local greenSupportCount = 0
+		local blueSupportCount = 0
+		for _, support in ipairs(activeSkill.supportList) do
+			if support.gemData.grantedEffect.color == 1 then
+				redSupportCount = redSupportCount + 1
+			elseif support.gemData.grantedEffect.color == 2 then
+				greenSupportCount = greenSupportCount + 1
+			elseif support.gemData.grantedEffect.color == 3 then
+				blueSupportCount = blueSupportCount + 1
+			end
+		end
+
+		local lookupModData = function(flag) 
+			local result = 	actor.modDB:Tabulate("FLAG", nil, flag)
+			return { source = result[1].mod.source, value = result[1].mod.value }
+		end
+		-- Conditionally check each to avoid future issues if a mod is reused in isolation
+		local modData = { source = nil, value = nil }
+		if skillModList:Flag(nil, "SkillDamageIncreasedPerRedSupport") then
+			modData = lookupModData("SkillDamageIncreasedPerRedSupport")
+			skillModList:NewMod("Damage", "INC", redSupportCount * modData.value, modData.source)
+		end
+		if skillModList:Flag(nil, "SkillSpeedIncreasedPerGreenSupport") then
+			modData = lookupModData("SkillSpeedIncreasedPerGreenSupport")
+			skillModList:NewMod("Speed", "INC", greenSupportCount * modData.value, modData.source)
+		end
+		if skillModList:Flag(nil, "SkillCritChanceIncreasedPerBlueSupport") then
+			modData = lookupModData("SkillCritChanceIncreasedPerBlueSupport")
+			skillModList:NewMod("CritChance", "INC", blueSupportCount * modData.value, modData.source)
+		end
+	end
 	if skillModList:Flag(nil, "MinionDamageAppliesToPlayer") or skillModList:Flag(skillCfg, "MinionDamageAppliesToPlayer") then
 		-- Minion Damage conversion from Spiritual Aid and The Scourge
 		local multiplier = (skillModList:Max(skillCfg, "ImprovedMinionDamageAppliesToPlayer") or 100) / 100

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2998,6 +2998,15 @@ local specialModList = {
 	["attribute requirements of gems can be satisi?fied by your highest attribute"] = { flag("GemAttributeRequirementsSatisfiedByHighestAttribute") },
 	["you can use two copies of the same support gem in different skills"] = { mod("MaxSupportGemCopies", "OVERRIDE", 2) },
 	["you can use each type of support gem an additional time in different skills"] = { mod("MaxSupportGemCopies", "OVERRIDE", 2) },
+	["skills gain (%d+)%% increased critical hit chance per socketed blue support gem"] = function(num) return { 
+		mod("SkillCritChanceIncreasedPerBlueSupport", "FLAG", num) 
+	} end,
+	["skills gain (%d+)%% increased damage per socketed red support gem"] = function(num) return { 
+		mod("SkillDamageIncreasedPerRedSupport", "FLAG", num) 
+	} end,
+	["skills gain (%d+)%% increased skill speed per socketed green support gem"] = function(num) return { 
+		mod("SkillSpeedIncreasedPerGreenSupport", "FLAG", num) 
+	} end,
 	-- Monk - Stormweaver
 	["targets can be affected by two of your shocks at the same time"] = { flag("ShockCanStack"), mod("ShockStacksMax", "OVERRIDE", 2) },
 	["targets can be affected by two of your chills at the same time"] = { flag("ChillCanStack"), mod("ChillStacksMax", "OVERRIDE", 2) },


### PR DESCRIPTION
Fixes #1070 

### Description of the problem being solved:
Integrated Efficency should only apply on a per-skill basis to the supports socketed with that skill.

**Reminder: Integrated Efficiency boosts Damage, Crit Hit Chance, and Skill Speed.** 

### Solution
I've set up a full capture on the passive's mods and have them add a flag for each respective passive. An alternative approach (I think?) would be to keep the shorter capture group but add in logic in the Calcs somewhere to check for "source == Tree:ID" and then perform the calc and apply the mods properly. But that seemed like more processor cycles, especially if you need to look up the Tree ID dynamically for Integrated Effic on each Calc call; in addition to this already happening inside the breakdown code.

The flags are checked for early on in calcs.offense() and the correct mods are applied to each skill's mods list. I've set the logic up so that each flag/mod can be applied in isolation. I opted to leave the old mod added from PR #955 in place, but I suspect it might need removed at some point if GGG adds more passives/mods that operate off of "per COLOR support gem" and they don't work off of a global count.

I've added tests that focus test each individual mod rather than the passive it self.

### Steps taken to verify a working solution:
- Hand Checking
- Added a set of tests to the Attack test suite for the relevant skill mods

### Link to a build that showcases this PR:
Not particularly relevant but here is a quick setup to match the screenshots: https://maxroll.gg/poe2/pob/l55n20rb

### Before screenshot:
<img width="1918" height="790" alt="Integeffic-Skills" src="https://github.com/user-attachments/assets/cdd5f94a-6fe1-4b85-8e75-1e8548601a4c" />

<img width="2388" height="1348" alt="Integeffic-CalcsBefore" src="https://github.com/user-attachments/assets/f1a0f3d1-cdca-49eb-972c-a1ff22727a94" />

### After screenshot:
<img width="1568" height="1433" alt="Integeffic-Calcs" src="https://github.com/user-attachments/assets/b1f3dc95-029e-48b3-85fc-f425fe32b1f3" />
