### PR TITLE
Fix Keystones and Jewel sockets from being allocated with Weapon Set passives

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -703,12 +703,12 @@ function PassiveSpecClass:AllocNode(node, altPath)
 	-- Allocate all nodes along the path
 	if #node.intuitiveLeapLikesAffecting > 0 then
 		node.alloc = true
-		node.allocMode = node.ascendancyName and 0 or self.allocMode
+		node.allocMode = (node.ascendancyName or node.type == "Keystone" or node.type == "Socket" or node.containJewelSocket) and 0 or self.allocMode
 		self.allocNodes[node.id] = node
 	else
 		for _, pathNode in ipairs(altPath or node.path) do
 			pathNode.alloc = true
-			pathNode.allocMode = node.ascendancyName and 0 or self.allocMode
+			pathNode.allocMode = (node.ascendancyName or pathNode.type == "Keystone" or pathNode.type == "Socket" or pathNode.containJewelSocket) and 0 or self.allocMode
 			-- set path attribute nodes to latest chosen attribute or default to Strength if allocating before choosing an attribute
 			if pathNode.isAttribute then 
 				self:SwitchAttributeNode(pathNode.id, self.attributeIndex or 1)

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -264,10 +264,44 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	end
 	
 	local hotkeyPressed = IsKeyDown("1") or IsKeyDown("I") or IsKeyDown("2") or IsKeyDown("S") or IsKeyDown("3") or IsKeyDown("D")
+
+	-- Helper function to determine if global node allocation should be blocked
+	local function shouldBlockGlobalNodeAllocation(node)
+		local isGlobalNode = node.type == "Keystone" or node.type == "Socket" or node.containJewelSocket
+
+		if not isGlobalNode or node.alloc or not node.path then
+			return false
+		end
+
+		local weaponSetMode = spec.allocMode > 0
+		local connectedToWeaponSetNodes = self:IsConnectedToWeaponSetNodes(node)
+
+		-- Only allow allocation from main tree AND node must not be connected to weapon set nodes
+		local shouldBlock = weaponSetMode or connectedToWeaponSetNodes
+
+		return shouldBlock
+	end
+
+	-- Helper function to determine if global node deallocation should be blocked
+	local function shouldBlockGlobalNodeDeallocation(node)
+		local isGlobalNode = node.type == "Keystone" or node.type == "Socket" or node.containJewelSocket
+
+		if not isGlobalNode or not node.alloc then
+			return false
+		end
+
+		-- Main-tree global nodes can only be deallocated from main tree
+		-- Legacy weapon-set global nodes can be deallocated from any mode
+		local shouldBlock = node.allocMode == 0 and spec.allocMode > 0
+
+		return shouldBlock
+	end
+
 	if treeClick == "LEFT" then
 		if hoverNode then
 			-- User left-clicked on a node
-			if hoverNode.alloc then
+			if hoverNode.alloc and not shouldBlockGlobalNodeDeallocation(hoverNode) then
+				-- Handle deallocation of allocated nodes
 				if hoverNode.isAttribute then
 					-- change to other attribute without needing to deallocate
 					if hotkeyPressed then
@@ -283,9 +317,8 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				end
 				spec:AddUndoState()
 				build.buildFlag = true
-			elseif hoverNode.path then
-				-- Node is unallocated and can be allocated, so allocate it
-				-- attribute switching, unallocated to allocated
+			elseif hoverNode.path and not shouldBlockGlobalNodeAllocation(hoverNode) then
+				-- Handle allocation of unallocated nodes
 				if hoverNode.isAttribute and not hotkeyPressed then
 					build.treeTab:ModifyAttributePopup(hoverNode)
 				else
@@ -301,6 +334,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			end
 		end
 	elseif treeClick == "RIGHT" then
+		-- User right-clicked on a node
 		if hoverNode then
 			if hoverNode.alloc and (hoverNode.type == "Socket" or hoverNode.containJewelSocket) then
 				local slot = build.itemsTab.sockets[hoverNode.id]
@@ -834,7 +868,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			-- Draw tooltip
 			SetDrawLayer(nil, 100)
 			local size = m_floor(node.size * scale)
-			if self.tooltip:CheckForUpdate(node, self.showStatDifferences, self.tracePath, launch.devModeAlt, build.outputRevision) then
+			if self.tooltip:CheckForUpdate(node, self.showStatDifferences, self.tracePath, launch.devModeAlt, build.outputRevision, build.spec.allocMode) then
 				self:AddNodeTooltip(self.tooltip, node, build, incSmallPassiveSkillEffect)
 			end
 			self.tooltip.center = true
@@ -1138,6 +1172,9 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		if socket ~= nil and socket:IsEnabled() then
 			tooltip:AddLine(14, colorCodes.TIP.."Tip: Right click this socket to go to the items page and choose the jewel for this socket.")
 		end
+
+		self:AddGlobalNodeWarningsToTooltip(tooltip, node, build)
+
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Shift or Ctrl to hide this tooltip.")
 		return
 	end
@@ -1397,10 +1434,73 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		tooltip:AddLine(14, "^7"..#node.depends .. " points gained from unallocating these nodes")
 		tooltip:AddLine(14, colorCodes.TIP)
 	end
+
+	self:AddGlobalNodeWarningsToTooltip(tooltip, node, build)
+
 	if node.type == "Socket" then
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Shift or Ctrl to hide this tooltip.")
 	else
 		tooltip:AddLine(14, colorCodes.TIP.."Tip: Hold Ctrl to hide this tooltip.")
+	end
+end
+
+-- Helper function to check if a node is connected to weapon set nodes
+function PassiveTreeViewClass:IsConnectedToWeaponSetNodes(node)
+	-- First check the path for weapon set nodes
+	if node.path and #node.path > 1 then
+		-- Check all nodes in the path (except the first element since it's the target node itself)
+		for i = 2, #node.path do
+			local pathNode = node.path[i]
+			if pathNode.alloc and pathNode.allocMode > 0 then
+				return true
+			end
+		end
+	end
+
+	-- And finally check for direct connections when path is short or empty
+	-- (This handles cases where global nodes are directly adjacent to weapon set nodes)
+	if node.linked then
+		for _, linkedNode in ipairs(node.linked) do
+			if linkedNode.alloc and linkedNode.allocMode and linkedNode.allocMode > 0 then
+				return true
+			end
+		end
+	end
+
+	return false
+end
+
+-- Helper function to add warnings in the tooltip for global nodes (keystones/jewel sockets)
+function PassiveTreeViewClass:AddGlobalNodeWarningsToTooltip(tooltip, node, build)
+	local isGlobalNode = node.type == "Keystone" or node.type == "Socket" or node.containJewelSocket
+
+	if not isGlobalNode then
+		return -- No warning needed for non-global nodes
+	end
+
+	local nodeTypeText = node.type == "Keystone" and "keystones" or "jewel sockets"
+	local warningText = ""
+	local tipText = ""
+
+	if not node.alloc and node.path then
+		-- Unallocated global node - check allocation conditions
+		if build.spec.allocMode > 0 then
+			warningText = "Cannot allocate " .. nodeTypeText .. " while weapon set " .. build.spec.allocMode .. " is selected"
+			tipText = "Tip: Switch to main tree (Alt+scroll) to allocate " .. nodeTypeText
+		elseif self:IsConnectedToWeaponSetNodes(node) then
+			warningText = "Cannot allocate " .. nodeTypeText .. " - connected to weapon set nodes"
+			tipText = "Tip: Deallocate weapon set nodes in the connection path to allow allocation"
+		end
+	elseif node.alloc and node.allocMode == 0 and build.spec.allocMode > 0 then
+		-- Allocated main-tree global node viewed from weapon set
+		warningText = "Cannot deallocate global " .. nodeTypeText .. " from weapon set " .. build.spec.allocMode
+		tipText = "Tip: Switch to main tree (Alt+scroll) to deallocate " .. nodeTypeText
+	end
+
+	if warningText ~= "" then
+		tooltip:AddSeparator(14)
+		tooltip:AddLine(14, colorCodes.WARNING .. warningText)
+		tooltip:AddLine(14, colorCodes.TIP .. tipText)
 	end
 end
 


### PR DESCRIPTION
## Summary
Fixes a bug where global nodes (keystones and jewel sockets) could be incorrectly allocated (and deallocated) when a specific weapon set is selected.
The fix includes: UI prevention, tooltip warnings, calculation alignment with legacy builds and cache invalidation fix. 

## Changes Made

### Global Node Protection (PassiveTreeView.lua & PassiveSpec.lua)
• Extended protection to cover both **keystones** and **jewel sockets** as global nodes
• Added UI prevention to block allocation/deallocation when weapon sets are selected  
• Enhanced storage logic to ensure global nodes always get `allocMode = 0` (character-wide)

### User Warnings (PassiveTreeView.lua)
• Real-time tooltip warnings when hovering over global nodes while weapon set is selected
• Contextual messages: "Cannot allocate keystones/jewel sockets while weapon set X is selected"
• Helpful tips: "Switch to main tree (Alt+scroll) to allocate keystones/jewel sockets"

### Tooltip System Improvements
• Fixed tooltip cache invalidation when switching between weapon sets

### Legacy Compatibility & Edge Cases
• **Main-tree global nodes**: Protected from weapon set deallocation (as intended)
• **Legacy global nodes**: Can be deallocated from anywhere without restrictions (backward compatibility)
• Graceful handling of corrupted/legacy builds with incorrect allocations
• No breaking changes to save format or existing functionality

## Validations
- Tested all combinations of weapon sets and keystones
- Verified tooltip warnings appear and update correctly when switching weapon sets
- Ensured stats update correctly when global nodes are properly allocated to main tree

## Before picture (allowing allocation of keystone)
<img width="460" height="300" alt="weapon-set-1-before" src="https://github.com/user-attachments/assets/b69c4422-f671-441a-9cea-797740c699df" />
<img width="460" height="300" alt="weapon-set-2-before" src="https://github.com/user-attachments/assets/7ed3c42c-6646-4f16-a4e4-e15f7c19fc72" />
<img width="460" height="300" alt="image" src="https://github.com/user-attachments/assets/14715541-e878-4175-891d-cdb92a2e1111" />
<img width="460" height="300" alt="image" src="https://github.com/user-attachments/assets/54150f2c-e1d9-4337-b75f-aad4fbb753b8" />

## After picture (not clickable + warning)
<img width="460" height="300" alt="weapon-set-1" src="https://github.com/user-attachments/assets/0e6e01af-d53a-426c-b0ea-aaaf3ba22d2c" />
<img width="460" height="300" alt="weapon-set-2" src="https://github.com/user-attachments/assets/55d570bf-e7d8-413a-9530-c823b2f833a1" />
<img width="460" height="300" alt="image" src="https://github.com/user-attachments/assets/e0b71c85-6077-4d40-9d16-262c9efe7235" />
<img width="460" height="300" alt="image" src="https://github.com/user-attachments/assets/39e04c90-ba0b-4a19-9cca-9cc63044a999" />

**Note:** The blue/green lines in the after pictures are only shown during the tooltip preview, as nothing is set, it gets removed after moving the mouse as expected.

Fixes #1133