### PR TITLE
Fix invalid authentification URL being opened 

### DIFF
--- a/src/Classes/PoEAPI.lua
+++ b/src/Classes/PoEAPI.lua
@@ -70,7 +70,7 @@ function PoEAPIClass:FetchAuthToken(callback)
 
 	local authUrl = string.format(
 		"https://www.pathofexile.com/oauth/authorize?client_id=pob&response_type=code&scope=%s&state=%s&code_challenge=%s&code_challenge_method=S256"
-		,table.concat(scopesOAuth, " ")
+		,table.concat(scopesOAuth, "%20")
 		,initialState
 		,code_challenge
 	)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

This may or may not be specific to my environment, i.e. Linux starting PoB through wine.

My goal was to import my character using the import API. The issue happens when I go through the authentication flow, as the URL opened in my browser was truncated at the first space, resulting in a invalid webpage opening, and the inability to authenticate.

### Steps taken to verify a working solution:
In the character import screen:
- Logout if previously authenticated (*Logout from Path of Exile API*)
- Attempt to authenticate again (*Authorize with Path of Exile*)
- Verify that the browser manages to open the authentication page

### Link to a build that showcases this PR:
N/A

### Before fix:
App logs:
```
Server started on 0.0.0.0:49082
Redirect URI: http://localhost:49082
Opening URL: https://www.pathofexile.com/oauth/authorize?client_id=pob&response_type=code&scope=account:profile account:leagues account:characters&state=XXXX&code_challenge=XXXX&code_challenge_method=S256&redirect_uri=http://localhost:49082
```

Firefox opens : `https://www.pathofexile.com/oauth/authorize?client_id=pob&response_type=code&scope=account:profile` which returns:
```json
{
  "error": "invalid_uri",
  "error_description": "The redirect URI is mandatory and was not supplied"
}
```

### After fix:
```
Server started on 0.0.0.0:49082
Redirect URI: http://localhost:49082
Opening URL: https://www.pathofexile.com/oauth/authorize?client_id=pob&response_type=code&scope=account:profile%20account:leagues%20account:characters&state=XXXX&code_challenge=XXX&code_challenge_method=S256&redirect_uri=http://localhost:49082
```

Firefox opens the correct URL
