### PR TITLE
Update statMap for Ligthning Conduit

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -13269,7 +13269,7 @@ skills["LightningConduitPlayer"] = {
 			damageIncrementalEffectiveness = 0.0096000004559755,
 			statDescriptionScope = "lightning_conduit",
 			statMap = {
-				["consume_enemy_shock_to_gain_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
+				["lightning_conduit_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
 					mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "Multiplier", var = "ShockEffect", div = 5, actor = "enemy" }),
 				},
 			},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -786,7 +786,7 @@ statMap = {
 #set LightningConduitPlayer
 #flags spell
 statMap = {
-	["consume_enemy_shock_to_gain_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
+	["lightning_conduit_damage_+%_final_per_5%_increased_damage_taken_from_shock"] = {
 		mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "Multiplier", var = "ShockEffect", div = 5, actor = "enemy" }),
 	},
 },


### PR DESCRIPTION
Wording for Lightning Conduit shock effect-dependent "more" damage mod was changed with 0.3.0, which caused it to no longer work.

### After screenshot:
<img width="1396" height="443" alt="image" src="https://github.com/user-attachments/assets/bab3a486-6f1f-4b13-a76e-a0953f95c7d8" />
<img width="615" height="43" alt="image" src="https://github.com/user-attachments/assets/0b0048ea-3c82-4fe5-9ec7-2f9ec6ed45e5" />

