### PR TITLE
Fix automatically running character import on loading build, and show logout button in more cases

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -29,7 +29,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		return "^7Character import status: "..(type(self.charImportStatus) == "function" and self.charImportStatus() or self.charImportStatus)
 	end)
 
-	self.controls.logoutApiButton = new("ButtonControl", {"TOPLEFT",self.controls.charImportStatusLabel,"TOPRIGHT"}, {4, 0, 200, 16}, "^7Logout from Path of Exile API", function()
+	self.controls.logoutApiButton = new("ButtonControl", {"TOPLEFT",self.controls.charImportStatusLabel,"TOPRIGHT"}, {4, 0, 180, 16}, "^7Logout from Path of Exile API", function()
 		main.lastToken = nil
 		self.api.authToken = nil
 		main.lastRefreshToken = nil
@@ -41,7 +41,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		self.charImportStatus = colorCodes.WARNING.."Not authenticated"
 	end)
 	self.controls.logoutApiButton.shown = function()
-		return self.charImportMode == "SELECTCHAR" and self.api.authToken ~= nil
+		return (self.charImportMode == "SELECTCHAR" or self.charImportMode == "GETACCOUNTNAME") and self.api.authToken ~= nil
 	end
 	
 	self.controls.characterImportAnchor = new("Control", {"TOPLEFT",self.controls.sectionCharImport,"TOPLEFT"}, {6, 40, 200, 16})

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -337,7 +337,6 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 			if self.charImportMode == "AUTHENTICATION" then
 				self.charImportMode = "GETACCOUNTNAME"
 				self.charImportStatus = "Authenticated"
-				self:DownloadCharacterList()
 			end
 			if updateSettings then
 				self:SaveApiSettings()


### PR DESCRIPTION
Fixes #1185.
Fixes #1181 (didn't test but brain says it should work)

### Description of the problem being solved:
Decreased logout button size a little, stopped the importer from running on loading any build, and show the logout button in more cases.
### After screenshot:
<img width="474" height="112" alt="image" src="https://github.com/user-attachments/assets/b5a65b4c-5f1e-4366-9728-13784f83cce8" />