### PR TITLE
Handle multiple PRs and contributors in changelog generation + Simplify CR handling

### DIFF
--- a/.github/tweak_changelogs.sh
+++ b/.github/tweak_changelogs.sh
@@ -2,11 +2,19 @@
 
 RELEASE_VERSION="$1"
 
+# Delete until and including the first line containing "<!-- Release notes generated"
+sed -i '1,/^<!-- Release notes generated/d' temp_change.md
+
+# Check if there is more than one non-empty line (the full changelog line) before we continue
+if [ $(grep -c '^[[:space:]]*[^[:space:]]' temp_change.md) -le 1 ]; then
+    echo "No changes to release $RELEASE_VERSION"
+    rm temp_change.md
+    exit 1
+fi
+
 # Remove all CR characters from all changelog files
 sed -i 's/\r//g' temp_change.md CHANGELOG.md changelog.txt
 
-# Delete until and including the first line containing "<!-- Release notes generated"
-sed -i '1,/^<!-- Release notes generated/d' temp_change.md
 # Reverse the order of lines in the file (last line becomes first, etc.)
 sed -i '1h;1d;$!H;$!d;G' temp_change.md
 # Convert "**Full Changelog**: URL" format to markdown link format "[Full Changelog](URL)"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -20,10 +20,6 @@ jobs:
               run: |
                 git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
                 git config --global user.name "github-actions[bot]"
-            # The hash suffix will help identifying if the beta version is up-to-date
-            - name: Add commit hash suffix to manifest version
-              run: |
-                sed -i "s/<Version number=\"\([^\"]*\)\"/<Version number=\"\1-$(git rev-parse --short HEAD)\"/g" manifest.xml
             - name: Generate Release notes
               run: |
                 echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
@@ -35,11 +31,18 @@ jobs:
                 gh release create beta --title "Beta Release" --draft --generate-notes
                 gh release view beta > temp_change.md
             - name: Tweak changelogs
+              id: tweak-changelogs
+              continue-on-error: true
               run: |
                 # Remove carriage returns to be able to run the script
                 sed -i 's/\r$//' .github/tweak_changelogs.sh
                 chmod +x .github/tweak_changelogs.sh
                 .github/tweak_changelogs.sh beta
+            # The hash suffix will help identifying if the beta version is up-to-date
+            - name: Add commit hash suffix to manifest version
+              if: steps.tweak-changelogs.outcome == 'success'
+              run: |
+                sed -i "s/<Version number=\"\([^\"]*\)\"/<Version number=\"\1-$(git rev-parse --short HEAD)\"/g" manifest.xml
             - name: Update manifest.xml
               run: python3 update_manifest.py --quiet --in-place
             - name: Push to beta branch


### PR DESCRIPTION
### Description of the problem being solved:
This simplifies the handling of the `\r` character by removing them all at the beginning and adding them back at the end (so that we don't have to care about them in the rest of the process).

It also adds the support of multiple PRs and contributors (when generating a release with a provided releaseNoteUrl).

For example, with this in the draft release:
```md
* Handle multiple PRs and contributors in changelog generation + Simplify CR handling by (@Musholic, @LocalIdentity) in (https://github.com/Musholic/PathOfBuilding-PoE2/pull/12, https://github.com/Musholic/PathOfBuilding-PoE2/pull/11)
* Handle multiple PRs and contributors in changelog generation + Simplify CR handling by @Musholic, @LocalIdentity in https://github.com/Musholic/PathOfBuilding-PoE2/pull/12, https://github.com/Musholic/PathOfBuilding-PoE2/pull/11
* Handle multiple PRs and contributors in changelog generation + Simplify CR handling by @Musholic in https://github.com/Musholic/PathOfBuilding-PoE2/pull/12
```
It produces this commit: https://github.com/Musholic/PathOfBuilding-PoE2/commit/2d62e1e6f62114f66a042165282062e35c3f434d

For the beta release it produces this commit: https://github.com/Musholic/PathOfBuilding-PoE2/commit/a77187e92b8269b5e5c11a88f1fc3d8aa3278684

- [ ] Should it handle short #PR in draft changelog? like in:
```md
* Handle multiple PRs and contributors in changelog generation + Simplify CR handling by (@Musholic, @LocalIdentity) in (#12, #11)
```
