### PR TITLE
Improve Totem Stat Behaviour

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4532,6 +4532,7 @@ skills["DarkEffigyProjectilePlayer"] = {
 				spell = true,
 				area = true,
 				projectile = true,
+				totem = true,
 			},
 			constantStats = {
 				{ "skill_disabled_unless_cloned", 2 },

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -145,6 +145,9 @@ skills["SupportAncestralWarriorTotemPlayer"] = {
 	name = "SupportAncestralWarriorTotemPlayer",
 	hidden = true,
 	support = true,
+	addFlags = {
+		totem = true,
+	},
 	requireSkillTypes = { SkillType.Attack, },
 	addSkillTypes = { SkillType.UsedByTotem, },
 	excludeSkillTypes = { SkillType.Meta, SkillType.Triggered, SkillType.Cooldown, SkillType.Channel, SkillType.Persistent, },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -305,7 +305,7 @@ statMap = {
 
 #skill DarkEffigyProjectilePlayer
 #set DarkEffigyProjectilePlayer
-#flags spell area projectile
+#flags spell area projectile totem
 #mods
 #skillEnd
 

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -12,6 +12,9 @@ local skills, mod, flag, skill = ...
 #skillEnd
 
 #skill SupportAncestralWarriorTotemPlayer
+	addFlags = {
+		totem = true,
+	},
 #set SupportAncestralWarriorTotemPlayer
 #flags
 #mods

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -231,6 +231,47 @@ local function getWeaponFlags(env, weaponData, weaponTypes)
 	return flags, info
 end
 
+-- Get stats from totem base skill in case of separate active skills or "totemification" via supports
+---@param activeSkill table @activeSkill with totem tag
+local function getTotemBaseStats(activeSkill)
+	local totemBase = {}
+
+	if activeSkill.skillTypes[SkillType.SummonsTotem] then -- Skill that summons totems already has stats on activeEffect
+		totemBase.grantedEffect = activeSkill.activeEffect.grantedEffect
+		totemBase.gemData = activeSkill.activeEffect.gemData
+		totemBase.skillLevel = activeSkill.activeEffect.level
+	elseif activeSkill.skillTypes[SkillType.UsedByTotem] then
+		if activeSkill.activeEffect.grantedEffect.skillTypes[SkillType.UsedByTotem] then -- is totem skill by default
+			totemBase.grantedEffect = activeSkill.activeEffect.gemData.grantedEffect 
+			totemBase.gemData = activeSkill.activeEffect.gemData
+			totemBase.totemified = true
+			totemBase.skillLevel = activeSkill.activeEffect.level
+		elseif activeSkill.supportList then -- skill is "totemified" via support
+			for _, support in ipairs(activeSkill.supportList) do
+				if support.grantedEffect.addSkillTypes and (not support.superseded) and support.isSupporting[activeSkill.activeEffect.srcInstance] then
+					for _, skillType in ipairs(support.grantedEffect.addSkillTypes) do
+						if skillType == SkillType.UsedByTotem then
+							totemBase.grantedEffect = support.gemData.grantedEffect
+							totemBase.gemData = support.gemData
+							break
+						end
+					end
+				end
+				if totemBase.gemData or totemBase.grantedEffect then
+					totemBase.totemified = true
+					totemBase.skillLevel = support.level
+					break
+				end
+			end
+		else
+			-- A totem skill that neither `SummonsTotem` nor `UsedByTotem` should not be possible, but I am leaving this here to alert us in case of unexpected future edge cases
+			error("Error: Unexpected SkillType behavior for skill with 'totem' flag")
+		end
+	end
+
+	return totemBase
+end
+
 --- Applies additional modifiers to skills with the "Empowered" flag.
 --- Checks for "ExtraEmpoweredMod" mods and applies them
 --- if they match the conditions set by the empowering effect.
@@ -465,10 +506,19 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		skillKeywordFlags = bor(skillKeywordFlags, KeywordFlag.Spell)
 	end
 
-	-- Get skill totem ID for totem skills
-	-- This is used to calculate totem life
+	-- Find totem base stats
 	if skillFlags.totem then
-		activeSkill.skillTotemId = activeGrantedEffect.skillTotemId
+		local totemBase = getTotemBaseStats(activeSkill)
+		if totemBase.grantedEffect and totemBase.gemData then
+			activeSkill.skillData.totemBase = totemBase
+		end
+		local totemLevelRequirement = activeSkill.skillData.totemBase and activeSkill.skillData.totemBase.grantedEffect.levels[totemBase.skillLevel].levelRequirement or activeEffect.grantedEffect.levels[activeEffect.level].levelRequirement
+		-- Note: Some active skills related to totem base skills (e.g. on Shockwave Totem) have level requirement = 0, making the additional ` > 0` check necessary
+		activeSkill.skillData.totemLevel = (totemLevelRequirement and (totemLevelRequirement > 0)) and totemLevelRequirement or 1
+
+		-- Get skill totem ID for totem skills
+		-- This is used to calculate totem life
+		activeSkill.skillTotemId = activeGrantedEffect.skillTotemId or (activeSkill.skillData.totemBase and activeSkill.skillData.totemBase.grantedEffect.skillTotemId)
 		if not activeSkill.skillTotemId then
 			if activeGrantedEffect.color == 2 then
 				activeSkill.skillTotemId = 2
@@ -629,11 +679,6 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	end
 	
 	applyExtraEmpowerMods(activeSkill)
-
-	-- Find totem level
-	if skillFlags.totem then
-		activeSkill.skillData.totemLevel = 1 or activeEffect.grantedEffect.levels[activeEffect.level].levelRequirement
-	end
 
 	-- Add active mine multiplier
 	if skillFlags.mine then

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -165,8 +165,7 @@ function calcs.createActiveSkill(activeEffect, supportList, env, actor, socketGr
 			if supportEffect.grantedEffect.addFlags and not summonSkill then
 				-- Support skill adds flags to supported skills (eg. Remote Mine adds 'mine')
 				for k in pairs(supportEffect.grantedEffect.addFlags) do
-					mainSkillFlags[k] = true
-					calcsSkillFlags[k] = true
+					skillFlags[k] = true
 				end
 			end
 		end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -55,7 +55,6 @@ function calcs.initModDB(env, modDB)
 	modDB:NewMod("WarcryCastTime", "BASE", 0.8, "Base")
 	modDB:NewMod("TotemPlacementTime", "BASE", 0.6, "Base")
 	modDB:NewMod("BallistaPlacementTime", "BASE", 0.35, "Base")
-	modDB:NewMod("ActiveTotemLimit", "BASE", 1, "Base")
 	modDB:NewMod("ShockStacksMax", "BASE", 1, "Base")
 	modDB:NewMod("ChillStacksMax", "BASE", 1, "Base")
 	modDB:NewMod("ScorchStacksMax", "BASE", 1, "Base")
@@ -1758,6 +1757,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent
 		end
 	end
+
 
 	-- Merge Requirements Tables
 	env.requirementsTable = tableConcat(env.requirementsTableItems, env.requirementsTableGems)


### PR DESCRIPTION
Partially fixes #502  . (Will have to check after 0.3.0 because behavior will change)

### Description of the problem being solved:
PoE2 treats the active portion of totem skills as separate "totemified" skills, rather than additional stat sets of the same skill. This lead to several problems because totem base stats are only available on the "base" skill (which in case of "Ancestral Warrior Totem" is on entirely different gem, as well)

**List of fixed issues:**
1. Totem level was incorrectly always set to 1 because the "totemified" skills had a `levelRequirement = 0` leading to crashes when trying to determine totem level in some cases
2. `skillTotemId` was not working because the stat was not present on the "totemified" skill
3. Totem life values were incorrect as a result of 1. and 2.
4. Skills supported by "Ancestral Warrior Totem" were not recognized as totem skills at all (and thus didn't benefit from totem-related stats)
5. The "totemified" part of Dark Effigy was lacking the `totem` flag
6. Totem limit was always 1 higher than it should be because totem skills now come with `{ "base_number_of_totems_allowed", 1 }`, making the `"Base"` mod in `CalcSetup` redundant

**Additional Notes:**
- I originally started this PR to implement the `alt_attack_container` behavior which made totems have their own weapon-independent attack stats. Since this behavior will be changed in 0.3.0 in a few days, it makes no sense to include here, but I have it saved somewhere in case we ever have to user `alt_attack_container` for something else.

### Steps taken to verify a working solution:
- Totem stats are now visible for all portions of totem skills
- In case of "Ancestral Warrior Totem",  totem level is correctly based on the level of the "support" rather than the totemified skill
- Totemified skills correctly benefit from totem-related stats
- Totem-related stat values match between totemified and totem base skills

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/qaitk0qc

### Before screenshot:
**No totem stats**
<img width="707" height="664" alt="image" src="https://github.com/user-attachments/assets/8e969fe0-386c-471b-b296-76f0babfae0f" />

**No increase from totem damage (Sunder on Ancestral Warrior Totem)**
<img width="378" height="203" alt="image" src="https://github.com/user-attachments/assets/7749f9d8-35ca-414e-92b5-191b7d97e917" />

### After screenshot:
**now with totem stats**
<img width="716" height="729" alt="image" src="https://github.com/user-attachments/assets/5dab254d-5aaa-4bc8-bddd-319612765200" />
<img width="756" height="656" alt="image" src="https://github.com/user-attachments/assets/6b9bd7aa-d607-4472-bd13-6a31b52eef6f" />

**Increase from totem damage works now (Sunder on Ancestral Warrior Totem)**
<img width="443" height="353" alt="image" src="https://github.com/user-attachments/assets/e355d567-bac7-4a1e-96e6-580f93f9f0c2" />


