### PR TITLE
Fix stat values for some Tree nodes when using Hulking Form

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1243,7 +1243,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 			end
 			
 			-- Apply Inc Node scaling from Hulking Form + Radius Jewels only visually
-			if (incSmallPassiveSkillEffect + localIncEffect) > 0 and (node.type == "Normal" or node.type == "Notable") and not node.isAttribute and not node.ascendancyName and node.mods[i].list then
+			if ((incSmallPassiveSkillEffect + localIncEffect) > 0 and node.type == "Normal") or (localIncEffect > 0 and node.type == "Notable") and not node.isAttribute and not node.ascendancyName and node.mods[i].list then
 				local scale = 1 + (node.type == "Normal" and incSmallPassiveSkillEffect or 0 + localIncEffect) / 100
 				local modsList = copyTable(node.mods[i].list)
 				local scaledList = new("ModList")
@@ -1259,7 +1259,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 					elseif type(mod.value) == "table" then
 						newValue = mod.value.mod.value
 					end
-					line = line:gsub("%d*%.?%d+", math.abs(newValue))
+					line = line:gsub("%d*%.?%d+", math.abs(newValue), 1) -- Only scale first number in line
 				end
 				-- line = line .. "  ^8(Effect increased by "..incSmallPassiveSkillEffect.."%)"
 			end


### PR DESCRIPTION
If Hulking form was allocated we were still scaling Notables by 1x and the gsub to scale the mod value would match multiple values in the line and replace them all with the scaled value
e.g. 1% increased Damage per 15 Strength
1% would be scaled by 1x and then the gsub would replace both numbers in the line with 1 so it would become
1% increased Damage per 1 Strength
Fixes #1413

Build:
https://maxroll.gg/poe2/pob/1c29d0gt

Before:
<img width="637" height="265" alt="image" src="https://github.com/user-attachments/assets/2fe10ca5-f1a4-4e49-b630-358b1d31cedd" />
<img width="568" height="83" alt="image" src="https://github.com/user-attachments/assets/e8e472d1-fe40-4683-84f7-6445a245f441" />


After:
<img width="574" height="92" alt="image" src="https://github.com/user-attachments/assets/50690a77-17fc-4c90-8628-e2903df13f45" />
<img width="432" height="121" alt="image" src="https://github.com/user-attachments/assets/8ac049cd-4212-44e8-9b7c-e1a7d1d072e7" />
