### PR TITLE
Fix Crit Chance when hitting with 2 weapons at once

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2266,6 +2266,12 @@ function calcs.offence(env, actor, activeSkill)
 			output[stat] = (output.MainHand[stat] or 0) + (output.OffHand[stat] or 0)
 		elseif mode == "AVERAGE" then
 			output[stat] = ((output.MainHand[stat] or 0) + (output.OffHand[stat] or 0)) / 2
+		elseif mode == "CRIT" then
+			if skillFlags.bothWeaponAttack and skillData.doubleHitsWhenDualWielding then
+				output[stat] = (output.MainHand[stat] or 0) + (output.OffHand[stat] or 0) - ((output.MainHand[stat] or 0) * (output.OffHand[stat] or 0) / 100)
+			else
+				output[stat] = ((output.MainHand[stat] or 0) + (output.OffHand[stat] or 0)) / 2
+			end
 		elseif mode == 'HARMONICMEAN' then
 			if output.MainHand[stat] == 0 or output.OffHand[stat] == 0 then
 				output[stat] = 0
@@ -4104,7 +4110,7 @@ function calcs.offence(env, actor, activeSkill)
 	if isAttack then
 		-- Combine crit stats, average damage and DPS
 		combineStat("PreEffectiveCritChance", "AVERAGE")
-		combineStat("CritChance", "AVERAGE")
+		combineStat("CritChance", "CRIT")
 		combineStat("PreEffectiveCritMultiplier", "AVERAGE")
 		combineStat("CritMultiplier", "AVERAGE")
 		combineStat("CritBifurcates", "AVERAGE")


### PR DESCRIPTION
When hitting with both weapons at once, only 1 of them needs to crit for the resulting hit to count as a crit
Not sure if this applies to other stats
