### PR TITLE
Implement Stoicism support and fix Innervate Support

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -759,6 +759,14 @@ return {
 ["active_skill_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),
 },
+["support_no_fear_damage_+%_final_per_second_up_to_30%"] = {
+	mod("Damage", "MORE", nil, 0, 0,
+		{ type = "Condition", var = "UsingStoicism" },
+		{ type = "Condition", var = "DodgeRolledRecently", neg = true },
+		{ type = "Condition", var = "UsedTravelSkillRecently", neg = true },
+		{ type = "Multiplier", var = "StoicismSeconds", limitVar = "StoicismCap", limitTotal = true }
+	),
+},
 ["active_skill_damage_+%_final_against_heavy_stunned_enemies"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "HeavyStunned" }),
 },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2614,7 +2614,7 @@ skills["SupportInnervatePlayer"] = {
 				["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
 					mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
 				},
-				["support_innervate_base_buff_duration"] = {
+				["support_innervate_buff_base_duration_ms"] = {
 					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),
 					div = 1000,
 				},

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -586,7 +586,7 @@ statMap = {
 	["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
 		mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
 	},
-	["support_innervate_base_buff_duration"] = {
+	["support_innervate_buff_base_duration_ms"] = {
 		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),
 		div = 1000,
 	},

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -402,10 +402,6 @@ local configSettings = {
 	{ var = "infusedChannellingInfusion", type = "check", label = "Is Infusion active?", ifSkill = "Infused Channelling", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:InfusionActive", "FLAG", true, "Config")
 	end },
-	{ label = "Innervate:", ifSkill = "Innervate" },
-	{ var = "innervateInnervation", type = "check", label = "Is Innervation active?", ifSkill = "Innervate", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:InnervationActive", "FLAG", true, "Config")
-	end },
 	{ label = "Intensify:", ifSkill = { "Intensify", "Crackling Lance", "Pinpoint" } },
 	{ var = "intensifyIntensity", type = "count", label = "# of Intensity:", ifSkill = { "Intensify", "Crackling Lance", "Pinpoint" }, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:Intensity", "BASE", val, "Config")

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -432,6 +432,12 @@ local configSettings = {
 	{ var = "momentumDamage", type = "check", label = "Moved 2m during Skill use?", ifSkill = "Momentum", ifFlag = "CanPerformSkillWhileMoving", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Moved2m", "FLAG", true, "Config")
 	end },
+	{ label = "Stoicism:", ifSkill = { "Stoicism I", "Stoicism II" } },
+	{ var = "stoicismSeconds", type = "count", label = "Seconds building Stoicism:", ifSkill = { "Stoicism I", "Stoicism II" }, tooltip = "Seconds since last reset. Stoicism I: 1%/s (full 20s). Stoicism II: 2%/s (full 10s).", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:UsingStoicism", "FLAG", true, "Config")
+		modList:NewMod("Multiplier:StoicismSeconds", "BASE", m_min(m_max(val, 0), 20), "Config")
+		modList:NewMod("Multiplier:StoicismCap", "BASE", 20, "Config")
+	end },
 	{ label = "Parry:", ifSkill = "Parry" },
 	{ var = "parryActive", type = "check", label = "Enemy has Parry Debuff", ifSkill = "Parry", tooltip = "The Parry debuff grants:\n\tEnemies take 50% more Attack Damage", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:ParryActive", "FLAG", true, "Config")


### PR DESCRIPTION
- Stoicism support:
  - Implemented ramping more Damage (cap 20%), resets on roll/travel
  - Added config: Seconds building Stoicism
- Innervate fixes:
  - Fixed duration stat key so gem shows as supported on tooltip
  - Removed Innervation checkbox; use “Killed a Shocked enemy in last 3s”