### PR TITLE
Guess main socket group based on dps + Full import button

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -925,7 +925,11 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 		end)
 	end
 	if mainSkillEmpty then
-		self.build.mainSocketGroup = self:GuessMainSocketGroup()
+		local mainSocketGroup = self:GuessMainSocketGroup()
+		self.build.mainSocketGroup = mainSocketGroup
+		if mainSocketGroup ~= nil then
+			self.build.skillsTab.socketGroupList[mainSocketGroup].includeInFullDPS = true
+		end
 	end
 	self.build.itemsTab:PopulateSlots()
 	self.build.itemsTab:AddUndoState()
@@ -1223,17 +1227,22 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 	end
 end
 
--- Return the index of the group with the most gems
+-- Return the index of the group with the most DPS
 function ImportTabClass:GuessMainSocketGroup()
-	local largestGroupSize = 0
-	local largestGroupIndex = 1
-	for i, socketGroup in ipairs(self.build.skillsTab.socketGroupList) do
-		if #socketGroup.gemList > largestGroupSize then
-			largestGroupSize = #socketGroup.gemList
-			largestGroupIndex = i
+	local bestDps = 0
+	local bestSocketGroup = nil
+	for i, socketGroup in pairs(self.build.skillsTab.socketGroupList) do
+		self.build.mainSocketGroup = i
+		socketGroup.includeInFullDPS = true
+		local mainOutput = self.build.calcsTab.calcs.buildOutput(self.build, "MAIN").player.output
+		socketGroup.includeInFullDPS = false
+		local dps = mainOutput.FullDPS
+		if dps > bestDps then
+			bestDps = dps
+			bestSocketGroup = i
 		end
 	end
-	return largestGroupIndex
+	return bestSocketGroup
 end
 
 function HexToChar(x)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -45,7 +45,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 	end
 	
 	self.controls.characterImportAnchor = new("Control", {"TOPLEFT",self.controls.sectionCharImport,"TOPLEFT"}, {6, 40, 200, 16})
-	self.controls.sectionCharImport.height = function() return self.charImportMode == "AUTHENTICATION" and 60 or 200 end
+	self.controls.sectionCharImport.height = function() return self.charImportMode == "AUTHENTICATION" and 60 or 240 end
 
 	-- Stage: Authenticate
 	self.controls.authenticateButton = new("ButtonControl", {"TOPLEFT",self.controls.characterImportAnchor,"TOPLEFT"}, {0, 0, 200, 16}, "^7Authorize with Path of Exile", function()
@@ -96,7 +96,20 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		return self.charImportMode == "SELECTCHAR"
 	end
 	self.controls.charImportHeader = new("LabelControl", {"TOPLEFT",self.controls.charSelect,"BOTTOMLEFT"}, {0, 16, 200, 16}, "^7Import:")
-	self.controls.charImportTree = new("ButtonControl", {"LEFT",self.controls.charImportHeader, "RIGHT"}, {8, 0, 170, 20}, "Passive Tree and Jewels", function()
+	self.controls.charImportFull = new("ButtonControl", {"LEFT",self.controls.charImportHeader, "RIGHT"}, {8, 0, 80, 20}, "Full Import", function()
+		if self.build.spec:CountAllocNodes() > 0 then
+			main:OpenConfirmPopup("Character Import", "Full import will overwrite your current passive tree and replace items/skills.", "Import", function()
+				self:DownloadFullImport()
+			end)
+		else
+			self:DownloadFullImport()
+		end
+	end)
+	self.controls.charImportFullOptions = new("LabelControl", {"LEFT",self.controls.charImportFull,"RIGHT"}, {8, 0, 200, 16}, "(uses below options)")
+	self.controls.charImportFull.enabled = function()
+		return self.charImportMode == "SELECTCHAR"
+	end
+	self.controls.charImportTree = new("ButtonControl", {"LEFT",self.controls.charImportHeader, "LEFT"}, {8, 36, 200, 20}, "Only Passive Tree and Jewels", function()
 		if self.build.spec:CountAllocNodes() > 0 then
 			main:OpenConfirmPopup("Character Import", "Importing the passive tree will overwrite your current tree.", "Import", function()
 				self:DownloadPassiveTree()
@@ -109,7 +122,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		return self.charImportMode == "SELECTCHAR"
 	end
 	self.controls.charImportTreeClearJewels = new("CheckBoxControl", {"LEFT",self.controls.charImportTree,"RIGHT"}, {90, 0, 18}, "Delete jewels:", nil, "Delete all existing jewels when importing.", true)
-	self.controls.charImportItems = new("ButtonControl", {"LEFT",self.controls.charImportTree, "LEFT"}, {0, 36, 110, 20}, "Items and Skills", function()
+	self.controls.charImportItems = new("ButtonControl", {"LEFT",self.controls.charImportTree, "LEFT"}, {0, 24, 140, 20}, "Only Items and Skills", function()
 		self:DownloadItems()
 	end)
 	self.controls.charImportItems.enabled = function()
@@ -654,6 +667,14 @@ function ImportTabClass:ImportQuestRewardConfig(questStats)
 		configTab.modFlag = true
 		self.build.buildFlag = true
 	end
+end
+
+function ImportTabClass:DownloadFullImport()
+	self:DownloadCharacter(function(charData)
+		self:ImportPassiveTreeAndJewels(charData)
+		self:ImportItemsAndSkills(charData)
+		self.charImportStatus = colorCodes.POSITIVE.."Full import successful."
+	end)
 end
 
 function ImportTabClass:ImportPassiveTreeAndJewels(charData)


### PR DESCRIPTION
### Description of the problem being solved:
This PR allows to have a one-button full import while allowing to better guess which socket group is the main one based on DPS calculations of all groups. It also includes the main skill in Full DPS.

Note that if we cannot import with only one button, it causes an issue where the variable `mainSkillEmpty = #self.build.skillsTab.socketGroupList == 0` is false because there is a skill coming from the tree ("Called shots" in my case).

This is also useful for the automatic test I'm preparing to have more relevant tests (having a skill correctly included for the full dps stats) (https://github.com/Musholic/PathOfBuilding-PoE2/pull/11).

- [x] I tested the performance on a simple character import (it was very fast), however it needs to be tested on more complex characters before we merge this PR
	- There was some tests done by LocalIdentiy at the time the PR was made with no significant performance impact (around 130ms max delay). There is a possible performance improvements to skip check on non damaging skills but it needs a reliable way to tell if a skill is non damaging.

### Steps taken to verify a working solution:
- Tested with my lvl 35 character

### Before screenshot:
<img width="976" height="233" alt="image" src="https://github.com/user-attachments/assets/02c90a1f-05eb-4598-87de-4d5f9ebcc58c" />

### After screenshot:
<img width="989" height="264" alt="image" src="https://github.com/user-attachments/assets/355742ff-fed4-4c23-b9aa-8bd48fffe9a9" />


