### PR TITLE
Fix incorrect base types on Crown of Eyes and The Prisoner's Manacles

### DIFF
--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -269,7 +269,7 @@ Gain (4-6) Mana per Enemy Killed
 Enemies in your Presence killed by anyone count as being killed by you instead
 ]],[[
 The Prisoner's Manacles
-Diviner Cuffs
+Verisium Cuffs
 League: Dawn of the Hunt
 (200-300)% increased Armour and Energy Shield
 +100 to maximum Life

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -175,7 +175,7 @@ Variant: Current
 {variant:2}Gain (10-15)% of maximum Life as Extra maximum Energy Shield
 ]],[[
 Crown of Eyes
-Coral Circlet
+Vermeil Circlet
 League: Dawn of the Hunt
 (100-140)% increased Energy Shield
 +(150-200) to Accuracy Rating

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -269,7 +269,7 @@ UniqueManaGainedFromEnemyDeath4
 UniqueEnemiesKilledCountAsYours1
 ]],[[
 The Prisoner's Manacles
-Diviner Cuffs
+Verisium Cuffs
 League: Dawn of the Hunt
 UniqueLocalIncreasedArmourAndEnergyShield21
 UniqueIncreasedLife54

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -175,7 +175,7 @@ Variant: Current
 {variant:2}UniqueEnergyShieldAsPercentOfLife1
 ]],[[
 Crown of Eyes
-Coral Circlet
+Vermeil Circlet
 League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent23
 UniqueIncreasedAccuracy9


### PR DESCRIPTION
Fixes #1290  .

### Description of the problem being solved:
These two uniques were still on basetypes that were removed, so they weren't showing up in the uniques list

### Before screenshot:
<img width="385" height="239" alt="image" src="https://github.com/user-attachments/assets/7e6c7e4f-4797-465a-9715-831ff2fa4df9" />

### After screenshot:
<img width="789" height="590" alt="image" src="https://github.com/user-attachments/assets/e6b9d7d2-1e85-49ea-803d-9be8dbaaad70" />
