### PR TITLE
Add support for Gem related Notables on the bottom of the tree

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4214,8 +4214,7 @@ c["Blocking Damage Poisons the Enemy as though dealing 100 Base Chaos Damage"]={
 c["Blocking Damage Poisons the Enemy as though dealing 100 Base Chaos Damage Blocking Damage Poisons the Enemy as though dealing 200 Base Chaos Damage"]={nil,"Blocking Damage Poisons the Enemy as though dealing 100 Base Chaos Damage Blocking Damage Poisons the Enemy as though dealing 200 Base Chaos Damage "}
 c["Blocking Damage Poisons the Enemy as though dealing 200 Base Chaos Damage"]={nil,"Blocking Damage Poisons the Enemy as though dealing 200 Base Chaos Damage "}
 c["Blood Magic"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Blood Magic"}},nil}
-c["Blue: Skills have 30% less cost"]={nil,"Blue: Skills have 30% less cost "}
-c["Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving"]={nil,"Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving "}
+c["Blue: Skills have 30% less cost"]={{[1]={[1]={type="Condition",var="MostNumerousBlueSocketedSupports"},flags=0,keywordFlags=0,name="ManaCost",type="MORE",value=-30}},nil}
 c["Body Armour grants +100% of Armour also applies to Chaos Damage"]={{[1]={[1]={itemSlot="Body Armour",rarityCond="NORMAL",type="ItemCondition"},flags=0,keywordFlags=0,name="Armour",type="BASE",value=100}},"  also applies to Chaos Damage "}
 c["Body Armour grants +50% of Armour also applies to Elemental Damage"]={{[1]={[1]={itemSlot="Body Armour",rarityCond="NORMAL",type="ItemCondition"},flags=0,keywordFlags=0,name="Armour",type="BASE",value=50}},"  also applies to Elemental Damage "}
 c["Body Armour grants +75% to Cold Resistance"]={{[1]={[1]={itemSlot="Body Armour",rarityCond="NORMAL",type="ItemCondition"},flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=75}},nil}
@@ -4599,10 +4598,7 @@ c["Fire Spells Convert 100% of Fire Damage to Chaos Damage"]={{[1]={[1]={skillTy
 c["Fissure Skills have a 20% chance to create an additional Fissure"]={nil,"Fissure Skills have a 20% chance to create an additional Fissure "}
 c["Flammability Magnitude is doubled"]={{},"Magnitude  "}
 c["Flasks gain 0.17 charges per Second"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesGenerated",type="BASE",value=0.17}},nil}
-c["For each colour of Socketed Support Gem that is most numerous, gain:"]={nil,"For each colour of Socketed Support Gem that is most numerous, gain: "}
-c["For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits against you have no Critical Damage Bonus"]={nil,"For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits  have no Critical Damage Bonus "}
-c["For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits against you have no Critical Damage Bonus Blue: Skills have 30% less cost"]={nil,"For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits  have no Critical Damage Bonus Blue: Skills have 30% less cost "}
-c["For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits against you have no Critical Damage Bonus Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving"]={nil,"For each colour of Socketed Support Gem that is most numerous, gain: Red: Hits  have no Critical Damage Bonus Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving "}
+c["For each colour of Socketed Support Gem that is most numerous, gain:"]={{},nil}
 c["Frenzy or Power Charge"]={nil,"Frenzy or Power Charge "}
 c["Fully Armour Broken enemies you kill with Hits Shatter"]={nil,"Fully Armour Broken enemies you kill with Hits Shatter "}
 c["Fully Broken Armour effects also apply to Fire Damage Taken from Hits"]={nil,"Fully Broken Armour effects also apply to Fire Damage Taken from Hits "}
@@ -5453,9 +5449,7 @@ c["Recover Life equal to 20% of Mana Flask's Recovery Amount when used Recover M
 c["Recover Mana equal to 20% of Life Flask's Recovery Amount when used"]={nil,"Recover Mana equal to 20% of Life Flask's Recovery Amount when used "}
 c["Recover all Mana when Used"]={nil,"Recover all Mana when Used "}
 c["Recover all Mana when Used Deals 25% of current Mana as Chaos Damage to you when Effect ends"]={nil,"Recover all Mana when Used Deals 25% of current Mana as Chaos Damage to you when Effect ends "}
-c["Red: Hits against you have no Critical Damage Bonus"]={nil,"Red: Hits  have no Critical Damage Bonus "}
-c["Red: Hits against you have no Critical Damage Bonus Blue: Skills have 30% less cost"]={nil,"Red: Hits  have no Critical Damage Bonus Blue: Skills have 30% less cost "}
-c["Red: Hits against you have no Critical Damage Bonus Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving"]={nil,"Red: Hits  have no Critical Damage Bonus Blue: Skills have 30% less cost Green: 40% less Movement Speed Penalty from using Skills while Moving "}
+c["Red: Hits against you have no Critical Damage Bonus"]={{[1]={[1]={type="Condition",var="MostNumerousRedSocketedSupports"},flags=0,keywordFlags=0,name="ReduceCritExtraDamage",type="BASE",value=100}},nil}
 c["Reflects opposite Ring"]={{},nil}
 c["Regenerate (0.7-1.2)% of Life per second"]={nil,"Regenerate (0.7-1.2)% of Life per second "}
 c["Regenerate 0.05 Life per second per Maximum Energy Shield"]={{[1]={[1]={div=1,stat="MaximumEnergyShield",type="PerStat"},flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=0.05}},nil}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1833,5 +1833,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.modDB.conditions["MajorityBlueSocketedSupports"] = true;
 	end
 	
+	-- Gem Studded, Gemling notable support
+	if (slotSupportGemSocketsCount.R >= slotSupportGemSocketsCount.G) and (slotSupportGemSocketsCount.R >= slotSupportGemSocketsCount.B) then
+		env.modDB.conditions["MostNumerousRedSocketedSupports"] = true;
+	elseif (slotSupportGemSocketsCount.G >= slotSupportGemSocketsCount.R) and (slotSupportGemSocketsCount.G >= slotSupportGemSocketsCount.B) then
+		env.modDB.conditions["MostNumerousGreenSocketedSupports"] = true;
+	elseif (slotSupportGemSocketsCount.B >= slotSupportGemSocketsCount.R) and (slotSupportGemSocketsCount.B >= slotSupportGemSocketsCount.G) then
+		env.modDB.conditions["MostNumerousBlueSocketedSupports"] = true;
+	end
+	
 	return env, cachedPlayerDB, cachedEnemyDB, cachedMinionDB
 end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3038,6 +3038,14 @@ local specialModList = {
 	["skills gain (%d+)%% increased skill speed per socketed green support gem"] = function(num) return { 
 		mod("SkillSpeedIncreasedPerGreenSupport", "FLAG", num) 
 	} end,
+	["for each colour of socketed support gem that is most numerous, gain:"] = {}, 
+	["red: hits against you have no critical damage bonus"] = { 
+		mod("ReduceCritExtraDamage", "BASE", 100, { type = "Condition", var = "MostNumerousRedSocketedSupports" })
+	}, 
+	["blue: skills have (%d+)%% less cost"] = function(count) return {
+		mod("ManaCost", "MORE", -count, { type = "Condition", var = "MostNumerousBlueSocketedSupports" })
+	} end,
+	
 	-- Monk - Stormweaver
 	["targets can be affected by two of your shocks at the same time"] = { flag("ShockCanStack"), mod("ShockStacksMax", "OVERRIDE", 2) },
 	["targets can be affected by two of your chills at the same time"] = { flag("ChillCanStack"), mod("ChillStacksMax", "OVERRIDE", 2) },


### PR DESCRIPTION
### Description of the problem being solved:
Adding support for the notables on the bottom of the screen that are related to the socketed gems that the player has:
- Crystalline Resistance
- Gem Enthusiast
- Crystallised Immunities

### Steps taken to verify a working solution:
- Create a new build
- Add at least 5 support gems of each color so that Crystalline Resistance applies
- Add at least 10 support gems of a color so that the relevant mod on Gem Enthusiast applies
- Ensure one of the colors has a majority so that the relevant immunity on Crystallised Immunities applies

### Link to a build that showcases this PR:
https://pobb.in/r_khroprzhg0

### Before screenshot:
<img width="639" height="226" alt="{70E40DB0-9DA7-4E6D-B86D-C70229ED1A6B}" src="https://github.com/user-attachments/assets/305ee1e2-b226-4c3b-adc8-aebd47a03cde" />
<img width="832" height="284" alt="{609D3E31-B081-42FF-82FB-781A284BFFCC}" src="https://github.com/user-attachments/assets/7d13a518-9874-41c1-b3e5-fbeee657911a" />
<img width="757" height="254" alt="{7880964E-AF36-4653-96F0-CC22FA12BE62}" src="https://github.com/user-attachments/assets/f145ecab-bbe0-4857-99f7-24fa9c893387" />

### After screenshot:
<img width="554" height="348" alt="{8D6CD277-D164-4541-AFBA-7AF7C8C7970A}" src="https://github.com/user-attachments/assets/5adcd215-b766-4fa0-8930-f2f2de6bc88b" />
<img width="669" height="403" alt="{8E701C86-5515-440E-BDAD-084FC709CDC6}" src="https://github.com/user-attachments/assets/8c67bfba-645b-4840-bc1a-972949e6d07d" />
<img width="740" height="335" alt="{42136001-0700-439C-9A9B-4098FE4BF56B}" src="https://github.com/user-attachments/assets/f00b0bdf-a0e3-47ac-898c-ad64ea35706e" />
<img width="717" height="111" alt="{85BAA827-1F17-4C71-B50A-C0F4A1B4FC13}" src="https://github.com/user-attachments/assets/20b49bbe-3449-418a-93f1-c4855ecde02c" />
