### PR TITLE
Add Mask of the Sanguimancer Unique

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -460,6 +460,15 @@ Allies in your Presence deal 50% increased Damage
 {variant:2}+(10-20) to Dexterity
 25% reduced Damage
 ]],[[
+Mask of the Sanguimancer
+Face Mask
++(20-25) to Evasion Rating
++(10-15) to maximum Energy Shield
+(20-40)% increased Critical Hit Chance for Spells
++(10-20) to Strength
++(10-20) to Intelligence
+Blood Magic
+]],[[
 Mind of the Council
 Death Mask
 League: Dawn of the Hunt

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -458,6 +458,14 @@ UniqueNearbyAlliesAllDamage1
 {variant:2}UniqueDexterity32
 UniqueAllDamage1
 ]],[[
+Mask of the Sanguimancer
+Face Mask
+UniqueLocalBaseEvasionRatingAndEnergyShield2
+UniqueSpellCriticalStrikeChance1
+UniqueStrength8
+UniqueIntelligence10
+UniqueBloodMagic1
+]],[[
 Mind of the Council
 Death Mask
 League: Dawn of the Hunt


### PR DESCRIPTION
Fixes #1267

### Description of the problem being solved:
We were missing the Mask of the Sanguimancer Unique from 0.1.0.
### After screenshot:
<img width="366" height="346" alt="image" src="https://github.com/user-attachments/assets/818ab689-431d-4f02-8764-56d8d86aa22e" />
