### PR TITLE
Fix base modifiers showing up as explicit mods

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -569,8 +569,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					self.requirements[specName:sub(1,3):lower()] = specToNumber(specVal)
 				elseif specName == "Critical Hit Range" or specName == "Attacks per Second" or specName == "Weapon Range" or
 				       specName == "Critical Hit Chance" or specName == "Physical Damage" or specName == "Elemental Damage" or
-				       specName == "Chaos Damage" or specName == "Reload Time" or specName == "Chance to Block" or specName == "Block chance" or 
-					   specName == "Armour" or specName == "Energy Shield" or specName == "Evasion" then
+				       specName == "Chaos Damage" or specName == "Fire Damage" or specName == "Cold Damage" or specName == "Lightning Damage" or 
+					   specName == "Reload Time" or specName == "Chance to Block" or specName == "Block chance" or 
+					   specName == "Armour" or specName == "Energy Shield" or specName == "Evasion" or specName == "Requires" then
 					self.hidden_specs = true
 				-- Anything else is an explicit with a colon in it (Fortress Covenant, Pure Talent, etc) unless it's part of the custom name
 				elseif not (self.name:match(specName) and self.name:match(specVal)) then


### PR DESCRIPTION
Fixes #1254

### Description of the problem being solved:
Copying items from in-game separates out each damage type instead of grouping them as "Elemental Damage" like in PoE1.  This PR also ignores the "Requires" line, as it comes from the base item.

The bow in the linked issue has already been mangled by our reformat, so it would have to be re-imported from the game to see the fix there.
Tested with this item:
```
Item Class: Two Hand Maces
Rarity: Rare
Skull Crack
Crumbling Maul
--------
Physical Damage: 90-114 (augmented)
Fire Damage: 6-10 (fire)
Critical Hit Chance: 6.01% (augmented)
Attacks per Second: 1.16 (augmented)
--------
Requires: Level 38, 68 (unmet) Str
--------
Item Level: 38
--------
Gain 1 Rage on Hit (enchant)
--------
Causes Enemies to Explode on Critical kill, for 10% of their Life as Physical Damage (implicit)
--------
33% increased Physical Damage
Adds 6 to 11 Physical Damage
Adds 6 to 10 Fire Damage
+50 to Accuracy Rating
+1.01% to Critical Hit Chance
5% increased Attack Speed
+6 to Strength
--------
Corrupted
```