### PR TITLE
Fix rounding for armour bases

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1566,10 +1566,10 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			qualityScalar = 0
 		end
 
-		armourData.Armour = round((armourBase + armourEvasionBase + armourEnergyShieldBase) * (1 + (armourInc + armourEvasionInc + armourEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
-		armourData.Evasion = round((evasionBase + armourEvasionBase + evasionEnergyShieldBase) * (1 + (evasionInc + armourEvasionInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
-		armourData.EnergyShield = round((energyShieldBase + evasionEnergyShieldBase + armourEnergyShieldBase) * (1 + (energyShieldInc + armourEnergyShieldInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
-		armourData.Ward = round((wardBase) * (1 + (wardInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.Armour = m_floor((armourBase + armourEvasionBase + armourEnergyShieldBase) * (1 + (armourInc + armourEvasionInc + armourEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.Evasion = m_floor((evasionBase + armourEvasionBase + evasionEnergyShieldBase) * (1 + (evasionInc + armourEvasionInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.EnergyShield = m_floor((energyShieldBase + evasionEnergyShieldBase + armourEnergyShieldBase) * (1 + (energyShieldInc + armourEnergyShieldInc + evasionEnergyShieldInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
+		armourData.Ward = m_floor((wardBase) * (1 + (wardInc + defencesInc) / 100) * (1 + (qualityScalar / 100)))
 
 		if self.base.armour.BlockChance then
 			armourData.BlockChance = m_floor((self.base.armour.BlockChance + calcLocal(modList, "BlockChance", "BASE", 0)) * (1 + calcLocal(modList, "BlockChance", "INC", 0) / 100))


### PR DESCRIPTION
Fixes #787

EDIT: Need to test out more, but some items seem to round down at 0.5, other up. In the linked build, Sol Stride comes to 220.5 and is 220 in game. Entropy Pace is 93.5 and 94 in game. In PoB, it shows 94 and 221, opposite behaviour of each other.

I tried taking the quality to the base first, then rounding it. But If we round normally, Entropy Pace and Sol Stride are both .5, which becomes an issue for final stat as said. If we round up, Entropy Pace becomes 95 ES. The Bound Boots also land on 178.5 with normal rounding before this PR. But our tooltip rounds that UP to 179, which is correct.

Floating point stuff, or maybe certain bases round differently for some reason?

https://maxroll.gg/poe2/pob/g898v0ld
This has a handful of items with expected values for testing.
### Description of the problem being solved:
Bases were being rounded, but it appears they are not. Haven't confirmed armour/evasion do the same, but assuming they are. Before PR the calcs come to 220.5, which would round to 221. On trade and in the issue linked the item was 220 ES.

### After screenshot:
<img width="834" height="444" alt="image" src="https://github.com/user-attachments/assets/25318076-129f-4156-b719-28b49d0f6db3" />
