### PR TITLE
Fix incorrect radius on Explosive Spear

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2584,6 +2584,7 @@ skills["ExplosiveSpearPlayer"] = {
 				{ "base_number_of_remote_spear_mines_allowed", 1 },
 				{ "active_skill_base_physical_damage_%_to_convert_to_fire", 60 },
 				{ "remote_spear_mine_minimum_target_distance", 10 },
+				{ "active_skill_base_area_of_effect_radius", 28 },
 				{ "active_skill_base_physical_damage_%_to_convert_to_fire", 40 },
 			},
 			stats = {
@@ -2660,6 +2661,7 @@ skills["ExplosiveSpearPlayer"] = {
 				{ "base_number_of_remote_spear_mines_allowed", 1 },
 				{ "active_skill_base_physical_damage_%_to_convert_to_fire", 60 },
 				{ "remote_spear_mine_minimum_target_distance", 10 },
+				{ "active_skill_base_area_of_effect_radius", 40 },
 				{ "active_skill_base_secondary_area_of_effect_radius", 15 },
 				{ "active_skill_base_tertiary_area_of_effect_radius", 20 },
 				{ "active_skill_base_physical_damage_%_to_convert_to_fire", 40 },

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -501,10 +501,25 @@ directiveTable.set = function(state, args, out)
 			statRow.InterpolationBases = tableConcat(baseStatRow.InterpolationBases, statRow.InterpolationBases)
 			statRow.AdditionalStats = tableConcat(baseStatRow.AdditionalStats, statRow.AdditionalStats)
 			statRow.AdditionalStatsValues = tableConcat(baseStatRow.AdditionalStatsValues, statRow.AdditionalStatsValues)
+			statRow.BaseStats = tableConcat(tableConcat(tableConcat(skill.baseGrantedEffectStatSet.ImplicitStats, skill.baseGrantedEffectStatSet.ConstantStats), baseStatRow.FloatStats), baseStatRow.AdditionalStats)
 		end
 		level.statInterpolation = statRow.StatInterpolations
 		level.actorLevel = statRow.ActorLevel
 		local tempRemoveStats = copyTable(set.removeStats, true)
+		for i, removeStat in pairs(set.removeStats) do
+			-- Fixes the case where a removeStat does not exist in the base set but does in future sets
+			-- It should not be removed if this is the case
+			local remove = false
+			for _, stat in ipairs(statRow.BaseStats) do
+				if stat.Id == removeStat then
+					remove = true
+				end
+			end
+			if remove == false then
+				table.remove(tempRemoveStats, i)
+				table.remove(set.removeStats, i)
+			end
+		end
 		local resolveInterpolation = true
 		local injectConstantValuesIntoEachLevel = false
 		local statMapOrderIndex = 1


### PR DESCRIPTION
Explosive Spear had `active_skill_base_area_of_effect_radius` as a remove stat but it did not exist in the base stat set for the skill so it was incidentally removing the stat from the following stat sets
Fixes #1258