### PR TITLE
Automatically check if the ModCache needs to be regenerated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,19 @@ jobs:
         run: busted --lua=luajit
       - name: Report coverage
         run: cd src; luacov-coveralls --repo-token=${{ secrets.github_token }} -e TestData -e Data -e runtime
+  check_modcache:
+    runs-on: ubuntu-latest
+    container: ghcr.io/pathofbuildingcommunity/pathofbuilding-tests:latest
+    steps:
+      - name: Install git dependency
+        run: apk add git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Regenerate ModCache
+        env:
+          LUA_PATH: ../runtime/lua/?.lua;../runtime/lua/?/init.lua
+          REGENERATE_MOD_CACHE: 1
+        run: cd src; luajit HeadlessWrapper.lua
+      - run: git config --global --add safe.directory $(pwd)
+      - name: Check if the generated ModCache is different
+        run: git diff --exit-code src/Data/ModCache.lua

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -110,7 +110,7 @@ function main:Init()
 		self:ChangeUserPath(self.userPath, ignoreBuild)
 	end
 
-	if launch.devMode and IsKeyDown("CTRL") then
+	if launch.devMode and IsKeyDown("CTRL") or os.getenv("REGENERATE_MOD_CACHE") == "1" then
 		-- If modLib.parseMod doesn't find a cache entry it generates it.
 		-- Not loading pre-generated cache causes it to be rebuilt
 		self.saveNewModCache = true


### PR DESCRIPTION
### Description of the problem being solved:
Add a github CI job to automatically check if the ModCache needs to be regenerated

You can see an example of the test failing on https://github.com/Musholic/PathOfBuilding-PoE2/pull/2