### PR TITLE
Essences mods were trying to apply to incompatible base types

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2516,12 +2516,14 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 				local modId = essence.mods[self.displayItem.type]
 				if modId then
 					local mod = self.displayItem.affixes[modId] or data.itemMods.Exclusive[modId]
-					t_insert(modList, {
-						label = essence.name .. "   " .. "^8[" .. table.concat(mod, "/") .. "]" .. " (" .. (mod.type or "Suffix") .. ")",
-						mod = mod,
-						type = "custom",
-						essence = essence,
-					})
+					if mod then -- passive_hash mods don't get described
+						t_insert(modList, {
+							label = essence.name .. "   " .. "^8[" .. table.concat(mod, "/") .. "]" .. " (" .. (mod.type or "Suffix") .. ")",
+							mod = mod,
+							type = "custom",
+							essence = essence,
+						})
+					end
 				end
 			end
 			table.sort(modList, function(a, b)
@@ -2537,7 +2539,9 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		t_insert(sourceList, { label = "Prefix", sourceId = "PREFIX" })
 		t_insert(sourceList, { label = "Suffix", sourceId = "SUFFIX" })
 	end
-	if self.displayItem.type ~= "Jewel" and self.displayItem.type ~= "Flask" then
+	buildMods("ESSENCE") 	-- This is technically a waste if there aren't any essence mods, 
+									-- but it makes it so we don't have to maintain a list of applicable essence-able base types
+	if #modList > 0 then
 		t_insert(sourceList, { label = "Essence", sourceId = "ESSENCE" })
 	end
 	t_insert(sourceList, { label = "Custom", sourceId = "CUSTOM" })


### PR DESCRIPTION


Fixes #1318 and fixes #1317 .

### Description of the problem being solved:
Two issues are being solved here:
1. Essences were trying to populate the custom mods for base types they didn't apply to, like Charms.
2. One of the essence mods grants a passive skill, which doesn't have a stat description.  This PR simply disables that mod from showing up.  I looked into exporting a stat description for it, but determined it would be way more involved to get the description to appear, let alone properly support selecting a passive node.  Likely it would end up looking something like https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/8223
### Steps taken to verify a working solution:
- Created a crafted body armour and ensured applying an essence custom mod didn't cause an error
- Created a crafted charm, ensuring that the essence dropdown for custom mods didn't appear
- Created the following custom item, ensuring prefixes and suffixes still appeared as expected in the custom mods pop-up