### PR TITLE
0.3 - Update gem Attributes requirement formula

### DIFF
--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -124,7 +124,7 @@ function calcLib.getGemStatRequirement(level, multi, isSupport)
 	if multi == 0 or isSupport then
 		return 0
 	end
-	local req = round( ( 5 + ( level - 3 ) * 2.25 ) * ( multi / 100 ) ^ 0.9 ) + 4
+	local req = round( ( 5 + ( level - 3 ) * 1.7 ) * ( multi / 100 ) ^ 0.9 ) + 4
 	return req < 8 and 0 or req
 end
 


### PR DESCRIPTION
Attribute requirements for gems have been changed in 0.3 and using a value of 1.7 instead of 2.25 accurately reflects the values shown off in the 0.3 reveal stream
