### PR TITLE
Fix Trade results not including Fractured Mods

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2593,6 +2593,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	else
 		tooltip:AddLine(20, rarityCode..item.namePrefix..item.baseName:gsub(" %(.+%)","")..item.nameSuffix)
 	end
+	if item.fractured then
+		tooltip:AddLine(16, colorCodes.FRACTURED.."Fractured Item")
+	end
 
 	tooltip:AddSeparator(10)
 

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -376,6 +376,7 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 
 				-- ensure these fields are initialised
 				item.enchantMods = item.enchantMods or { }
+				item.fracturedMods = item.fracturedMods or { }
 				item.runeMods = item.runeMods or { }
 				item.implicitMods = item.implicitMods or { }
 				item.explicitMods = item.explicitMods or { }
@@ -389,6 +390,9 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 				end
 				for _, modLine in ipairs(item.implicitMods) do
 					t_insert(rawLines, escapeGGGString(modLine))
+				end
+				for _, modLine in ipairs(item.fracturedMods) do
+					t_insert(rawLines, "{fractured}"	.. escapeGGGString(modLine))
 				end
 				for _, modLine in ipairs(item.explicitMods) do
 					t_insert(rawLines, escapeGGGString(modLine))


### PR DESCRIPTION
We were not taking into account the fractured mods list when retrieving mods from the trade site
Fractured mods always seem to be the first mod on the item to no need to reorder them
Fixes #1140
<img width="888" height="479" alt="image" src="https://github.com/user-attachments/assets/5911984c-e017-4de7-9225-ff738c1206a5" />
