### PR TITLE
Fix minion Gas Arrow skill not showing Poison / Explode damage

### DIFF
--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -222,6 +222,7 @@ skills["GasShotSkeletonSniperMinion"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "sniper_gas_shot_statset_2",
 			baseFlags = {
+				attack = true,
 				hit = true,
 				area = true,
 			},

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -37,7 +37,7 @@ local skills, mod, flag, skill = ...
 #flags attack area duration
 #mods
 #set GasShotCloudExplodeSkeletonSniperMinion
-#flags hit area
+#flags attack area
 #mods
 #skillEnd
 

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -967,8 +967,10 @@ function calcs.createMinionSkills(env, activeSkill)
 		}
 		local minionSkillIndex = activeSkill.activeEffect.srcInstance.skillMinionSkill
 		local minionSkillIndexCalcs = activeSkill.activeEffect.srcInstance.skillMinionSkillCalcs
-		local minionStatSetIndex = activeSkill.activeEffect.srcInstance.minionStatSet and activeSkill.activeEffect.srcInstance.minionStatSet[activeSkill.activeEffect.grantedEffect.id][minionSkillIndex] or 1
-		local minionStatSetCalcsIndex = activeSkill.activeEffect.srcInstance.minionStatSetCalcs and activeSkill.activeEffect.srcInstance.minionStatSetCalcs[activeSkill.activeEffect.grantedEffect.id][minionSkillIndexCalcs] or 1
+		local minionStatSetIndex = activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookup and activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookup[activeSkill.activeEffect.grantedEffect.id] 
+			and activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookup[activeSkill.activeEffect.grantedEffect.id][minionSkillIndex] or 1
+		local minionStatSetCalcsIndex = activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookupCalcs and activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookupCalcs[activeSkill.activeEffect.grantedEffect.id]
+			and activeSkill.activeEffect.srcInstance.skillMinionSkillStatSetIndexLookupCalcs[activeSkill.activeEffect.grantedEffect.id][minionSkillIndexCalcs] or 1
 		activeEffect.statSet = {
 			index = minionStatSetIndex,
 		}


### PR DESCRIPTION
We were using a old variable name so the check to find which minion stat set was used always failed and used 1
Also added the attack tag to the gas arrow explosion so the damage numbers would show up
Fixes #660

Before:
<img width="713" height="786" alt="image" src="https://github.com/user-attachments/assets/97847002-0879-45a4-9d1d-d5f42040c629" />

After:
<img width="716" height="806" alt="image" src="https://github.com/user-attachments/assets/af5e614f-f1f7-4eb7-a0fa-61c5c140e611" />
