### PR TITLE
Fix Payload support "Grendade active a second time" not working

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2446,7 +2446,7 @@ return {
 },
 -- Grenade
 ["grenade_skill_%_chance_to_explode_twice"] = {
-	mod("GrenadeExplodeTwice", "INC", nil),
+	mod("GrenadeActivateTwice", "BASE", nil),
 },
 ["support_grenade_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1023,6 +1023,11 @@ function calcs.offence(env, actor, activeSkill)
 		skillData.boltCount = ammoStats.boltCount
 		skillData.reloadTime = ammoStats.reloadTime
 	end
+	
+	if activeSkill.skillTypes[SkillType.Grenade] then
+		local detonateTwice = m_min(skillModList:Sum("BASE", skillCfg, "GrenadeActivateTwice"), 100)
+		modDB:NewMod("DPS", "MORE", detonateTwice, "Grenade Activate Twice")
+	end
 
 	if skillModList:Flag(nil, "HasSeals") and activeSkill.skillTypes[SkillType.Unleashable] and not skillModList:Flag(nil, "NoRepeatBonuses") then
 		-- Applies DPS multiplier based on seals count

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4341,7 +4341,7 @@ local specialModList = {
 	["loads? an additional bolt"] = { mod("CrossbowBoltCount", "BASE", 1, nil, ModFlag.Crossbow, { type = "SkillType", skillType = SkillType.CrossbowSkill }) },
 	["loads? (%d+) additional bolts?"] = function(num) return { mod("CrossbowBoltCount", "BASE", num, nil, ModFlag.Crossbow, { type = "SkillType", skillType = SkillType.CrossbowSkill }) } end,
 	["grenade skills fire an additional projectile"] = { mod("ProjectileCount", "BASE", 1, nil, ModFlag.Projectile, { type = "SkillType", skillType = SkillType.Grenade })},
-	["grenades have (%d+)%% chance to activate a second time"] = function(num) return { mod("DPS", "MORE", num, nil, ModFlag.Projectile, { type = "SkillType", skillType = SkillType.Grenade })} end,
+	["grenades have (%d+)%% chance to activate a second time"] = function(num) return { mod("GrenadeActivateTwice", "BASE", num, { type = "SkillType", skillType = SkillType.Grenade })} end,
 	["skills fire an additional projectile"] = { mod("ProjectileCount", "BASE", 1) },
 	["spells [hf][ai][vr]e an additional projectile"] = { mod("ProjectileCount", "BASE", 1, nil, ModFlag.Spell) },
 	["attacks fire an additional projectile"] = { mod("ProjectileCount", "BASE", 1, nil, ModFlag.Attack) },


### PR DESCRIPTION
The mod had a stat map but it was not hooked up to any DPS calcs
Changed the way the tree node works so that both stats are additive and cap out at 100% chance
Fixes #1307