### PR TITLE
Fix Imported Gem level for skills linked to + gem level supports

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -733,7 +733,11 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 			gemInstance.nameSpec = self.build.data.gems[gemId].name
 			for _, property in pairs(skillData.properties) do
 				if property.name == "Level" then
-					gemInstance.level = tonumber(property.values[1][1]:match("%d+"))
+					if skillData.properties[_ + 1] and skillData.properties[_ + 1].values[1][1]:match("(%d+) Level[s]? from Gem") then
+						gemInstance.level = tonumber(skillData.properties[_ + 1].values[1][1]:match("(%d+) Level[s]? from Gem"))
+					else
+						gemInstance.level = tonumber(property.values[1][1]:match("%d+"))
+					end
 				elseif escapeGGGString(property.name) == "Quality" then
 					gemInstance.quality = tonumber(property.values[1][1]:match("%d+"))
 				end


### PR DESCRIPTION
The level property for gems linked to + gem level supports already takes into account the levels gained by support gems and does not give the raw gem level
Instead, we take the level from the property after levels (if it exists), as that is the one that has the raw gem level

Before:
Level 18 Gem with +2 Gem level supports and +3 Global levels
<img width="379" height="275" alt="image" src="https://github.com/user-attachments/assets/881f2973-e569-43cc-a0f7-5622e9b75eb2" />

After:
Level 18 Gem with +2 Gem level supports and +3 Global levels
<img width="381" height="288" alt="image" src="https://github.com/user-attachments/assets/a60060ef-f7ad-4e41-af45-8f0a124da00e" />
