### PR TITLE
Fix Crash when using Bow with +1 Arrow Rune

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -809,7 +809,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			local specificItemType = self.base.type:lower()
 			for runeName, runeMods in pairs(data.itemMods.Runes) do
 				local addModToGroupedRunes = function (modLine)
-					local runeValue
+					local runeValue = 1
 					local runeStrippedModLine = modLine:gsub("(%d%.?%d*)", function(val)
 						runeValue = val
 						return "#"
@@ -835,7 +835,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 
 			local remainingRunes = self.itemSocketCount
 			for i, modLine in ipairs(self.runeModLines) do
-				local value
+				local value = 1
 				local strippedModLine = modLine.line:gsub("(%d%.?%d*)", function(val)
 					value = val
 					return "#"


### PR DESCRIPTION
In the function to try and guess how many of the same rune there are on an item, it expects to see an integer somewhere in the modline
The fix sets the value as 1 but should be fine as if a mod has a number in it, the value will be overwritten anyway
Fixes #1279