### PR TITLE
Fix many Melee skills not hitting with both weapons when dual wielding

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -944,7 +944,8 @@ return {
 	mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "CastOnFrostbolt" }),
 },
 ["active_skill_damage_+%_final_while_dual_wielding"] = {
-	mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "DualWielding" })
+	mod("Damage", "MORE", nil, 0, 0, { type = "Condition", var = "DualWielding" }),
+	skill("doubleHitsWhenDualWielding", true),
 },
 ["active_skill_additive_minion_damage_modifiers_apply_to_all_damage_at_%_value"] = {
 	flag("MinionDamageAppliesToPlayer"),


### PR DESCRIPTION
For some reason the only way I can tell if a skill combines dual wielding hits is if it has this more damage mod on it
Fixes #643