### PR TITLE
Fix Abyss Timeless jewel mod display

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1308,7 +1308,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	local function processTimeLostModsAndGetLocalEffect(mNode, build)
 		local localIncEffect = 0
 		local hasWSCondition = false
-		local newSd = copyTable(build.spec.tree.nodes[mNode.id].sd)
+		local newSd = copyTable(mNode.sd)
 		for _, mod in ipairs(mNode.finalModList) do
 			-- if the jewelMod has a WS Condition, only add the incEffect given it matches the activeWeaponSet
 			-- otherwise the mod came from a jewel that is allocMode 0, so it always applies
@@ -1348,7 +1348,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		local isInRadius = false
 		for id, socket in pairs(build.itemsTab.sockets) do
 			if build.itemsTab.activeSocketList and socket.inactive == false or socket.inactive == nil then
-				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[3][node.id] ~= nil)
+				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[4][node.id] ~= nil)
 				if isInRadius then break end
 			end
 		end
@@ -1366,7 +1366,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	if mNode.sd and mNode.sd[1] and not mNode.allMasteryOptions then
 		tooltip:AddLine(16, "")
 		local localIncEffect = 0
-		if not mNode.isAttribute and (mNode.type == "Normal" or mNode.type == "Notable") and isNodeInARadius(node) then
+		if not (mNode.isAttribute and not mNode.conqueredBy) and (mNode.type == "Normal" or mNode.type == "Notable") and isNodeInARadius(node) then
 			localIncEffect = processTimeLostModsAndGetLocalEffect(mNode, build)
 		end
 		for i, line in ipairs(mNode.sd) do

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -131,7 +131,7 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 	-- Run first pass radius jewels // jewel functions caught by jewelOtherFuncs
 	for _, rad in pairs(env.radiusJewelList) do
 		if rad.type == "Other" and rad.nodes[node.id] and rad.nodes[node.id].type ~= "Mastery" then
-			if rad.item.baseName:find("Time%-Lost") == nil then
+			if rad.item.baseName:find("Time%-Lost") == nil and rad.item.baseName:find("Timeless Jewel") == nil then
 				rad.func(node, modList, rad.data)
 			elseif not node.isAttribute and (node.type == "Normal" or node.type == "Notable") then
 				local cache = GlobalCache.cachedData[env.mode].radiusJewelData[rad.nodeId]

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6501,6 +6501,18 @@ local jewelOtherFuncs = {
 			end
 		end
 	end,
+	["conquered (%w+) Passive Skills also grant (.*)$"] = function(type, mod)
+		return function(node, out, data)
+			if node and (node.type == firstToUpper(type) or (node.type == "Normal" and not node.isAttribute and firstToUpper(type) == "Small") or (node.type == "Normal" and node.isAttribute and firstToUpper(type) == "Attribute")) then
+				local modList, line = parseMod(mod)
+				if not line and modList[1] then -- something failed to parse, do not add to list
+					modList[1].parsedLine = capitalizeWordsInString(mod)
+					modList[1].source = data.modSource
+					out:AddMod(modList[1])
+				end
+			end
+		end
+	end,
 	--------
 	["50% increased Effect of non-Keystone Passive Skills in Radius"] = function(node, out, data)
 		if node and node.type ~= "Keystone" then
@@ -6699,15 +6711,9 @@ for k, v in pairs(jewelOtherFuncs) do
 		-- Need to not modify any nodes already modified by timeless jewels
 		-- Some functions return a function instead of simply adding mods, so if
 		-- we don't see a node right away, run the outer function first
-		if cap1 and type(cap1) == "table" and cap1.conqueredBy then
-			return
-		end
 		local innerFuncOrNil = v(cap1, cap2, cap3, cap4, cap5)
 		-- In all (current) cases, there is only one nested layer, so no need for recursion
 		return function(node, out, other)
-			if node and type(node) == "table" and node.conqueredBy then
-				return
-			end
 			return innerFuncOrNil(node, out, other)
 		end
 	end, type = "Other" }


### PR DESCRIPTION
The mods granted by the timeless jewel do not appear in the node tooltip cause it is pulled from the tree file instead of the modified one. Not sure if this will cause bugs elsewhere
The change in CalcSetup is needed so that it doesn't run the whole calc setup file every time you allocate a node but it causes the issue where stat don't get added to the base attribute nodes. Not sure how to fix this

Test build:
https://maxroll.gg/poe2/pob/sora0cqv

Before:
<img width="544" height="269" alt="image" src="https://github.com/user-attachments/assets/03aee36b-c9c4-46ff-8161-26344d44ce72" />

After:
<img width="592" height="367" alt="image" src="https://github.com/user-attachments/assets/bd0313bb-6633-4b40-b756-7f600cead389" />
