### PR TITLE
Add: Rarity and Spirit Trade Weight Stats

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1101,6 +1101,11 @@ function calcs.perform(env, skipEHP)
 		end
 	end
 
+	-- THIS LINE FOR RARITY CALC
+	output.EffectiveLootRarityMod = calcLib.mod(modDB, nil, "LootRarity")
+	-- THIS LINE FOR SPIRIT
+	output.Spirit = m_floor(calcLib.val(modDB, nil, "Spirit"))
+
 	-- Special Rarity / Quantity Calc for Bisco's
 	local lootQuantityNormalEnemies = modDB:Sum("INC", nil, "LootQuantityNormalEnemies")
 	output.LootQuantityNormalEnemies = (lootQuantityNormalEnemies > 0) and lootQuantityNormalEnemies + modDB:Sum("INC", nil, "LootQuantity") or 0

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -139,6 +139,7 @@ data.powerStatList = {
 	{ stat="ManaRegen", label="Mana regen" },
 	{ stat="ManaLeechRate", label="Mana leech" },
 	{ stat="Ward", label="Ward" },
+	{ stat="Spirit", label="Spirit" },
 	{ stat="Str", label="Strength" },
 	{ stat="Dex", label="Dexterity" },
 	{ stat="Int", label="Intelligence" },
@@ -163,6 +164,7 @@ data.powerStatList = {
 	{ stat="BlockChance", label="Block Chance" },
 	{ stat="SpellBlockChance", label="Spell Block Chance" },
 	{ stat="SpellSuppressionChance", label="Spell Suppression Chance" },
+	{ stat="EffectiveLootRarityMod", label="Rarity of Items found" },
 }
 
 data.misc = { -- magic numbers


### PR DESCRIPTION
Fixes #404

### Description of the problem being solved:

The current Stat Weight Multiplier does not have  **Spirit** or **Increased Item Rarity** as a stat. This makes them unavailable for use in the trade query's stat weighting system.

This PR introduces the necessary logic to integrate both Spirit and Rarity into the trading calculation pipeline.

### Steps taken to verify a working solution:
- Used the "Trader" to create a weighted search using both Spirit and Rarity to confirm the filter generation is working as expected.


- Spellchecked :
<img width="435" height="80" alt="image" src="https://github.com/user-attachments/assets/46d1d1ca-4e43-4ecd-9019-863e293e761d" />


- Docker :
<img width="720" height="168" alt="image" src="https://github.com/user-attachments/assets/a757fd75-1516-424c-abb1-50b54bdb82f4" />


### Link to a build that showcases this PR:
----

### Before screenshot:
(A screenshot of the Calcs tab or Trader showing Spirit/Rarity as missing)
<img width="428" height="306" alt="image" src="https://github.com/user-attachments/assets/1a3d8423-5272-48e6-a812-f04569e0aa17" />
<img width="436" height="303" alt="image" src="https://github.com/user-attachments/assets/fbad470e-1ddd-41f2-8b8d-abfb2222a41b" />


### After screenshot:
(A screenshot showing Spirit and Rarity available for weighting in the Trader.)
<img width="421" height="290" alt="image" src="https://github.com/user-attachments/assets/33298c2f-3dfd-4d44-a246-039a62ff7228" />
<img width="424" height="294" alt="image" src="https://github.com/user-attachments/assets/3361fe27-42e8-40d8-a793-20454b39a89f" />

