### PR TITLE
Make sure it uses the latest available tag for generating beta changelog

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -16,6 +16,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                 ref: 'dev'
+                fetch-depth: 0
             - name: Configure bot user
               run: |
                 git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -28,7 +29,9 @@ jobs:
                   gh release delete beta --yes
                 fi
                 # Create new beta draft release with generated notes
-                gh release create beta --title "Beta Release" --draft --generate-notes
+                # Make sure the latest tag is correct, even if the current commit is already tagged
+                LATEST_TAG=$(git describe --tags --abbrev=0)
+                gh release create beta --title "Beta Release" --draft --generate-notes --notes-start-tag "$LATEST_TAG"
                 gh release view beta > temp_change.md
             - name: Tweak changelogs
               id: tweak-changelogs


### PR DESCRIPTION
### Description of the problem being solved:
Fix the changelog generation for the beta release when it's done after a release, on an already tagged commit.

Without this fix, the draft release may use an older tag to generate the changelog

I could reproduce the issue on my repo and I could test the fix on https://github.com/Musholic/PathOfBuilding-PoE2/actions/runs/17767939939