### PR TITLE
Fix OAuth2 redirect timeouts caused by closing the server too early

### DIFF
--- a/src/LaunchServer.lua
+++ b/src/LaunchServer.lua
@@ -95,15 +95,15 @@ ConPrintf("Opening URL: %s", url)
 OpenURL(url)
 
 --- Handle an incoming socket connection, to complete an OAuth redirect.
---- @param client table The socket connection to handle, as returned by `server:accept()`.
---- @param attempt number The number of attempts made to handle an incoming connection. This is used for logging
+--- @param client table @The socket connection to handle, as returned by `server:accept()`.
+--- @param attempt number @The number of attempts made to handle an incoming connection. This is used for logging
 --- purposes, since spurious issues can be difficult to identify otherwise.
---- @return boolean shouldRetry Whether we should wait for another connection. If false, we've successfully responded to
---- a HTTP request. Note that, for the purposes of this function, we don't care whether authorization was *granted*,
+--- @return boolean shouldRetry @Whether we should wait for another connection. If false, we've successfully responded
+--- to a HTTP request. Note that, for the purposes of this function, we don't care whether authorization was *granted*,
 --- just that the process itself was completed and the user was redirected as intended.
---- @return string? code The OAuth authorization code. This is exchanged for an access token and refresh token later.
---- @return string? state The OAuth state string. This is a sentinel value used to ensure that a request hasn't been
---  forged.
+--- @return string? code @The OAuth authorization code. This is exchanged for an access token and refresh token later.
+--- @return string? state @The OAuth state string. This is a sentinel value used to ensure that a request hasn't been
+--- forged.
 function handleConnection(client, attempt)
 	local shouldRetry, code, state = true, nil, nil
 


### PR DESCRIPTION
Fixes the issue mentioned in #994, where redirects don't behave properly.

### Description of the problem being solved:
I've explained it in greater detail in a comment in `LaunchServer.lua`, but this fixes a hard-to-pin-down timing issue that caused OAuth authorization to fail. More specifically, the server only waited for one connection before closing, so _anything_ elsewhere on the OS misbehaving (be it a loopback adaptor, a VPN/proxy application, or some other program) by opening a connection would cause the server to give up and close, _before_ the actual OAuth redirect reached it, which resulted in the OAuth redirect timing out, as described in #994. This prevented me from importing characters - since the OAuth redirect never completed, PoB never received the authorization code necessary to retrieve an access/refresh token later. I assume it's something many others have run into once or twice as well.

### Steps taken to verify a working solution:
- Repeated testing in a development environment
- Static type-checking provided by EmmyLua

### Link to a build that showcases this PR:

Environment-dependent, any build or account could cause this issue.

### Before screenshot:

<img width="1065" height="438" alt="image" src="https://github.com/user-attachments/assets/dbfaf633-6590-422f-93cb-9a37d3ce45dd" />

### After screenshot:

<img width="643" height="316" alt="image" src="https://github.com/user-attachments/assets/edc0e1a0-6911-4a53-bb12-abb91983f864" />
