### PR TITLE
Fix display of some stats in gem tooltips

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -651,7 +651,7 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 			if grantedEffectLevel.baseMultiplier then
 				self.tooltip:AddLine(16, string.format("^x7F7F7FAttack Damage: ^7%g%% of base", grantedEffectLevel.baseMultiplier * 100))
 			end
-		else
+		elseif not grantedEffect.hidden then
 			if grantedEffect.castTime > 0 then
 				self.tooltip:AddLine(16, string.format("^x7F7F7FCast Time: ^7%.2f sec", grantedEffect.castTime))
 			else

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ancestral_cry_projectile.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ancestral_cry_projectile.lua
@@ -69,12 +69,38 @@ return {
 	[6]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					},
+					[2]={
+						[1]="#",
+						[2]="#"
+					},
+					[3]={
+						[1]=0,
+						[2]=0
+					}
 				},
 				text="Fires {0:+d} Molten Projectile"
 			},
 			[2]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					},
+					[2]={
+						[1]="#",
+						[2]="#"
+					},
+					[3]={
+						[1]=0,
+						[2]=0
+					}
 				},
 				text="Fires {0:+d} Molten Projectiles"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ancestral_cry_statset_0.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ancestral_cry_statset_0.lua
@@ -114,7 +114,12 @@ return {
 	[9]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Warcry duration per Endurance Charge consumed"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ball_lightning_statset_2.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ball_lightning_statset_2.lua
@@ -9,7 +9,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=10,
+						[2]=10
+					}
 				},
 				text="{0:+d} metre to Ignited Ground radius"
 			},
@@ -18,7 +23,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} metres to Ignited Ground radius"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/bone_cone.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/bone_cone.lua
@@ -134,7 +134,12 @@ return {
 	[4]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Minions have {0}% increased Movement Speed"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/burst_shot_incendiary.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/burst_shot_incendiary.lua
@@ -68,7 +68,12 @@ return {
 	[7]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Ignite duration for each Fragment in a single hit"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/create_mirage.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/create_mirage.lua
@@ -38,7 +38,12 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} seconds to Mirage duration"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/dark_effigy_projectile.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/dark_effigy_projectile.lua
@@ -14,7 +14,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=10,
+						[2]=10
+					}
 				},
 				text="{0:+d} metre to Impact radius"
 			},
@@ -23,7 +28,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} metres to Impact radius"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/feast_of_flesh.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/feast_of_flesh.lua
@@ -96,12 +96,22 @@ return {
 	[4]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
 				},
 				text="Consumes {0:+d} Corpse"
 			},
 			[2]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Consumes {0:+d} Corpses"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/foresight.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/foresight.lua
@@ -29,7 +29,12 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} seconds to Beyond Sight duration"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/frost_bomb.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/frost_bomb.lua
@@ -5,7 +5,20 @@ return {
 	[1]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					},
+					[2]={
+						[1]="#",
+						[2]="#"
+					},
+					[3]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{2:+d}% maximum Elemental Exposure applied"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/hand_of_chayula.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/hand_of_chayula.lua
@@ -5,7 +5,12 @@ return {
 	[1]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased duration of socketed Curses"
 			},
@@ -39,7 +44,12 @@ return {
 	[2]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Magnitudes of socketed Curses"
 			},
@@ -73,7 +83,12 @@ return {
 	[3]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Effect of Socketed Marks"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/igneous_shield.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/igneous_shield.lua
@@ -42,7 +42,12 @@ return {
 					k="negate",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0}% reduced Imbuement time"
 			},
@@ -80,7 +85,12 @@ return {
 	[3]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Block chance"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/poisonbloom_arrow_statset_0.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/poisonbloom_arrow_statset_0.lua
@@ -92,12 +92,22 @@ return {
 	[4]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
 				},
 				text="Limit {0:+d} pustule"
 			},
 			[2]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=2,
+						[2]="#"
+					}
 				},
 				text="Limit {0:+d} pustules"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/rapid_shot_permafrost.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/rapid_shot_permafrost.lua
@@ -138,7 +138,20 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=3
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					},
+					[2]={
+						[1]=0,
+						[2]=0
+					},
+					[3]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Shards deal up to {0:+d}% more Damage after arming"
 			}

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ravenous_swarm.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/ravenous_swarm.lua
@@ -16,7 +16,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} metres to swarm Attack radius"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/reap.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/reap.lua
@@ -9,7 +9,12 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1000,
+						[2]=1000
+					}
 				},
 				text="Critical Weakness duration is {0:+d} second"
 			},
@@ -18,7 +23,12 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Critical Weakness duration is {0:+d} seconds"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/sorcery_ward.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/sorcery_ward.lua
@@ -35,7 +35,12 @@ return {
 	[4]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="Barrier can take Elemental Damage up to an additional {0:+d}% of your Armour and Evasion Rating"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/thunderfist_statset_1.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/thunderfist_statset_1.lua
@@ -14,7 +14,16 @@ return {
 					k="milliseconds_to_seconds_2dp_if_required",
 					v=2
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=0,
+						[2]=0
+					},
+					[2]={
+						[1]="#",
+						[2]=-1
+					}
 				},
 				text="-{1} seconds to bolt cooldown"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/toxic_domain_statset_0.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/toxic_domain_statset_0.lua
@@ -41,7 +41,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=10,
+						[2]=10
+					}
 				},
 				text="{0:+d} metre to Toxic Bloom radius"
 			},
@@ -50,7 +55,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} metres to Toxic Bloom radius"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/toxic_domain_statset_1.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/toxic_domain_statset_1.lua
@@ -21,7 +21,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=10,
+						[2]=10
+					}
 				},
 				text="{0:+d} metre to Pustule Detonation radius"
 			},
@@ -30,7 +35,12 @@ return {
 					k="divide_by_ten_1dp_if_required",
 					v=1
 				},
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d} metres to Pustule Detonation radius"
 			},

--- a/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/wrath_aura.lua
+++ b/src/Data/StatDescriptions/Specific_Skill_Stat_Descriptions/wrath_aura.lua
@@ -37,7 +37,12 @@ return {
 	[3]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Additional Hits deal {0}% more damage"
 			},

--- a/src/Data/StatDescriptions/active_skill_gem_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/active_skill_gem_stat_descriptions.lua
@@ -6140,12 +6140,22 @@ return {
 	[249]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
 				},
 				text="Chains an additional time"
 			},
 			[2]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Chains {0:+d} additional times"
 			},

--- a/src/Data/StatDescriptions/meta_gem_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/meta_gem_stat_descriptions.lua
@@ -191,7 +191,12 @@ return {
 	[8]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased duration of socketed Curses"
 			},
@@ -254,7 +259,12 @@ return {
 	[10]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Supported Curses have {0}% increased Magnitudes"
 			},
@@ -359,7 +369,12 @@ return {
 	[13]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="{0:+d}% increased Effect of Socketed Marks"
 			},

--- a/src/Data/StatDescriptions/skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/skill_stat_descriptions.lua
@@ -11085,7 +11085,12 @@ return {
 	[469]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% more Damage for each remaining Chain"
 			},
@@ -12348,12 +12353,38 @@ return {
 	[522]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					},
+					[2]={
+						[1]=0,
+						[2]=0
+					},
+					[3]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Fires {0:+d} Projectiles"
 			},
 			[2]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					},
+					[2]={
+						[1]=0,
+						[2]=0
+					},
+					[3]={
+						[1]="#",
+						[2]="#"
+					}
 				},
 				text="Fires {0:+d} Arrows"
 			},
@@ -23671,7 +23702,12 @@ return {
 	[1075]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% chance per Power to spawn a Cold Remnant on\nFreezing a target"
 			},
@@ -23692,7 +23728,12 @@ return {
 	[1076]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% chance to spawn a Fire Remnant on\nIgniting a non-Ignited target"
 			},
@@ -23713,7 +23754,12 @@ return {
 	[1077]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
 				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
 				},
 				text="{0:+d}% chance to spawn a Lightning Remnant on\nShocking a non-Shocked target"
 			},

--- a/src/Export/Scripts/statdesc.lua
+++ b/src/Export/Scripts/statdesc.lua
@@ -43,7 +43,7 @@ local function processStatFile(name, changeOutLocation)
 				curLang = nil--{ }
 				--curDescriptor.lang[langName] = curLang
 			elseif curLang and not line:match('table_only') then
-				local statLimits, text, special = line:match('([%d%-#!| ]+)%s*"(.-)"%s*(.*)')
+				local statLimits, quality, text, special = line:match('([%d%-#| !]+)%s*([%w_]*)%s*"(.-)"%s*(.*)')
 				if statLimits then
 					local desc = { text = sanitiseText(escapeGGGString(text)):gsub("\\([^nb])", "\\n%1"), limit = { } }
 					for statLimit in statLimits:gmatch("[!%d%-#|]+") do
@@ -81,6 +81,10 @@ local function processStatFile(name, changeOutLocation)
 							v = true,
 						})
 						nk["canonical_line"] = true
+					end
+					if quality:match("gem_quality") then
+						desc[quality] = true
+						nk["gem_quality"] = true
 					end
 					table.insert(curLang, desc)
 				end

--- a/src/Export/statdesc.lua
+++ b/src/Export/statdesc.lua
@@ -44,7 +44,7 @@ function loadStatFile(fileName)
 				curLang = { }
 				--curDescriptor.lang[langName] = curLang
 			elseif not line:match('table_only') then
-				local statLimits, text, special = line:match('([%d%-#| !]+)%s*"(.-)"%s*(.*)')
+				local statLimits, quality, text, special = line:match('([%d%-#| !]+)%s*([%w_]*)%s*"(.-)"%s*(.*)')
 				if statLimits then
 					local desc = { text = escapeGGGString(text):gsub("\\([^nb])", "\\n%1"), limit = { } }
 					for statLimit in statLimits:gmatch("[!%d%-#|]+") do
@@ -82,6 +82,10 @@ function loadStatFile(fileName)
 							v = true,
 						})
 						nk["canonical_line"] = true
+					end
+					if quality:match("gem_quality") then
+						desc[quality] = true
+						nk["gem_quality"] = true
 					end
 					table.insert(curLang, desc)
 				end

--- a/src/Modules/StatDescriber.lua
+++ b/src/Modules/StatDescriber.lua
@@ -38,22 +38,24 @@ local function getScope(scopeName)
 	end
 end
 
-local function matchLimit(lang, val) 
+local function matchLimit(lang, val, quality)
 	for _, desc in ipairs(lang) do
-		local match = true
-		for i, limit in ipairs(desc.limit) do
-			if limit[1] == "!" then
-				if val[i].min == limit[2] then
+		if quality or not desc.gem_quality then -- Skip gem_quality lines for regular mods
+			local match = true
+			for i, limit in ipairs(desc.limit) do
+				if limit[1] == "!" then
+					if val[i].min == limit[2] then
+						match = false
+						break
+					end
+				elseif (limit[2] ~= "#" and val[i].min > limit[2]) or (limit[1] ~= "#" and val[i].min < limit[1]) then
 					match = false
 					break
 				end
-			elseif (limit[2] ~= "#" and val[i].min > limit[2]) or (limit[1] ~= "#" and val[i].min < limit[1]) then
-				match = false
-				break
 			end
-		end
-		if match then
-			return desc
+			if match then
+				return desc
+			end
 		end
 	end
 end
@@ -218,7 +220,7 @@ local function applySpecial(val, spec)
 	end
 end
 
-return function(stats, scopeName)
+return function(stats, scopeName, quality)
 	local rootScope = getScope(scopeName)
 
 	-- Figure out which descriptions we need, and identify them by the first stat that they describe
@@ -263,7 +265,7 @@ return function(stats, scopeName)
 			end
 			val[i].fmt = "d"
 		end
-		local desc = matchLimit(descriptor.description[1], val)
+		local desc = matchLimit(descriptor.description[1], val, quality)
 		if desc then
 			for _, spec in ipairs(desc) do
 				applySpecial(val, spec)


### PR DESCRIPTION
GGG added a new variant in the stat description files that is meant to be used only for gem quality tooltips.
We were not handling it properly before so if the same stat existed on the gem, the display for the stat was broken too.
e.g. Arc showed "Chains an additional time" instead of "Chains 9 times"
Now properly handled in the stat export and in stat describer

Before:
<img width="491" height="457" alt="image" src="https://github.com/user-attachments/assets/1066c4ff-6530-4ef8-b3ed-3e549920c12e" />

After:
<img width="494" height="468" alt="image" src="https://github.com/user-attachments/assets/f8bc7998-1c98-4f10-9ea2-427602578077" />
