### PR TITLE
Feat: Implement trade mode selection

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -359,6 +359,20 @@ Highest Weight - Displays the order retrieved from trade]]
 		-- self:PullPoENinjaCurrencyConversion(self.pbLeague)
 	end)
 	self.controls.pbNotice = new("LabelControl",  {"BOTTOMRIGHT", nil, "BOTTOMRIGHT"}, {-row_height - pane_margins_vertical - row_vertical_padding, -pane_margins_vertical - row_height - row_vertical_padding, 300, row_height}, "")
+	
+	-- Add Trade Mode dropdown to the bottom right
+	self.tradeModeList = {
+		"Instant Buyout and In Person Trade",
+		"Instant Buyout Only",
+		"In Person Trade Only",
+		"Any"
+	}
+	self.pbTradeModeSelectionIndex = 3 -- Default to "In Person Trade Only"
+	self.controls.tradeModeSelection = new("DropDownControl", {"BOTTOMRIGHT", nil, "BOTTOMRIGHT"}, {-pane_margins_horizontal, -pane_margins_vertical, 220, row_height}, self.tradeModeList, function(index, value)
+		self.pbTradeModeSelectionIndex = index
+	end)
+	self.controls.tradeModeSelection:SetSel(self.pbTradeModeSelectionIndex)
+	self.controls.tradeModeSelection.enableDroppedWidth = true
 
 	-- Realm selection
 	self.controls.realmLabel = new("LabelControl", {"LEFT", self.controls.setSelect, "RIGHT"}, {18, 0, 20, row_height - 4}, "^7Realm:")
@@ -844,7 +858,7 @@ function TradeQueryClass:PriceItemRowDisplay(row_idx, top_pane_alignment_ref, ro
 	local nameColor = slotTbl.unique and colorCodes.UNIQUE or "^7"
 	controls["name"..row_idx] = new("LabelControl", top_pane_alignment_ref, {0, row_idx*(row_height + row_vertical_padding), 100, row_height - 4}, nameColor..slotTbl.slotName)
 	controls["bestButton"..row_idx] = new("ButtonControl", { "LEFT", controls["name"..row_idx], "LEFT"}, {100 + 8, 0, 80, row_height}, "Find best", function()
-		self.tradeQueryGenerator:RequestQuery(activeSlot, { slotTbl = slotTbl, controls = controls, row_idx = row_idx }, self.statSortSelectionList, function(context, query, errMsg)
+		self.tradeQueryGenerator:RequestQuery(activeSlot, { slotTbl = slotTbl, controls = controls, row_idx = row_idx }, self.statSortSelectionList, self.pbTradeModeSelectionIndex, function(context, query, errMsg)
 			if errMsg then
 				self:SetNotice(context.controls.pbNotice, colorCodes.NEGATIVE .. errMsg)
 				return

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -817,6 +817,9 @@ function TradeQueryGeneratorClass:FinishQuery()
 	-- So apply a modifier to get a reasonable min and hopefully approximate that the query will start out with small upgrades.
 	local minWeight = megalomaniacSpecialMinWeight or currentStatDiff * 0.5
 	
+	local tradeModeMap = { "available", "securable", "online", "any" }
+	local tradeMode = tradeModeMap[self.calcContext.options.tradeModeIndex] or "online"
+	
 	-- Generate trade query str and open in browser
 	local filters = 0
 	local queryTable = {
@@ -829,7 +832,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 					}
 				}
 			},
-			status = { option = "online" },
+			status = { option = tradeMode },
 			stats = {
 				{
 					type = "weight",
@@ -910,7 +913,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 	main:ClosePopup()
 end
 
-function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callback)
+function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, tradeModeIndex, callback)
 	self.requesterCallback = callback
 	self.requesterContext = context
 
@@ -1029,6 +1032,7 @@ function TradeQueryGeneratorClass:RequestQuery(slot, context, statWeights, callb
 			options.sockets = tonumber(controls.sockets.buf)
 		end
 		options.statWeights = statWeights
+		options.tradeModeIndex = tradeModeIndex
 
 		self:StartQuery(slot, options)
 	end)


### PR DESCRIPTION
### Description of the problem being solved:
> This PR introduces a **"Trade Mode"** dropdown to the Trader pane, giving users control over the online status of their item searches. Previously, all weighted searches were hardcoded to _"In Person Trade Only"_ (`online`). This change allows users to specify their preferred trade method, enabling searches for items with instant buyouts or including offline listings.

The four available options are:
* Instant Buyout and In Person Trade (`available`)
* Instant Buyout Only (`securable`)
* In Person Trade Only (`online`)
* Any (`any`)

### Steps taken to verify a working solution:
- Opened the Trader pane and selected each of the four options from the new **"Trade Mode"** dropdown.
- Generated a **"Find best"** weighted search for an item slot for each selection.
- Verified that the resulting trade query correctly used the corresponding status option (`available`, `securable`, `online`, `any`).
- Confirmed that the default selection is _"In Person Trade Only"_ to maintain the previous default behavior.

### Link to a build that showcases this PR:

> Not applicable. This is a core feature enhancement for the Trader and is not build-specific.

### Before screenshot:
<img width="856" height="595" alt="image" src="https://github.com/user-attachments/assets/a84db130-55a2-434c-8809-4ede68e95eee" />

**
*_The Trader pane UI before this change, with no option to select the trade mode in the bottom-right corner._*

### After screenshot:
<img width="855" height="655" alt="image" src="https://github.com/user-attachments/assets/d3e054e9-5d74-418a-a223-b8041501a309" />

**
*_The Trader pane UI with the new **"Trade Mode"** dropdown displayed in the bottom-right corner._*