### PR TITLE
Add support for Deliberation Damage Mod

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -1077,6 +1077,11 @@ skills["SupportDeliberationPlayer"] = {
 			label = "Deliberation",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_deliberation_damage_+%_final"] = {
+					mod("Damage", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -250,6 +250,11 @@ statMap = {
 
 #skill SupportDeliberationPlayer
 #set SupportDeliberationPlayer
+statMap = {
+	["support_deliberation_damage_+%_final"] = {
+		mod("Damage", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #1161

### Description of the problem being solved:
Just supports the 20% more damage mod on Deliberation, the movement speed mod hasn't been touched.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/r36yx0wd
### After screenshot:
<img width="754" height="304" alt="image" src="https://github.com/user-attachments/assets/730595c8-4390-4da8-a06b-b1a20e7baa2c" />
<img width="426" height="140" alt="image" src="https://github.com/user-attachments/assets/3cd0fa16-c6c6-49ce-b888-d9655bb73f86" />