### PR TITLE
Fix errorneous call to GetUserPath and update pop-up message

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -77,10 +77,10 @@ function main:Init()
 		-- If running in dev mode or standalone mode, put user data in the script path
 		self.userPath = GetScriptPath().."/"
 	else
-		local invalidPath
-		self.userPath, invalidPath = GetUserPath()
+		local invalidPath, errMsg
+		self.userPath, invalidPath, errMsg = GetUserPath()
 		if not self.userPath then
-			self:OpenPathPopup(invalidPath, ignoreBuild)
+			self:OpenPathPopup(invalidPath, errMsg, ignoreBuild)
 		else
 			self.userPath = self.userPath.."/Path of Building (PoE2)/"
 		end
@@ -749,17 +749,16 @@ function main:SaveSettings()
 	end
 end
 
-function main:OpenPathPopup(invalidPath, ignoreBuild)
+function main:OpenPathPopup(invalidPath, errMsg, ignoreBuild)
 	local controls = { }
 	local defaultLabelPlacementX = 8
 
 	controls.label = new("LabelControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, 20, 206, 16 }, function()
-		return "^7User settings path contains unicode characters and cannot be loaded."..
+		return "^7User settings path cannot be loaded: ".. errMsg ..
 		"\nCurrent Path: "..invalidPath:gsub("?", "^1?^7").."/Path of Building/"..
-		"\nSpecify a new location for your Settings.xml:"
-	end)
-	controls.explainButton = new("ButtonControl", { "LEFT", controls.label, "RIGHT" }, { 4, 0, 20, 20 }, "?", function()
-		OpenURL("https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/wiki/Why-do-I-have-to-change-my-Settings-path%3F")
+		"\nIf this location is managed by OneDrive, navigate to that folder and manually try" ..
+		"\nto open Settings.xml in a text editor before re-opening Path of Building" ..
+		"\nOtherwise, specify a new location for your Settings.xml:"
 	end)
 	controls.userPath = new("EditControl", { "TOPLEFT", controls.label, "TOPLEFT" }, { 0, 60, 206, 20 }, invalidPath, nil, nil, nil, function(buf)
 		invalidPath = sanitiseText(buf)

--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -79,8 +79,10 @@ end
 ConPrintf("Checking for update...")
 
 -- Use built-in helpers to obtain absolute paths without spawning a shell.
-local scriptPath = "."
-local runtimePath = "."
+local scriptPath, scriptFallback = GetScriptPath()
+scriptPath = scriptPath or scriptFallback or "."
+local runtimePath, runtimeFallback = GetRuntimePath()
+runtimePath = runtimePath or runtimeFallback or scriptPath
 
 -- Load and process local manifest
 local localVer


### PR DESCRIPTION
### Description of the problem being solved:
This depends on https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/76 and attempts to mitigate the situation described in [`02cf10a` (#372)](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/372/commits/02cf10acf7403472fb1e2077678be96b34f20c79)

Most installations should be fine using the relative paths, but some exotic installs would not have these files in the correct relative location.

## To test:

Have a legacy PoB setup, where the runtime files are stored separately from the script files.  Change these directories to be Unicode so the bare-bones Lua runtime can't parse the path and will use the fallback path.