### PR TITLE
Allow failure of "Report coverage" step in "run_tests" job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Run tests
         run: busted --lua=luajit
       - name: Report coverage
+        continue-on-error: true # May fail on server errors (of coveralls.io)
         run: cd src; luacov-coveralls --repo-token=${{ secrets.github_token }} -e TestData -e Data -e runtime
   check_modcache:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of the problem being solved:
Sometimes the run_tests job can fail, and when checking the reason, it's actually the coverage step that failed (could happen if the coveralls.io server is overloaded but I also saw other 50X http errors). As the coverage is not something we usually care much, it makes sense to ignore errors.

### Steps taken to verify a working solution:
- Tested on my LE fork + should not fail on this commit