### PR TITLE
Fix Gem tooltips missing stats on some skills

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -562,6 +562,10 @@ function GemSelectClass:AddGemTooltip(gemInstance)
 			for _, statSet in ipairs(additional.statSets) do
 				self:AddStatSetInfo(gemInstance, grantedEffect, statSet)
 			end
+		else
+			for _, statSet in ipairs(additional.statSets) do
+				self:AddStatSetInfo(gemInstance, grantedEffect, statSet, true)
+			end
 		end
 	end
 end
@@ -682,14 +686,14 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 		end
 	end
 end
-function GemSelectClass:AddStatSetInfo(gemInstance, grantedEffect, statSet)
+function GemSelectClass:AddStatSetInfo(gemInstance, grantedEffect, statSet, noLabel)
 	local displayInstance = gemInstance.displayEffect or gemInstance
 	local statSetLevel = statSet.levels[displayInstance.level] or { }
-	if statSet.label ~= grantedEffect.name and statSet.label ~= "" then
+	if statSet.label ~= grantedEffect.name and statSet.label ~= "" and not noLabel then
 		self.tooltip:AddSeparator(10)
 		self.tooltip:AddLine(20, colorCodes.GEM .. statSet.label)
+		self.tooltip:AddSeparator(10)
 	end
-	self.tooltip:AddSeparator(10)
 	if statSetLevel.critChance then
 		self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", statSetLevel.critChance))
 	end
@@ -697,7 +701,7 @@ function GemSelectClass:AddStatSetInfo(gemInstance, grantedEffect, statSet)
 		self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%d%%", statSetLevel.baseMultiplier * 100))
 	end
 	if self.skillsTab and self.skillsTab.build.data.describeStats then
-		self.tooltip:AddSeparator(10)
+		if not noLabel then self.tooltip:AddSeparator(10) end
 		local stats = calcLib.buildSkillInstanceStats(displayInstance, grantedEffect, statSet)
 		--if mergeStatsFrom then
 		--	for stat, val in pairs(calcLib.buildSkillInstanceStats(displayInstance, mergeStatsFrom)) do

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -5211,7 +5211,7 @@ skills["SupportMirageArcherPlayer"] = {
 		[1] = {
 			label = "SupportMirageArcherPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -849,7 +849,7 @@ skills["SupportBarrierInvocationPlayer"] = {
 		[1] = {
 			label = "SupportBarrierInvocationPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -1076,7 +1076,7 @@ skills["SupportBlasphemyPlayer"] = {
 		[1] = {
 			label = "Curses",
 			incrementalEffectiveness = 0.092720001935959,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			statMap = {
 				["support_blasphemy_curse_effect_+%_final"] = {
 					mod("CurseEffect", "MORE", nil),
@@ -2133,7 +2133,7 @@ skills["SupportMetaCastOnCritPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnCritPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -2356,7 +2356,7 @@ skills["SupportMetaCastOnDodgePlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnDodgePlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -2580,7 +2580,7 @@ skills["SupportMetaCastOnElementalAilmentPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnElementalAilmentPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -2802,7 +2802,7 @@ skills["SupportMetaCastOnMinionDeathPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnMinionDeathPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -4385,7 +4385,7 @@ skills["SupportMetaCastCurseOnBlockPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastCurseOnBlockPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -5552,7 +5552,7 @@ skills["SupportElementalInvocationPlayer"] = {
 		[1] = {
 			label = "SupportElementalInvocationPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -11220,7 +11220,7 @@ skills["SupportHandOfChayulaPlayer"] = {
 		[1] = {
 			label = "Support",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			stats = {
@@ -15934,7 +15934,7 @@ skills["SupportReapersInvocationPlayer"] = {
 		[1] = {
 			label = "SupportReapersInvocationPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -570,7 +570,7 @@ skills["SupportAncestralWarriorTotemPlayer"] = {
 		[1] = {
 			label = "SupportAncestralWarriorTotemPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			statMap = {
 				["support_ancestral_warrior_totem_attack_speed_+%_final"] = {
 					mod("Speed", "MORE", nil, ModFlag.Attack),
@@ -1856,7 +1856,7 @@ skills["SupportMetaCastOnBlockPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnBlockPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -1961,7 +1961,7 @@ skills["SupportMetaCastOnMeleeKillPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnMeleeKillPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -2029,7 +2029,7 @@ skills["SupportMetaCastOnMeleeStunPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnMeleeStunPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -11244,7 +11244,7 @@ skills["SupportMortarCannonPlayer"] = {
 		[1] = {
 			label = "SupportMortarCannonPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			statMap = {
 				["support_grenade_ballista_damage_+%_final"] = {
 					mod("Damage", "MORE", nil),
@@ -14367,7 +14367,7 @@ skills["SupportMetaCastLightningSpellOnHitPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastLightningSpellOnHitPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -1023,7 +1023,7 @@ skills["SupportMetaDeadeyeMarksPlayer"] = {
 		[1] = {
 			label = "SupportMetaDeadeyeMarksPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -1247,7 +1247,7 @@ skills["SupportMetaCastOnCharmUsePlayer"] = {
 		[1] = {
 			label = "SupportMetaCastOnCharmUsePlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {
@@ -3021,7 +3021,7 @@ skills["SupportMetaCastFireSpellOnHitPlayer"] = {
 		[1] = {
 			label = "SupportMetaCastFireSpellOnHitPlayer",
 			incrementalEffectiveness = 0.054999999701977,
-			statDescriptionScope = "gem_stat_descriptions",
+			statDescriptionScope = "meta_gem_stat_descriptions",
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -679,7 +679,19 @@ directiveTable.set = function(state, args, out)
 		out:write('\t\t\tdamageIncrementalEffectiveness = ', grantedEffectStatSet.DamageIncrementalEffectiveness, ',\n')
 	end
 	if state.granted.IsSupport then
-		state.statDescriptionScope = "gem_stat_descriptions"
+		local gemEffect = dat("GemEffects"):GetRowList("AdditionalGrantedEffects", state.granted )
+		if gemEffect[1] and gemEffect[1].Tags then
+			for _, tag in ipairs(gemEffect[1].Tags) do
+				if tag.Id == "meta" then
+					skill.isMeta = true
+				end
+			end
+		end
+		if skill.isMeta then
+			state.statDescriptionScope = "meta_gem_stat_descriptions"
+		else
+			state.statDescriptionScope = "gem_stat_descriptions"
+		end
 	else
 		state.statDescriptionScope = state.granted.ActiveSkill.StatDescription:gsub("^Metadata/StatDescriptions/", ""):
 		-- Need to subtract 1 from setIndex because GGG indexes from 0

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -7418,7 +7418,7 @@ return {
 		},
 		[6]={
 			list=true,
-			name="",
+			name="StatSetIndex",
 			refTo="",
 			type="Int",
 			width=150


### PR DESCRIPTION
Gems that had a secondary granted effect were not showing mods
Meta gems were missing mods too as they weren't using the correct statDescription scope

Before:
<img width="431" height="331" alt="image" src="https://github.com/user-attachments/assets/f64f0639-cfa2-4c0e-b1ef-88fdab3a9d55" />


After:
<img width="474" height="385" alt="image" src="https://github.com/user-attachments/assets/9bf430fe-bfc0-4463-b110-0851636dd524" />
