### PR TITLE
Fix hover tooltip showing same name for all companions/spectres

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1148,7 +1148,7 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 		for _, skillEffect in ipairs(activeSkill.effectList) do
 			tooltip:AddLine(20, string.format("%s%s ^7%d%s/%d%s",
 				data.skillColorMap[skillEffect.grantedEffect.color or skillEffect.gemData and skillEffect.gemData.grantedEffect.color],
-				skillEffect.grantedEffect.name,
+				skillEffect.srcInstance.nameSpec or skillEffect.grantedEffect.name,
 				skillEffect.srcInstance and skillEffect.srcInstance.level or skillEffect.level,
 				(skillEffect.srcInstance and skillEffect.level > skillEffect.srcInstance.level) and colorCodes.MAGIC.."+"..(skillEffect.level - skillEffect.srcInstance.level).."^7" or "",
 				skillEffect.srcInstance and skillEffect.srcInstance.quality or skillEffect.quality,


### PR DESCRIPTION
### Description of the problem being solved:
The hover tooltip did not show the gem name per instance, so Companion/Spectres were showing the same on all tooltips.

### Before screenshot:
<img width="599" height="249" alt="image" src="https://github.com/user-attachments/assets/31ae11e7-426a-4b2f-86c1-26e08b71f432" />
### After screenshot:
<img width="732" height="250" alt="image" src="https://github.com/user-attachments/assets/c066ab60-86bc-420b-ac83-a646cea7ebfc" />
