### PR TITLE
fix: update quest rewards for 0.3

### DIFF
--- a/src/Data/QuestRewards.lua
+++ b/src/Data/QuestRewards.lua
@@ -1,7 +1,7 @@
 return {
 	{
 		["Act"] = 1,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Clearfell",
 		["Stat"] = "+10% to Cold Resistance",
 		["AreaLevel"] = 2,
@@ -9,7 +9,7 @@ return {
 	},
 	{
 		["Act"] = 1,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Hunting Grounds",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -18,7 +18,7 @@ return {
 	},
 	{
 		["Act"] = 1,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Freythorn",
 		["Stat"] = "+30 to Spirit",
 		["AreaLevel"] = 11,
@@ -26,7 +26,7 @@ return {
 	},
 	{
 		["Act"] = 1,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Ogham Farmlands",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -35,7 +35,7 @@ return {
 	},
 	{
 		["Act"] = 1,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Ogham Manor",
 		["Stat"] = "+20 to Maximum Life",
 		["AreaLevel"] = 15,
@@ -43,7 +43,7 @@ return {
 	},
 	{
 		["Act"] = 2,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Keth",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -52,7 +52,7 @@ return {
 	},
 	{
 		["Act"] = 2,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Valley of the Titans",
 		["Options"] = {
 			"30% increased Charm Charges Gained, +1 Charm Slot",
@@ -63,7 +63,7 @@ return {
 	},
 	{
 		["Act"] = 2,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Deshar",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -72,7 +72,7 @@ return {
 	},
 	{
 		["Act"] = 2,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "The Spires of Deshar",
 		["Stat"] = "+10% to Lightning Resistance",
 		["AreaLevel"] = 30,
@@ -80,7 +80,7 @@ return {
 	},
 	{
 		["Act"] = 3,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Jungle Ruins",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -89,7 +89,7 @@ return {
 	},
 	{
 		["Act"] = 3,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "The Azak Bog",
 		["Stat"] = "+30 to Spirit",
 		["AreaLevel"] = 38,
@@ -97,7 +97,7 @@ return {
 	},
 	{
 		["Act"] = 3,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "The Venom Crypts",
 		["Options"] = {
 			"25% increased Stun Threshold",
@@ -109,7 +109,7 @@ return {
 	},
 	{
 		["Act"] = 3,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Jiquanis Machinarium",
 		["Stat"] = "+10% to Fire Resistance",
 		["AreaLevel"] = 40,
@@ -117,7 +117,7 @@ return {
 	},
 	{
 		["Act"] = 3,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Aggorat",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -126,7 +126,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Isle Of Kin",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -135,7 +135,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Eye of Hinekora",
 		["Stat"] = "5% increased Maximum Mana",
 		["AreaLevel"] = 49,
@@ -143,7 +143,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Tawhoa's Test",
 		["Options"] = {
 			"+5 to Dexterity",
@@ -154,7 +154,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Tasalio's Test",
 		["Options"] = {
 			"+5 to Intelligence",
@@ -165,7 +165,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Ngamahu's Test",
 		["Options"] = {
 			"+5 to Strength",
@@ -176,7 +176,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Trial Of The Ancestors",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -185,7 +185,7 @@ return {
 	},
 	{
 		["Act"] = 4,
-		["Type"] = "Normal",
+		["Type"] = "",
 		["Area"] = "Abandoned prison",
 		["Options"] = {
 			"30% increased Mana Recovery from Flasks",
@@ -196,7 +196,7 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
+		["Type"] = "Interlude 1",
 		["Area"] = "Wolvenhold",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -205,8 +205,8 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
-		["Area"] = "Clearing The Way",
+		["Type"] = "Interlude 2",
+		["Area"] = "Khari Bazaar",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
 		["AreaLevel"] = 58,
@@ -214,7 +214,7 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
+		["Type"] = "Interlude 2",
 		["Area"] = "The Khari Crossing",
 		["Stat"] = "5% increased Maximum Life",
 		["AreaLevel"] = 60,
@@ -222,7 +222,7 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
+		["Type"] = "Interlude 2",
 		["Area"] = "Qimah",
 		["Options"] = {
 			"+5 to All Attributes",
@@ -237,7 +237,7 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
+		["Type"] = "Interlude 3",
 		["Area"] = "Kriar Village",
 		["Stat"] = "+40 to Spirit",
 		["AreaLevel"] = 62,
@@ -245,7 +245,7 @@ return {
 	},
 	{
 		["Act"] = 5,
-		["Type"] = "Normal",
+		["Type"] = "Interlude 3",
 		["Area"] = "Howling Caves",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
@@ -254,7 +254,7 @@ return {
 	},
 	{
 		["Act"] = 6,
-		["Type"] = "Normal",
+		["Type"] = "Epilog",
 		["Area"] = "Kingsmarch",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,

--- a/src/Data/QuestRewards.lua
+++ b/src/Data/QuestRewards.lua
@@ -37,7 +37,7 @@ return {
 		["Act"] = 1,
 		["Type"] = "Normal",
 		["Area"] = "Ogham Manor",
-		["Stat"] = "+20 to maximum Life",
+		["Stat"] = "+20 to Maximum Life",
 		["AreaLevel"] = 15,
 		["useConfig"] = true
 	},
@@ -213,7 +213,7 @@ return {
 		["useConfig"] = false
 	},
 	{
-		["Act"] = 6,
+		["Act"] = 5,
 		["Type"] = "Normal",
 		["Area"] = "The Khari Crossing",
 		["Stat"] = "5% increased Maximum Life",
@@ -221,7 +221,7 @@ return {
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 6,
+		["Act"] = 5,
 		["Type"] = "Normal",
 		["Area"] = "Qimah",
 		["Options"] = {
@@ -236,7 +236,7 @@ return {
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 6,
+		["Act"] = 5,
 		["Type"] = "Normal",
 		["Area"] = "Kriar Village",
 		["Stat"] = "+40 to Spirit",
@@ -244,7 +244,7 @@ return {
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 6,
+		["Act"] = 5,
 		["Type"] = "Normal",
 		["Area"] = "Howling Caves",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",

--- a/src/Data/QuestRewards.lua
+++ b/src/Data/QuestRewards.lua
@@ -55,8 +55,8 @@ return {
 		["Type"] = "Normal",
 		["Area"] = "Valley of the Titans",
 		["Options"] = {
-			"30% increased Charm Charges gained",
-			"15% increased Mana Recovery from Flasks",
+			"30% increased Charm Charges Gained, +1 Charm Slot",
+			"30% increased Charm Effect Duration, +1 Charm Slot",
 		},
 		["AreaLevel"] = 26,
 		["useConfig"] = true
@@ -125,120 +125,140 @@ return {
 		["useConfig"] = false
 	},
 	{
-		["Act"] = 1,
-		["Type"] = "Cruel",
-		["Area"] = "Clearfell",
-		["Stat"] = "+10% to Cold Resistance",
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Isle Of Kin",
+		["Stat"] = "+2 Weapon Set Passive Skill Points",
+		["questPoints"] = 2,
 		["AreaLevel"] = 45,
+		["useConfig"] = false
+	},
+	{
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Eye of Hinekora",
+		["Stat"] = "5% increased Maximum Mana",
+		["AreaLevel"] = 49,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 1,
-		["Type"] = "Cruel",
-		["Area"] = "Hunting Grounds",
-		["Stat"] = "+2 Weapon Set Passive Skill Points",
-		["questPoints"] = 2,
-		["AreaLevel"] = 49,
-		["useConfig"] = false
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Tawhoa's Test",
+		["Options"] = {
+			"+5 to Dexterity",
+			"+5% to Lightning Resistance",
+		},
+		["AreaLevel"] = 50,
+		["useConfig"] = true
 	},
 	{
-		["Act"] = 1,
-		["Type"] = "Cruel",
-		["Area"] = "Ogham Farmlands",
-		["Stat"] = "+2 Weapon Set Passive Skill Points",
-		["questPoints"] = 2,
-		["AreaLevel"] = 49,
-		["useConfig"] = false
-	},
-	{
-		["Act"] = 1,
-		["Type"] = "Cruel",
-		["Area"] = "Ogham Manor",
-		["Stat"] = "5% increased maximum Life",
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Tasalio's Test",
+		["Options"] = {
+			"+5 to Intelligence",
+			"+5% to Cold Resistance",
+		},
 		["AreaLevel"] = 51,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 2,
-		["Type"] = "Cruel",
-		["Area"] = "Keth",
-		["Stat"] = "+2 Weapon Set Passive Skill Points",
-		["questPoints"] = 2,
-		["AreaLevel"] = 55,
-		["useConfig"] = false
-	},
-	{
-		["Act"] = 2,
-		["Type"] = "Cruel",
-		["Area"] = "Valley of the Titans",
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Ngamahu's Test",
 		["Options"] = {
-			"30% increased Charm Charges gained",
-			"15% increased Life Recovery from Flasks",
+			"+5 to Strength",
+			"+5% to Fire Resistance",
 		},
-		["AreaLevel"] = 55,
+		["AreaLevel"] = 52,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 2,
-		["Type"] = "Cruel",
-		["Area"] = "Deshar",
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Trial Of The Ancestors",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
-		["AreaLevel"] = 56,
+		["AreaLevel"] = 55,
 		["useConfig"] = false
 	},
 	{
-		["Act"] = 2,
-		["Type"] = "Cruel",
-		["Area"] = "The Spires of Deshar",
-		["Stat"] = "+10% to Lightning Resistance",
-		["AreaLevel"] = 57,
+		["Act"] = 4,
+		["Type"] = "Normal",
+		["Area"] = "Abandoned prison",
+		["Options"] = {
+			"30% increased Mana Recovery from Flasks",
+			"30% increased Life Recovery from Flasks",
+		},
+		["AreaLevel"] = 56,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 3,
-		["Type"] = "Cruel",
-		["Area"] = "Jungle Ruins",
+		["Act"] = 5,
+		["Type"] = "Normal",
+		["Area"] = "Wolvenhold",
+		["Stat"] = "+2 Weapon Set Passive Skill Points",
+		["questPoints"] = 2,
+		["AreaLevel"] = 57,
+		["useConfig"] = false
+	},
+	{
+		["Act"] = 5,
+		["Type"] = "Normal",
+		["Area"] = "Clearing The Way",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
 		["AreaLevel"] = 58,
 		["useConfig"] = false
 	},
 	{
-		["Act"] = 3,
-		["Type"] = "Cruel",
-		["Area"] = "The Azak Bog",
-		["Stat"] = "+40 to Spirit",
+		["Act"] = 6,
+		["Type"] = "Normal",
+		["Area"] = "The Khari Crossing",
+		["Stat"] = "5% increased Maximum Life",
 		["AreaLevel"] = 60,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 3,
-		["Type"] = "Cruel",
-		["Area"] = "The Venom Crypts",
+		["Act"] = 6,
+		["Type"] = "Normal",
+		["Area"] = "Qimah",
 		["Options"] = {
-			"+10% to Chaos Resistance",
 			"+5 to All Attributes",
-			"15% reduced Slowing Potency of Debuffs on you",
+			"+5% to All Elemental Resistances",
+			"12% increased Cooldown Recovery Rate",
+			"3% increased Movement Speed",
+			"20% increased Presence Area Of Effect",
+			"15% increased Global Defences",
 		},
-		["AreaLevel"] = 59,
+		["AreaLevel"] = 61,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 3,
-		["Type"] = "Cruel",
-		["Area"] = "Jiquanis Machinarium",
-		["Stat"] = "+10% to Fire Resistance",
-		["AreaLevel"] = 60,
+		["Act"] = 6,
+		["Type"] = "Normal",
+		["Area"] = "Kriar Village",
+		["Stat"] = "+40 to Spirit",
+		["AreaLevel"] = 62,
 		["useConfig"] = true
 	},
 	{
-		["Act"] = 3,
-		["Type"] = "Cruel",
-		["Area"] = "Aggorat",
+		["Act"] = 6,
+		["Type"] = "Normal",
+		["Area"] = "Howling Caves",
 		["Stat"] = "+2 Weapon Set Passive Skill Points",
 		["questPoints"] = 2,
 		["AreaLevel"] = 63,
+		["useConfig"] = false
+	},
+	{
+		["Act"] = 6,
+		["Type"] = "Normal",
+		["Area"] = "Kingsmarch",
+		["Stat"] = "+2 Weapon Set Passive Skill Points",
+		["questPoints"] = 2,
+		["AreaLevel"] = 64,
 		["useConfig"] = false
 	},
 }


### PR DESCRIPTION
TODO:
1. add area levels for new content.
2. add the penalties for the +5% XP Qimah > The Seven Pillars quest.

Notes:
1. For 2) above, I don't know how to add multi-mod quest reward.
2. The Interludes have all been added as Act 5, and the reward for completing them added as Act 6.
3. The difficulty type needs to be removed.
4. 2) & 3) are probably fine until the quest reward code is rewritten.
