### PR TITLE
Add Movement Speed while using skill to sidebar

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2805,7 +2805,7 @@ c["50% less Life Recovery from Flasks"]={{[1]={flags=0,keywordFlags=0,name="Flas
 c["50% less Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="LightningResist",type="MORE",value=-50}},nil}
 c["50% less Mana Recovery Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRecoveryRate",type="MORE",value=-50}},nil}
 c["50% less Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="MORE",value=-50}},nil}
-c["50% less Movement Speed Penalty from using Skills while moving"]={{[1]={[1]={type="Condition",var="Moving"},flags=0,keywordFlags=0,name="MovementSpeed",type="MORE",value=-50}},"  Penalty from using Skills  "}
+c["50% less Movement Speed Penalty from using Skills while moving"]={{[1]={flags=0,keywordFlags=0,name="MovementSpeedPenalty",type="MORE",value=-50}},nil}
 c["50% more Armour from Equipped Body Armour"]={{[1]={[1]={slotName="Body Armour",type="SlotName"},flags=0,keywordFlags=0,name="Armour",type="MORE",value=50}},nil}
 c["50% more Critical Damage Bonus"]={{[1]={flags=0,keywordFlags=0,name="CritMultiplier",type="MORE",value=50}},nil}
 c["50% more Damage against Heavy Stunned Enemies"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="HeavyStunned"},flags=0,keywordFlags=0,name="Damage",type="MORE",value=50}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -327,6 +327,12 @@ return {
 ["movement_speed_+%_final_while_performing_action"] = {
 	mod("SkillMovementSpeed", "MORE", nil),
 },
+["support_mobility_movement_speed_penalty_+%_final_while_performing_action"] = {
+	mod("MovementSpeedPenalty", "MORE", nil),
+},
+["support_deliberation_movement_speed_penalty_+%_final_while_performing_action"] = {
+	mod("MovementSpeedPenalty", "MORE", nil),
+},
 --
 -- Defensive modifiers
 --

--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -188,6 +188,7 @@ local displayStats = {
 	{ label = "Chaos Resistance", val = "Immune", labelStat = "ChaosResist", color = colorCodes.CHAOS, condFunc = function(o) return o.ChaosInoculation end },
 	{ },
 	{ stat = "EffectiveMovementSpeedMod", label = "Movement Speed Modifier", fmt = "+.1f%%", mod = true, condFunc = function() return true end },
+	{ stat = "MovementSpeedWhileUsingSkill", label = "Skill Movement Speed", fmt = "+.1f%%", mod = true, condFunc = function() return true end },
 	{ },
 	{ stat = "PresenceRadiusMetres", label = "Presence Radius", fmt = ".1fm", compPercent = true },
 	--[[ potentially useful mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2928,21 +2928,27 @@ function calcs.offence(env, actor, activeSkill)
 		output.QuantityMultiplier = quantityMultiplier
 	end
 
-	do
-		local penaltyMod = m_max((100 + activeSkill.skillModList:Sum("INC", nil, "MovementSpeedPenalty")), 0) / 100
-		local base = activeSkill.skillModList:More(activeSkill.skillCfg, "SkillMovementSpeed") or 0
+	if activeSkill.skillTypes[SkillType.UsableWhileMoving] then
+		local inc = skillModList:Sum("INC", skillCfg, "MovementSpeedPenalty")
+		local more = skillModList:More(skillCfg, "MovementSpeedPenalty")
+		local penaltyMod = m_max(0, skillModList:Override(skillCfg, "MovementSpeedPenalty") or (1 + inc / 100) * more)
+		local base = calcLib.mod(skillModList, skillCfg, "SkillMovementSpeed")
 		local total = (1 - base) * penaltyMod
 		output.MovementSpeedWhileUsingSkill = (1 - total) * output.MovementSpeedMod
+		output.MovementSpeedWhileUsingSkillPercent = (1 - total) * 100
 		if breakdown then
 			breakdown.MovementSpeedWhileUsingSkill = {
 				"Minimum Movement Speed while using this skill",
 				"^8(This is the lowest movement speed you will reach while using this skill,",
 				"^8subject to acceleration and deceleration)",
-				s_format("1 - (%.2f ^8(movement speed penalty from using skill)", 1 - base),
-				s_format("x %.2f) ^8(increased/reduced penalty)", penaltyMod),
-				s_format("= %.2f", 1 - total),
-				s_format("x %.2f ^8(movement speed modifier)", output.MovementSpeedMod),
-				s_format("= %.2f", output.MovementSpeedWhileUsingSkill),
+				"",
+				s_format("%d%% ^8(movement speed penalty from using skill)", 100 - base * 100),
+				s_format("x %.2f) ^8(increased/reduced penalty)", 1 + inc / 100),
+				s_format("x %.2f) ^8(more/less penalty)", more),
+				s_format("= %.1f%% ^8(movement speed penalty)", 100 - output.MovementSpeedWhileUsingSkillPercent),
+				s_format(""),
+				s_format("100%% - %.1f%% ^8(100 - movement speed penalty)", 100 - output.MovementSpeedWhileUsingSkillPercent),
+				s_format("= %.1f%% ^8(movement speed while casting)", output.MovementSpeedWhileUsingSkillPercent),
 			}
 		end
 	end

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1426,8 +1426,8 @@ return {
 	{ label = "Enemy Life Recovery", haveOutput = "EnemyLifeRegen", { format =  "{0:output:EnemyLifeRegen}%", { modName = "LifeRegen", modType = "INC", enemy = true }, }, },
 	{ label = "Enemy Mana Recovery", haveOutput = "EnemyManaRegen", { format =  "{0:output:EnemyManaRegen}%", { modName = "ManaRegen", modType = "INC", enemy = true }, }, },
 	{ label = "Enemy ES Recovery", haveOutput = "EnemyEnergyShieldRegen", { format =  "{0:output:EnemyEnergyShieldRegen}%", { modName = "EnergyShieldRegen", modType = "INC", enemy = true }, }, },
-	{ label = "MS While Casting", { format = "{2:output:MovementSpeedWhileUsingSkill}", { breakdown = "MovementSpeedWhileUsingSkill" }, { modName = { "SkillMovementSpeed", "MovementSpeedPenalty" }, cfg = "skill" }, }, },
-	} }
+	{ label = "MS While Casting", { format = "{1:output:MovementSpeedWhileUsingSkillPercent}%", { breakdown = "MovementSpeedWhileUsingSkill" }, { modName = { "SkillMovementSpeed", "MovementSpeedPenalty" }, cfg = "skill" }, }, },
+} }
 } },
 -- attributes/resists
 { 1, "Attributes", 2, colorCodes.NORMAL, {{ defaultCollapsed = false, label = "Attributes", data = {

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5697,6 +5697,7 @@ local specialModList = {
 		mod("LightningMax", "BASE", 1, { type = "PercentStat", stat = "Mana" , percent = num }, { type = "SkillType", skillType = SkillType.Attack }),
 	} end,
 	["(%d+)%% reduced movement speed penalty from using skills while moving"] = function(num) return { mod("MovementSpeedPenalty", "INC", -num) } end,
+	["(%d+)%% less movement speed penalty from using skills while moving"] = function(num) return { mod("MovementSpeedPenalty", "MORE", -num) } end,
 		-- Conditional Player Quantity / Rarity
 	["(%d+)%% increased quantity of items dropped by slain normal enemies"] = function(num) return { mod("LootQuantityNormalEnemies", "INC", num) } end,
 	["(%d+)%% increased rarity of items dropped by slain magic enemies"] = function(num) return { mod("LootRarityMagicEnemies", "INC", num) } end,


### PR DESCRIPTION
Many skills allow you to move while casting / attacking and its helpful to know what your movement speed is while doing do
Does not take into account the movement speed / penalty when using the Rhoa mount with skills though

Build
https://maxroll.gg/poe2/pob/552zf0jj

<img width="727" height="382" alt="image" src="https://github.com/user-attachments/assets/85e8d517-841a-4e22-9c99-d8c803819c0c" />
