### PR TITLE
Load Crossbow Damage skills by default instead of Ammo Skill

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -535,7 +535,7 @@ function GemSelectClass:AddGemTooltip(gemInstance)
 	if grantedEffect.name:match("^Spectre:") or grantedEffect.name:match("^Companion:") then
 		self.tooltip:AddLine(20, colorCodes.GEM .. (gemInstance.displayEffect and gemInstance.displayEffect.nameSpec or gemInstance.gemData.name))	
 	else
-		self.tooltip:AddLine(20, colorCodes.GEM .. grantedEffect.name)
+		self.tooltip:AddLine(20, colorCodes.GEM .. gemInstance.gemData.name)
 	end
 	self.tooltip:AddSeparator(10)
 	self.tooltip:AddLine(18, colorCodes.NORMAL .. gemInstance.gemData.gemType)

--- a/src/Data/Gems.lua
+++ b/src/Data/Gems.lua
@@ -7366,6 +7366,7 @@ return {
 		variantId = "BlackPowderBlitzReservation",
 		grantedEffectId = "BlackPowderBlitzReservationPlayer",
 		additionalGrantedEffectId1 = "BlackPowderBlitzPlayer",
+		grantedEffectDisplayOrder = { 1 },
 		tags = {
 			buff = true,
 			strength = true,
@@ -7616,6 +7617,7 @@ return {
 		variantId = "HighVelocityRounds",
 		grantedEffectId = "HighVelocityRoundsAmmoPlayer",
 		additionalGrantedEffectId1 = "HighVelocityRoundsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7643,6 +7645,7 @@ return {
 		variantId = "FragmentationRounds",
 		grantedEffectId = "FragmentationRoundsAmmoPlayer",
 		additionalGrantedEffectId1 = "FragmentationRoundsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7670,6 +7673,7 @@ return {
 		variantId = "SiegeCascade",
 		grantedEffectId = "SiegeCascadeAmmoPlayer",
 		additionalGrantedEffectId1 = "SiegeCascadePlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7696,6 +7700,7 @@ return {
 		variantId = "ArmourPiercingRounds",
 		grantedEffectId = "ArmourPiercingBoltsAmmoPlayer",
 		additionalGrantedEffectId1 = "ArmourPiercingBoltsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7721,6 +7726,7 @@ return {
 		variantId = "ExplosiveShot",
 		grantedEffectId = "ExplosiveShotAmmoPlayer",
 		additionalGrantedEffectId1 = "ExplosiveShotPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7748,6 +7754,7 @@ return {
 		variantId = "IncendiaryShot",
 		grantedEffectId = "IncendiaryShotAmmoPlayer",
 		additionalGrantedEffectId1 = "IncendiaryShotPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7775,6 +7782,7 @@ return {
 		variantId = "RapidShot",
 		grantedEffectId = "RapidShotAmmoPlayer",
 		additionalGrantedEffectId1 = "RapidShotPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7800,6 +7808,7 @@ return {
 		variantId = "GlacialBolt",
 		grantedEffectId = "GlacialBoltAmmoPlayer",
 		additionalGrantedEffectId1 = "GlacialBoltPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7827,6 +7836,7 @@ return {
 		variantId = "PermafrostBolts",
 		grantedEffectId = "PermafrostBoltsAmmoPlayer",
 		additionalGrantedEffectId1 = "PermafrostBoltsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7854,6 +7864,7 @@ return {
 		variantId = "HailstormRounds",
 		grantedEffectId = "HailstormRoundsAmmoPlayer",
 		additionalGrantedEffectId1 = "HailstormRoundsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7881,6 +7892,7 @@ return {
 		variantId = "IceShards",
 		grantedEffectId = "IceShardsAmmoPlayer",
 		additionalGrantedEffectId1 = "IceShardsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7909,6 +7921,7 @@ return {
 		variantId = "PlasmaBlast",
 		grantedEffectId = "PlasmaBlastAmmoPlayer",
 		additionalGrantedEffectId1 = "PlasmaBlastPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7936,6 +7949,7 @@ return {
 		variantId = "GalvanicShards",
 		grantedEffectId = "GalvanicShardsAmmoPlayer",
 		additionalGrantedEffectId1 = "GalvanicShardsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7963,6 +7977,7 @@ return {
 		variantId = "StormblastBolts",
 		grantedEffectId = "StormblastBoltsAmmoPlayer",
 		additionalGrantedEffectId1 = "StormblastBoltsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -7990,6 +8005,7 @@ return {
 		variantId = "ShockburstRounds",
 		grantedEffectId = "ShockburstRoundsAmmoPlayer",
 		additionalGrantedEffectId1 = "ShockburstRoundsPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -10246,6 +10262,7 @@ return {
 		variantId = "WarBanner",
 		grantedEffectId = "WarBannerReservationPlayer",
 		additionalGrantedEffectId1 = "WarBannerPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -10273,6 +10290,7 @@ return {
 		variantId = "DefianceBanner",
 		grantedEffectId = "DefianceBannerReservationPlayer",
 		additionalGrantedEffectId1 = "DefianceBannerPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -10300,6 +10318,7 @@ return {
 		variantId = "DreadBanner",
 		grantedEffectId = "DreadBannerReservationPlayer",
 		additionalGrantedEffectId1 = "DreadBannerPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,
@@ -11313,6 +11332,7 @@ return {
 		grantedEffectId = "MetaMirageArcherPlayer",
 		additionalGrantedEffectId1 = "SupportMirageArcherPlayer",
 		additionalGrantedEffectId2 = "MirageArcherSpawnPlayer",
+		grantedEffectDisplayOrder = { 1, 2 },
 		tags = {
 			buff = true,
 			dexterity = true,
@@ -15814,6 +15834,7 @@ return {
 		variantId = "CrossbowRequiem",
 		grantedEffectId = "CrossbowRequiemAmmoPlayer",
 		additionalGrantedEffectId1 = "CrossbowRequiemPlayer",
+		grantedEffectDisplayOrder = { 1, 0 },
 		tags = {
 			strength = true,
 			dexterity = true,

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -898,6 +898,15 @@ for skillGem in dat("SkillGems"):Rows() do
 					out:write('\t\tadditionalGrantedEffectId' .. tostring(count) .. ' = "', additionalGrantedEffect.Id, '",\n')
 				end
 			end
+			if gemEffect.GrantedEffectDisplayOrder then
+				local grantedEffectDisplayOrder = { }
+				for _, order in ipairs(gemEffect.GrantedEffectDisplayOrder) do
+					table.insert(grantedEffectDisplayOrder, order)
+				end
+				if next(grantedEffectDisplayOrder) then
+					out:write('\t\tgrantedEffectDisplayOrder = { ', table.concat(grantedEffectDisplayOrder, ", "), ' },\n')
+				end
+			end
 			if #gemEffect.SecondarySupportName > 0 then
 				out:write('\t\tsecondaryEffectName = "', gemEffect.SecondarySupportName, '",\n')
 			end

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -7123,7 +7123,7 @@ return {
 		},
 		[13]={
 			list=true,
-			name="",
+			name="GrantedEffectDisplayOrder",
 			refTo="",
 			type="Int",
 			width=150

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1738,11 +1738,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 					group.displayLabel = nil
 					for _, gemInstance in ipairs(group.gemList) do
 						local grantedEffect = gemInstance.gemData and gemInstance.gemData.grantedEffect or gemInstance.grantedEffect
+						local gemName = gemInstance.gemData and gemInstance.gemData.name
 						if grantedEffect and not grantedEffect.support and gemInstance.enabled then
 							if grantedEffect.name:match("^Companion:") or grantedEffect.name:match("^Spectre:") then
 								group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. gemInstance.nameSpec
 							else
-								group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. grantedEffect.name
+								group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. gemName or grantedEffect.name
 							end
 						end
 					end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -892,6 +892,18 @@ local function setupGem(gem, gemId)
 		table.insert(gem.additionalGrantedEffects, data.skills[gem["additionalGrantedEffectId"..i]])
 		i = i + 1
 	end
+	if gem.grantedEffectDisplayOrder then
+		local tempTable = {}
+		local moved = false
+		for i, temp in ipairs(gem.grantedEffectList) do
+			if gem.grantedEffectDisplayOrder[i] then
+				tempTable[i] = gem.grantedEffectList[gem.grantedEffectDisplayOrder[i] + 1]
+			else
+				tempTable[i] = temp
+			end
+		end
+		gem.grantedEffectList = tempTable
+	end
 	gem.naturalMaxLevel = gem.naturalMaxLevel or (#gem.grantedEffect.levels > 20 and #gem.grantedEffect.levels - 20) or (gem.grantedEffect.levels[3][1] and 3) or 1
 end
 


### PR DESCRIPTION
The Crossbow skills have their Ammo skill as the GrantedEffect entry so we were previously loading them first in the stat set list.
This also caused the Ammo Skill to be used in all the places the skill name showed up like the sidebar, skill list, calcs tab etc
Build:
https://maxroll.gg/poe2/pob/9phj0dep

Before:
<img width="1278" height="224" alt="image" src="https://github.com/user-attachments/assets/16a1357b-5a9d-43b3-97f1-06c30b176d81" />

After:
<img width="1280" height="228" alt="image" src="https://github.com/user-attachments/assets/01876522-14c2-459a-b92f-cdd0c4b9351d" />

