### PR TITLE
Add 0.3 25% more damage for Spectres and Beasts

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -897,6 +897,9 @@ skills["SummonBeastPlayer"] = {
 				duration = true,
 				permanentMinion = true,
 			},
+			baseMods = {
+				mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3,
+			},
 			constantStats = {
 				{ "minion_base_resummon_time_ms", 12000 },
 			},

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -18894,6 +18894,9 @@ skills["SummonSpectrePlayer"] = {
 				duration = true,
 				permanentMinion = true,
 			},
+			baseMods = {
+				mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3,
+			},
 			constantStats = {
 				{ "minion_base_resummon_time_ms", 12000 },
 				{ "spectre_warp_start_distance", 100 },

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -91,6 +91,7 @@ statMap = {
 #skill SummonBeastPlayer
 #set SummonBeastPlayer
 #flags spell minion summonBeast duration permanentMinion
+#baseMod mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3
 #mods
 #skillEnd
 

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1140,6 +1140,7 @@ statMap = {
 #skill SummonSpectrePlayer
 #set SummonSpectrePlayer
 #flags spell minion spectre duration permanentMinion
+#baseMod mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3
 #mods
 #skillEnd
 


### PR DESCRIPTION
The 0.3 patch added a 25% more damage bonus for spectres and beasts that is handled server side so we need to manually add a stat to the gems for it to work in PoB
