### PR TITLE
Fix quality stats on gems not showing up in gem tooltip

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -560,11 +560,11 @@ function GemSelectClass:AddGemTooltip(gemInstance)
 			self.tooltip:AddSeparator(10)
 			self:AddGrantedEffectInfo(gemInstance, additional)
 			for _, statSet in ipairs(additional.statSets) do
-				self:AddStatSetInfo(gemInstance, grantedEffect, statSet)
+				self:AddStatSetInfo(gemInstance, additional, statSet)
 			end
 		else
 			for _, statSet in ipairs(additional.statSets) do
-				self:AddStatSetInfo(gemInstance, grantedEffect, statSet, true)
+				self:AddStatSetInfo(gemInstance, additional, statSet, true)
 			end
 		end
 	end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -573,7 +573,7 @@ end
 function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 	local displayInstance = gemInstance.displayEffect or gemInstance
 	local grantedEffectLevel = grantedEffect.levels[displayInstance.level] or { }
-	if gemInstance.gemData.Tier and not grantedEffect.isLineage then
+	if gemInstance.gemData.Tier and not grantedEffect.isLineage and not grantedEffect.hidden then
 			self.tooltip:AddLine(16, string.format("^x7F7F7FTier: ^7%d", gemInstance.gemData.Tier))
 		end
 	if addReq and not grantedEffect.support then
@@ -583,7 +583,7 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 			(gemInstance.level >= gemInstance.gemData.naturalMaxLevel) and " (Max)" or ""
 		))
 	end
-	if grantedEffect.support then
+	if grantedEffect.support and not grantedEffect.hidden then
 		if grantedEffectLevel.manaMultiplier and grantedEffectLevel.reservationMultiplier and grantedEffectLevel.manaMultiplier == grantedEffectLevel.reservationMultiplier then
 			self.tooltip:AddLine(16, string.format("^x7F7F7FCost & Reservation Multiplier: ^7%d%%", grantedEffectLevel.manaMultiplier + 100))
 		elseif grantedEffectLevel.reservationMultiplier then
@@ -628,41 +628,43 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 		if cost then
 			self.tooltip:AddLine(16, "^x7F7F7FCost: ^7"..cost)
 		end
-		if grantedEffectLevel.cooldown then
-			local string = string.format("^x7F7F7FCooldown Time: ^7%.2f sec", grantedEffectLevel.cooldown)
-			if grantedEffectLevel.storedUses and grantedEffectLevel.storedUses > 1 then
-				string = string .. string.format(" (%d uses)", grantedEffectLevel.storedUses)
+		if not grantedEffect.hidden then
+			if grantedEffectLevel.cooldown then
+				local string = string.format("^x7F7F7FCooldown Time: ^7%.2f sec", grantedEffectLevel.cooldown)
+				if grantedEffectLevel.storedUses and grantedEffectLevel.storedUses > 1 then
+					string = string .. string.format(" (%d uses)", grantedEffectLevel.storedUses)
+				end
+				self.tooltip:AddLine(16, string)
 			end
-			self.tooltip:AddLine(16, string)
-		end
-		if grantedEffectLevel.vaalStoredUses then
-			self.tooltip:AddLine(16, string.format("^x7F7F7FCan Store ^7%d ^x7F7F7FUse (%d Souls)", grantedEffectLevel.vaalStoredUses, grantedEffectLevel.vaalStoredUses * grantedEffectLevel.cost.Soul))
-		end
-		if grantedEffectLevel.soulPreventionDuration then
-			self.tooltip:AddLine(16, string.format("^x7F7F7FSoul Gain Prevention: ^7%d sec", grantedEffectLevel.soulPreventionDuration))
-		end
-		if gemInstance.gemData.tags.attack then
-			if grantedEffectLevel.attackSpeedMultiplier then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Speed: ^7%d%% of base", grantedEffectLevel.attackSpeedMultiplier + 100))
+			if grantedEffectLevel.vaalStoredUses then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FCan Store ^7%d ^x7F7F7FUse (%d Souls)", grantedEffectLevel.vaalStoredUses, grantedEffectLevel.vaalStoredUses * grantedEffectLevel.cost.Soul))
 			end
-			if grantedEffectLevel.attackTime then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Time: ^7%.2f sec", grantedEffectLevel.attackTime / 1000))
+			if grantedEffectLevel.soulPreventionDuration then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FSoul Gain Prevention: ^7%d sec", grantedEffectLevel.soulPreventionDuration))
 			end
-			if grantedEffectLevel.baseMultiplier then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%g%% of base", grantedEffectLevel.baseMultiplier * 100))
-			end
-		else
-			if grantedEffect.castTime > 0 then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FCast Time: ^7%.2f sec", grantedEffect.castTime))
+			if gemInstance.gemData.tags.attack then
+				if grantedEffectLevel.attackSpeedMultiplier then
+					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Speed: ^7%d%% of base", grantedEffectLevel.attackSpeedMultiplier + 100))
+				end
+				if grantedEffectLevel.attackTime then
+					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Time: ^7%.2f sec", grantedEffectLevel.attackTime / 1000))
+				end
+				if grantedEffectLevel.baseMultiplier then
+					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%g%% of base", grantedEffectLevel.baseMultiplier * 100))
+				end
 			else
-				self.tooltip:AddLine(16, "^x7F7F7FCast Time: ^7Instant")
+				if grantedEffect.castTime > 0 then
+					self.tooltip:AddLine(16, string.format("^x7F7F7FCast Time: ^7%.2f sec", grantedEffect.castTime))
+				else
+					self.tooltip:AddLine(16, "^x7F7F7FCast Time: ^7Instant")
+				end
 			end
-		end
-		if grantedEffectLevel.critChance then
-			self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", grantedEffectLevel.critChance))
-		end
-		if gemInstance.gemData.weaponRequirements then
-			self.tooltip:AddLine(16, "^x7F7F7F Requires: ^7" .. gemInstance.gemData.weaponRequirements)
+			if grantedEffectLevel.critChance then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", grantedEffectLevel.critChance))
+			end
+			if gemInstance.gemData.weaponRequirements then
+				self.tooltip:AddLine(16, "^x7F7F7F Requires: ^7" .. gemInstance.gemData.weaponRequirements)
+			end
 		end
 	end
 	if addReq and displayInstance.quality > 0 then
@@ -689,16 +691,18 @@ end
 function GemSelectClass:AddStatSetInfo(gemInstance, grantedEffect, statSet, noLabel)
 	local displayInstance = gemInstance.displayEffect or gemInstance
 	local statSetLevel = statSet.levels[displayInstance.level] or { }
-	if statSet.label ~= grantedEffect.name and statSet.label ~= "" and not noLabel then
-		self.tooltip:AddSeparator(10)
-		self.tooltip:AddLine(20, colorCodes.GEM .. statSet.label)
-		self.tooltip:AddSeparator(10)
-	end
-	if statSetLevel.critChance then
-		self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", statSetLevel.critChance))
-	end
-	if statSetLevel.baseMultiplier then
-		self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%d%%", statSetLevel.baseMultiplier * 100))
+	if not grantedEffect.hidden then
+		if statSet.label ~= grantedEffect.name and statSet.label ~= "" and not noLabel then
+			self.tooltip:AddSeparator(10)
+			self.tooltip:AddLine(20, colorCodes.GEM .. statSet.label)
+			self.tooltip:AddSeparator(10)
+		end
+		if statSetLevel.critChance then
+			self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", statSetLevel.critChance))
+		end
+		if statSetLevel.baseMultiplier then
+			self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%d%%", statSetLevel.baseMultiplier * 100))
+		end
 	end
 	if self.skillsTab and self.skillsTab.build.data.describeStats then
 		if not noLabel then self.tooltip:AddSeparator(10) end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -583,7 +583,7 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 			(gemInstance.level >= gemInstance.gemData.naturalMaxLevel) and " (Max)" or ""
 		))
 	end
-	if grantedEffect.support and not grantedEffect.hidden then
+	if grantedEffect.support then
 		if grantedEffectLevel.manaMultiplier and grantedEffectLevel.reservationMultiplier and grantedEffectLevel.manaMultiplier == grantedEffectLevel.reservationMultiplier then
 			self.tooltip:AddLine(16, string.format("^x7F7F7FCost & Reservation Multiplier: ^7%d%%", grantedEffectLevel.manaMultiplier + 100))
 		elseif grantedEffectLevel.reservationMultiplier then
@@ -628,43 +628,41 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 		if cost then
 			self.tooltip:AddLine(16, "^x7F7F7FCost: ^7"..cost)
 		end
-		if not grantedEffect.hidden then
-			if grantedEffectLevel.cooldown then
-				local string = string.format("^x7F7F7FCooldown Time: ^7%.2f sec", grantedEffectLevel.cooldown)
-				if grantedEffectLevel.storedUses and grantedEffectLevel.storedUses > 1 then
-					string = string .. string.format(" (%d uses)", grantedEffectLevel.storedUses)
-				end
-				self.tooltip:AddLine(16, string)
+		if grantedEffectLevel.cooldown then
+			local string = string.format("^x7F7F7FCooldown Time: ^7%.2f sec", grantedEffectLevel.cooldown)
+			if grantedEffectLevel.storedUses and grantedEffectLevel.storedUses > 1 then
+				string = string .. string.format(" (%d uses)", grantedEffectLevel.storedUses)
 			end
-			if grantedEffectLevel.vaalStoredUses then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FCan Store ^7%d ^x7F7F7FUse (%d Souls)", grantedEffectLevel.vaalStoredUses, grantedEffectLevel.vaalStoredUses * grantedEffectLevel.cost.Soul))
+			self.tooltip:AddLine(16, string)
+		end
+		if grantedEffectLevel.vaalStoredUses then
+			self.tooltip:AddLine(16, string.format("^x7F7F7FCan Store ^7%d ^x7F7F7FUse (%d Souls)", grantedEffectLevel.vaalStoredUses, grantedEffectLevel.vaalStoredUses * grantedEffectLevel.cost.Soul))
+		end
+		if grantedEffectLevel.soulPreventionDuration then
+			self.tooltip:AddLine(16, string.format("^x7F7F7FSoul Gain Prevention: ^7%d sec", grantedEffectLevel.soulPreventionDuration))
+		end
+		if gemInstance.gemData.tags.attack then
+			if grantedEffectLevel.attackSpeedMultiplier then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Speed: ^7%d%% of base", grantedEffectLevel.attackSpeedMultiplier + 100))
 			end
-			if grantedEffectLevel.soulPreventionDuration then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FSoul Gain Prevention: ^7%d sec", grantedEffectLevel.soulPreventionDuration))
+			if grantedEffectLevel.attackTime then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Time: ^7%.2f sec", grantedEffectLevel.attackTime / 1000))
 			end
-			if gemInstance.gemData.tags.attack then
-				if grantedEffectLevel.attackSpeedMultiplier then
-					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Speed: ^7%d%% of base", grantedEffectLevel.attackSpeedMultiplier + 100))
-				end
-				if grantedEffectLevel.attackTime then
-					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Time: ^7%.2f sec", grantedEffectLevel.attackTime / 1000))
-				end
-				if grantedEffectLevel.baseMultiplier then
-					self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%g%% of base", grantedEffectLevel.baseMultiplier * 100))
-				end
+			if grantedEffectLevel.baseMultiplier then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%g%% of base", grantedEffectLevel.baseMultiplier * 100))
+			end
+		else
+			if grantedEffect.castTime > 0 then
+				self.tooltip:AddLine(16, string.format("^x7F7F7FCast Time: ^7%.2f sec", grantedEffect.castTime))
 			else
-				if grantedEffect.castTime > 0 then
-					self.tooltip:AddLine(16, string.format("^x7F7F7FCast Time: ^7%.2f sec", grantedEffect.castTime))
-				else
-					self.tooltip:AddLine(16, "^x7F7F7FCast Time: ^7Instant")
-				end
+				self.tooltip:AddLine(16, "^x7F7F7FCast Time: ^7Instant")
 			end
-			if grantedEffectLevel.critChance then
-				self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", grantedEffectLevel.critChance))
-			end
-			if gemInstance.gemData.weaponRequirements then
-				self.tooltip:AddLine(16, "^x7F7F7F Requires: ^7" .. gemInstance.gemData.weaponRequirements)
-			end
+		end
+		if grantedEffectLevel.critChance then
+			self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", grantedEffectLevel.critChance))
+		end
+		if gemInstance.gemData.weaponRequirements and not grantedEffect.hidden then
+			self.tooltip:AddLine(16, "^x7F7F7F Requires: ^7" .. gemInstance.gemData.weaponRequirements)
 		end
 	end
 	if addReq and displayInstance.quality > 0 then
@@ -691,18 +689,16 @@ end
 function GemSelectClass:AddStatSetInfo(gemInstance, grantedEffect, statSet, noLabel)
 	local displayInstance = gemInstance.displayEffect or gemInstance
 	local statSetLevel = statSet.levels[displayInstance.level] or { }
-	if not grantedEffect.hidden then
-		if statSet.label ~= grantedEffect.name and statSet.label ~= "" and not noLabel then
-			self.tooltip:AddSeparator(10)
-			self.tooltip:AddLine(20, colorCodes.GEM .. statSet.label)
-			self.tooltip:AddSeparator(10)
-		end
-		if statSetLevel.critChance then
-			self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", statSetLevel.critChance))
-		end
-		if statSetLevel.baseMultiplier then
-			self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%d%%", statSetLevel.baseMultiplier * 100))
-		end
+	if statSet.label ~= grantedEffect.name and statSet.label ~= "" and not noLabel then
+		self.tooltip:AddSeparator(10)
+		self.tooltip:AddLine(20, colorCodes.GEM .. statSet.label)
+		self.tooltip:AddSeparator(10)
+	end
+	if statSetLevel.critChance then
+		self.tooltip:AddLine(16, string.format("^x7F7F7FCritical Hit Chance: ^7%.2f%%", statSetLevel.critChance))
+	end
+	if statSetLevel.baseMultiplier then
+		self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%d%%", statSetLevel.baseMultiplier * 100))
 	end
 	if self.skillsTab and self.skillsTab.build.data.describeStats then
 		if not noLabel then self.tooltip:AddSeparator(10) end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -768,7 +768,7 @@ function SkillsTabClass:CreateGemSlot(index)
 					-- Do the stats one at a time because we're not guaranteed to get the descriptions in the same order we look at them here
 					local stats = { }
 					stats[qual[1]] = qual[2] * 20
-					local descriptions = self.build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope)
+					local descriptions = self.build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope, true)
 					-- line may be nil if the value results in no line due to not being enough quality
 					for _, line in ipairs(descriptions) do
 						if line then

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -756,41 +756,53 @@ function SkillsTabClass:CreateGemSlot(index)
 		end
 		-- Function for both granted effect and secondary such as vaal
 		local addQualityLines = function(qualityList, grantedEffect)
-			tooltip:AddLine(18, colorCodes.GEM..grantedEffect.name)
-			-- Hardcoded to use 20% quality instead of grabbing from gem, this is for consistency and so we always show something
-			tooltip:AddLine(16, colorCodes.NORMAL.."At +20% Quality:")
-			for k, qual in pairs(qualityList) do
-				-- Do the stats one at a time because we're not guaranteed to get the descriptions in the same order we look at them here
-				local stats = { }
-				stats[qual[1]] = qual[2] * 20
-				local descriptions = self.build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope)
-				-- line may be nil if the value results in no line due to not being enough quality
-				for _, line in ipairs(descriptions) do
-					if line then
-						-- Check if we have a handler for the mod in the gem's statMap or in the shared stat map for skills
-						if grantedEffect.statSets[1].statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
-							tooltip:AddLine(16, colorCodes.MAGIC..line)
-						else
-							local line = colorCodes.UNSUPPORTED..line
-							line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
-							tooltip:AddLine(16, line)
+			if #qualityList > 0 then
+				if grantedEffect.name == "" then
+					tooltip:AddLine(18, colorCodes.GEM..grantedEffect.statSets[1].label)
+				else
+					tooltip:AddLine(18, colorCodes.GEM..grantedEffect.name)
+				end
+				-- Hardcoded to use 20% quality instead of grabbing from gem, this is for consistency and so we always show something
+				tooltip:AddLine(16, colorCodes.NORMAL.."At +20% Quality:")
+				for k, qual in pairs(qualityList) do
+					-- Do the stats one at a time because we're not guaranteed to get the descriptions in the same order we look at them here
+					local stats = { }
+					stats[qual[1]] = qual[2] * 20
+					local descriptions = self.build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope)
+					-- line may be nil if the value results in no line due to not being enough quality
+					for _, line in ipairs(descriptions) do
+						if line then
+							-- Check if we have a handler for the mod in the gem's statMap or in the shared stat map for skills
+							if grantedEffect.statSets[1].statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
+								tooltip:AddLine(16, colorCodes.MAGIC..line)
+							else
+								local line = colorCodes.UNSUPPORTED..line
+								line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+								tooltip:AddLine(16, line)
+							end
 						end
 					end
 				end
 			end
 		end
 		-- Check if there is a quality of this type for the effect
-		if gemData and gemData.grantedEffect.qualityStats then
+		-- Currently only checks the first 2 additionalGrantedEffects. Will need to fix if gems ever add more
+		if gemData and gemData.grantedEffect.qualityStats and #gemData.grantedEffect.qualityStats > 0 then
 			local qualityTable = gemData.grantedEffect.qualityStats
 			addQualityLines(qualityTable, gemData.grantedEffect)
 		end
-		if gemData and gemData.secondaryGrantedEffect and gemData.secondaryGrantedEffect.qualityStats then
-			local qualityTable = gemData.secondaryGrantedEffect.qualityStats
+		if gemData and gemData.additionalGrantedEffects[1] and gemData.additionalGrantedEffects[1].qualityStats and #gemData.additionalGrantedEffects[1].qualityStats > 0 then
+			local qualityTable = gemData.additionalGrantedEffects[1].qualityStats
 			tooltip:AddSeparator(10)
-			addQualityLines(qualityTable, gemData.secondaryGrantedEffect)
+			addQualityLines(qualityTable, gemData.additionalGrantedEffects[1])
+		end
+		if gemData and gemData.additionalGrantedEffects[2] and gemData.additionalGrantedEffects[2].qualityStats and #gemData.additionalGrantedEffects[2].qualityStats > 0  then
+			local qualityTable = gemData.additionalGrantedEffects[2].qualityStats
+			tooltip:AddSeparator(10)
+			addQualityLines(qualityTable, gemData.additionalGrantedEffects[2])
 		end
 		-- Add stat comparisons for hovered quality (based on set quality)
-		if gemData and (gemData.grantedEffect.qualityStats or (gemData.secondaryGrantedEffect and gemData.secondaryGrantedEffect.qualityStats)) and self.displayGroup.gemList[index] then
+		if gemData and (gemData.grantedEffect.qualityStats or (gemData.additionalGrantedEffects[1] and gemData.additionalGrantedEffects[1].qualityStats or gemData.additionalGrantedEffects[2] and gemData.additionalGrantedEffects[2].qualityStats)) and self.displayGroup.gemList[index] then
 			local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then
 				local storedQuality = self.displayGroup.gemList[index].quality

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -5167,6 +5167,8 @@ skills["SupportMirageArcherPlayer"] = {
 	requireSkillTypes = { SkillType.RangedAttack, SkillType.CrossbowAmmoSkill, SkillType.OR, },
 	addSkillTypes = { },
 	excludeSkillTypes = { SkillType.HasUsageCondition, },
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -803,6 +803,8 @@ skills["SupportBarrierInvocationPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -1030,6 +1032,8 @@ skills["SupportBlasphemyPlayer"] = {
 	excludeSkillTypes = { SkillType.Trapped, SkillType.RemoteMined, SkillType.OR, SkillType.SummonsTotem, SkillType.UsedByTotem, SkillType.NOT, SkillType.AND, SkillType.SupportedByHourglass, },
 	isTrigger = true,
 	ignoreMinionTypes = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2087,6 +2091,8 @@ skills["SupportMetaCastOnCritPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2310,6 +2316,8 @@ skills["SupportMetaCastOnDodgePlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2534,6 +2542,8 @@ skills["SupportMetaCastOnElementalAilmentPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2756,6 +2766,8 @@ skills["SupportMetaCastOnMinionDeathPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, SkillType.CreatesMinion, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -4339,6 +4351,8 @@ skills["SupportMetaCastCurseOnBlockPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -5506,6 +5520,8 @@ skills["SupportElementalInvocationPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -11174,6 +11190,10 @@ skills["SupportHandOfChayulaPlayer"] = {
 	requireSkillTypes = { SkillType.AppliesCurse, SkillType.Mark, SkillType.OR, },
 	addSkillTypes = { },
 	excludeSkillTypes = { },
+	qualityStats = {
+		{ "base_curse_duration_+%", 1 },
+		{ "mark_effect_+%", 0.5 },
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -15888,6 +15908,8 @@ skills["SupportReapersInvocationPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -521,6 +521,8 @@ skills["SupportAncestralWarriorTotemPlayer"] = {
 		["One Handed Axe"] = true,
 		["One Handed Sword"] = true,
 	},
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -1810,6 +1812,8 @@ skills["SupportMetaCastOnBlockPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -1954,6 +1958,8 @@ skills["SupportMetaCastOnMeleeKillPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[8] = { storedUses = 1, levelRequirement = 0, cooldown = 0.2, },
 	},
@@ -2022,6 +2028,8 @@ skills["SupportMetaCastOnMeleeStunPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[8] = { storedUses = 1, levelRequirement = 0, cooldown = 0.2, },
 	},
@@ -11200,6 +11208,8 @@ skills["SupportMortarCannonPlayer"] = {
 	requireSkillTypes = { SkillType.Grenade, },
 	addSkillTypes = { SkillType.UsedByTotem, },
 	excludeSkillTypes = { SkillType.Meta, SkillType.Triggered, SkillType.Channel, SkillType.Persistent, },
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -14326,6 +14336,8 @@ skills["SupportMetaCastLightningSpellOnHitPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -977,6 +977,8 @@ skills["SupportMetaDeadeyeMarksPlayer"] = {
 	requireSkillTypes = { SkillType.Mark, },
 	addSkillTypes = { },
 	excludeSkillTypes = { },
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -1201,6 +1203,8 @@ skills["SupportMetaCastOnCharmUsePlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2975,6 +2979,8 @@ skills["SupportMetaCastFireSpellOnHitPlayer"] = {
 	addSkillTypes = { SkillType.Triggered, SkillType.Cooldown, },
 	excludeSkillTypes = { SkillType.SupportedByHourglass, },
 	isTrigger = true,
+	qualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -271,7 +271,7 @@ directiveTable.skill = function(state, args, out)
 		--end
 		table.insert(skill.levels, level)
 	end
-	if not skill.qualityStats and not granted.IsSupport then
+	if not (skillGem and granted.IsSupport) then
 		skill.qualityStats = { }
 		local qualityStats = dat("GrantedEffectQualityStats"):GetRow("GrantedEffect", granted)
 		if qualityStats and qualityStats.GrantedStats then


### PR DESCRIPTION
We were still using the old logic for secondaryGrantedEffect that PoB 1 uses, so if any skill had a quality stat on a additionalGrantedEffects, it wouldn't show up in the quality tooltip or get added to the main gem tooltip
We now iterate over the first 2 entries in the additionalGrantedEffects list to check for quality stats in them
Note: We technically handle quality stats wrong for quite a few gem. Some gems have restrictions on the stat sets the quality stat should apply to but we currently just apply the quality stat to all the stat sets.
I'll look into fixing this in the future
We were also missing the export of the quality stat on Hand of Chayula

Before:
<img width="461" height="467" alt="image" src="https://github.com/user-attachments/assets/40c1a430-3edc-47f3-bef4-bdf61c1e7a61" />
<img width="467" height="675" alt="image" src="https://github.com/user-attachments/assets/40eaeae3-6b84-4aaf-ae81-d09056a72fb9" />



After:
<img width="460" height="513" alt="image" src="https://github.com/user-attachments/assets/c2b32dd4-4ae5-4efe-8f52-5a7fb93cf0c4" />
<img width="463" height="604" alt="image" src="https://github.com/user-attachments/assets/9332775c-925d-4af6-b94d-02e1d38f1b6d" />



