### PR TITLE
Generate the changelog for the beta releases

### DIFF
--- a/.github/tweak_changelogs.sh
+++ b/.github/tweak_changelogs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+RELEASE_VERSION="$1"
+
+# Delete until the first line containing "--"
+sed -i '1,/--/d' temp_change.md
+# Reverse the order of lines in the file (last line becomes first, etc.)
+sed -i '1h;1d;$!H;$!d;G' temp_change.md
+# Convert "**Full Changelog**: URL" format to markdown link format "[Full Changelog](URL)"
+sed -i -re 's/\*\*Full Changelog\*\*: (.*)/\[Full Changelog\]\(\1\)\n/' temp_change.md
+# Delete everything from "## New Contributors" line to the end of file
+sed -i '/## New Contributors/,$d' temp_change.md
+# Convert GitHub changelog entries from "* description by @username in pull/URL/number"
+# to "- description [#number](pull/URL/number) ([username](https://github.com/username))" format
+sed -i -re 's/^\*(.*)\sby\s@(.*)\sin\s(.*\/pull\/)(.*)/-\1 [\\#\4](\3\4) ([\2](https:\/\/github.com\/\2))/' temp_change.md
+# Username substitutions for preferred display names
+sed -i 's/\[Quotae/\[Quote_a/' temp_change.md
+sed -i 's/\[learn2draw/\[Lexy/' temp_change.md
+sed -i 's/\[Voronoff/\[Tom Clancy Is Dead/' temp_change.md
+sed -i 's/\[PJacek/\[TPlant/' temp_change.md
+sed -i 's/\[justjuangui/\[trompetin17/' temp_change.md
+
+cp temp_change.md changelog_temp.txt
+# Append existing CHANGELOG.md content (excluding first line) to temp_change.md
+sed '1d' CHANGELOG.md >> temp_change.md
+# Create new CHANGELOG.md with header containing version and date, followed by processed changes
+printf "# Changelog\n\n## [$RELEASE_VERSION](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/tree/$RELEASE_VERSION) ($(date +'%Y/%m/%d'))\n\n" | cat - temp_change.md > CHANGELOG.md
+# Convert changelog entries from markdown link format to simplified "* description (username)" format
+sed -i -re 's/^- (.*) \[.*\) \(\[(.*)\]\(.*/* \1 (\2)/' changelog_temp.txt
+# Create new changelog format: add version header, remove lines 2-3, format section headers, remove ## headers with following line, prepend to existing changelog
+echo "VERSION[${RELEASE_VERSION#v}][$(date +'%Y/%m/%d')]" | cat - changelog_temp.txt | sed '2,3d' | sed -re 's/^### (.*)/\n--- \1 ---/' | sed -e '/^##.*/,+1 d' | cat - changelog.txt > changelog_new.txt
+mv changelog_new.txt changelog.txt
+
+# Normalize line endings to CRLF for all output files to ensure consistent checksums with Windows
+sed 's/\r*$/\r/' CHANGELOG.md > CHANGELOG_normalized.md && mv CHANGELOG_normalized.md CHANGELOG.md
+sed 's/\r*$/\r/' changelog.txt > changelog_normalized.txt && mv changelog_normalized.txt changelog.txt
+
+# Clean up temporary files
+rm temp_change.md
+rm changelog_temp.txt

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -20,6 +20,26 @@ jobs:
               run: |
                 git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
                 git config --global user.name "github-actions[bot]"
+            # The hash suffix will help identifying if the beta version is up-to-date
+            - name: Add commit hash suffix to manifest version
+              run: |
+                sed -i "s/<Version number=\"\([^\"]*\)\"/<Version number=\"\1-$(git rev-parse --short HEAD)\"/g" manifest.xml
+            - name: Generate Release notes
+              run: |
+                echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+                # Delete existing beta draft if it exists
+                if gh release view beta >/dev/null 2>&1; then
+                  gh release delete beta --yes
+                fi
+                # Create new beta draft release with generated notes
+                gh release create beta --title "Beta Release" --draft --generate-notes
+                gh release view beta > temp_change.md
+            - name: Tweak changelogs
+              run: |
+                # Remove carriage returns to be able to run the script
+                sed -i 's/\r$//' .github/tweak_changelogs.sh
+                chmod +x .github/tweak_changelogs.sh
+                .github/tweak_changelogs.sh beta
             - name: Update manifest.xml
               run: python3 update_manifest.py --quiet --in-place
             - name: Push to beta branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,27 +29,11 @@ jobs:
                 echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token;
                 gh release view $(basename ${{ github.event.inputs.releaseNoteUrl }}) > temp_change.md
             - name: Tweak changelogs
-              run: >
-                sed -i '1,10d' temp_change.md;
-                sed -i '1h;1d;$!H;$!d;G' temp_change.md;
-                sed -i -re 's/\*\*Full Changelog\*\*: (.*)/\[Full Changelog\]\(\1\)\n/' temp_change.md;
-                sed -i '/## New Contributors/,$d' temp_change.md;
-                sed -i -re 's/^\*(.*)\sby\s@(.*)\sin\s(.*\/pull\/)(.*)\r?/-\1 [\\#\4](\3\4) ([\2](https:\/\/github.com\/\2))/' temp_change.md;
-                sed -i 's/\[Quotae/\[Quote_a/' temp_change.md;
-                sed -i 's/\[learn2draw/\[Lexy/' temp_change.md;
-                sed -i 's/\[Voronoff/\[Tom Clancy Is Dead/' temp_change.md;
-                sed -i 's/\[PJacek/\[TPlant/' temp_change.md;
-                sed -i 's/\[justjuangui/\[trompetin17/' temp_change.md;
-                sed -i 's/\r//g' temp_change.md;
-                cp temp_change.md changelog_temp.txt;
-                cat CHANGELOG.md | tr \\r \\n | sed '1d' >> temp_change.md;
-                printf "# Changelog\n\n## [v${{ github.event.inputs.releaseVersion }}](https://github.com/PathOfBuildingCommunity/PathOfBuilding/tree/v${{ github.event.inputs.releaseVersion }}) ($(date +'%Y/%m/%d'))\n\n" | cat - temp_change.md > CHANGELOG.md;
-
-                sed -i -re 's/^- (.*) \[.*\) \(\[(.*)\]\(.*/* \1 (\2)/' changelog_temp.txt;
-                echo "VERSION[${{ github.event.inputs.releaseVersion }}][`date +'%Y/%m/%d'`]" | cat - changelog_temp.txt | tr -d \\r | sed '2,3d' | sed -re 's/^### (.*)/\n--- \1 ---/' | sed -e '/^##.*/,+1 d' | cat - changelog.txt > changelog_new.txt;
-                rm temp_change.md;
-                rm changelog_temp.txt;
-                mv changelog_new.txt changelog.txt
+              run: |
+                # Remove carriage returns to be able to run the script
+                sed -i 's/\r$//' .github/tweak_changelogs.sh
+                chmod +x .github/tweak_changelogs.sh
+                .github/tweak_changelogs.sh "v${{ github.event.inputs.releaseVersion }}"
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v5
               with:


### PR DESCRIPTION
### Description of the problem being solved:
This PR modify the beta workflow to use release-drafter as a way to get generated changelogs.

It refactors the tweak_changelogs logic (with comments thanks to the AI otherwise it's hard to understand) and handle CRLF issues of the generated changelog since we need to have proper hash generation in the manifest file for the auto-update mechanism.

The workflow is hard to test beforehand (without actually doing a beta release or a release) but I tested a similar version on my Last Epoch fork (of pob1). I should be able to test this particular commit on my fork of pob2 later on.

Let me know if you have questions or remarks