### PR TITLE
Fix rounding issue for min/max damage

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3409,8 +3409,8 @@ function calcs.offence(env, actor, activeSkill)
 			local baseMax = output[damageTypeMax.."Base"]
 			local summedMin = baseMin * convMult + convertedMin + gainedMin
 			local summedMax = baseMax * convMult + convertedMax + gainedMax
-			output[damageType.."SummedMinBase"] = m_floor(summedMin)
-			output[damageType.."SummedMaxBase"] = m_floor(summedMax)
+			output[damageType.."SummedMinBase"] = round(summedMin)
+			output[damageType.."SummedMaxBase"] = round(summedMax)
 			if breakdown then
 				if (baseMin ~= 0 or baseMax ~= 0) then
 					if convMult ~= 1 then


### PR DESCRIPTION
Fixes #773.

### Description of the problem being solved:
Small rounding issue when getting the min/max of damage types. This fixes the issue in the build provided.


### After screenshot:
<img width="413" height="191" alt="image" src="https://github.com/user-attachments/assets/46a5a222-a7a8-4344-8994-ef25df9cf0ee" />
