### PR TITLE
Add support gem filtering options in Skills tab

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -101,7 +101,11 @@ function GemSelectClass:PopulateGemList()
 		if (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
 			local levelRequirement = (gemData.grantedEffect.levels and gemData.grantedEffect.levels[1] and gemData.grantedEffect.levels[1].levelRequirement) or 1
 			if characterLevel >= levelRequirement or not matchLevel then
-				self.gems["Default:" .. gemId] = gemData
+				if (showLineage or showAll) and gemData.grantedEffect.isLineage then
+					self.gems["Default:" .. gemId] = gemData
+				elseif (showNormal or showAll) and not gemData.grantedEffect.isLineage then
+					self.gems["Default:" .. gemId] = gemData
+				end
 			end
 		end
 	end
@@ -115,7 +119,7 @@ function GemSelectClass:FilterSupport(gemId, gemData)
 	local showSupportTypes = self.skillsTab.showSupportGemTypes
 	return (not gemData.grantedEffect.support
 		or showSupportTypes == "ALL"
-		or (showSupportTypes == "NORMAL" and not gemData.grantedEffect.plusVersionOf)
+		or (showSupportTypes == "NORMAL" and not gemData.grantedEffect.isLineage)
 		or (showSupportTypes == "LINEAGE" and gemData.grantedEffect.isLineage))
 end
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -92,7 +92,7 @@ end
 function GemSelectClass:PopulateGemList()
 	wipeTable(self.gems)
 	local showAll = self.skillsTab.showSupportGemTypes == "ALL"
-	local showAwakened = self.skillsTab.showSupportGemTypes == "AWAKENED"
+	local showLineage = self.skillsTab.showSupportGemTypes == "LINEAGE"
 	local showNormal = self.skillsTab.showSupportGemTypes == "NORMAL"
 	local matchLevel = self.skillsTab.defaultGemLevel == "characterLevel"
 	local characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1
@@ -116,7 +116,7 @@ function GemSelectClass:FilterSupport(gemId, gemData)
 	return (not gemData.grantedEffect.support
 		or showSupportTypes == "ALL"
 		or (showSupportTypes == "NORMAL" and not gemData.grantedEffect.plusVersionOf)
-		or (showSupportTypes == "AWAKENED" and gemData.grantedEffect.plusVersionOf))
+		or (showSupportTypes == "LINEAGE" and gemData.grantedEffect.isLineage))
 end
 
 function GemSelectClass:BuildList(buf)

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -54,7 +54,7 @@ This hides gems with a minimum level requirement above your character level, pre
 
 local showSupportGemTypeList = {
 	{ label = "All", show = "ALL" },
-	{ label = "Non-Awakened", show = "NORMAL" },
+	{ label = "Highest Tier Per Family", show = "NORMAL" },
 	{ label = "Lineage", show = "LINEAGE" },
 }
 

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -55,7 +55,7 @@ This hides gems with a minimum level requirement above your character level, pre
 local showSupportGemTypeList = {
 	{ label = "All", show = "ALL" },
 	{ label = "Non-Awakened", show = "NORMAL" },
-	{ label = "Awakened", show = "AWAKENED" },
+	{ label = "Lineage", show = "LINEAGE" },
 }
 
 local sortGemTypeList = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -4109,7 +4109,6 @@ skills["SupportPrecisionPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Precision",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 10, levelRequirement = 0, },
 	},
@@ -4145,7 +4144,6 @@ skills["SupportPrecisionPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Precision",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 20, levelRequirement = 0, },
 	},
@@ -5656,7 +5654,6 @@ skills["SupportWarmbloodedPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "WarmBlooded",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -988,7 +988,6 @@ skills["SupportClarityPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Clarity",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 10, levelRequirement = 0, },
 	},
@@ -1024,7 +1023,6 @@ skills["SupportClarityPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Clarity",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 20, levelRequirement = 0, },
 	},
@@ -4128,7 +4126,6 @@ skills["SupportMysticismPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Mysticism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -4164,7 +4161,6 @@ skills["SupportMysticismPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Mysticism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 30, levelRequirement = 0, },
 	},
@@ -4935,7 +4931,6 @@ skills["SupportStrongHeartedPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "StrongHearted",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -5118,7 +5113,6 @@ skills["SupportUpwellingPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Upwellling",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -5149,7 +5143,6 @@ skills["SupportUpwellingPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Upwellling",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 30, levelRequirement = 0, },
 	},

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1272,7 +1272,6 @@ skills["SupportCannibalismPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Cannibalism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -1308,7 +1307,6 @@ skills["SupportCannibalismPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Cannibalism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 30, levelRequirement = 0, },
 	},
@@ -1543,7 +1541,6 @@ skills["SupportCoolheadedPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "CoolHeaded",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -2064,7 +2061,6 @@ skills["SupportDirestrikePlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Direstrike",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 20, levelRequirement = 0, },
 	},
@@ -2100,7 +2096,6 @@ skills["SupportDirestrikePlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Direstrike",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 40, levelRequirement = 0, },
 	},
@@ -3650,7 +3645,6 @@ skills["SupportHerbalismPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Herbalism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 15, levelRequirement = 0, },
 	},
@@ -3686,7 +3680,6 @@ skills["SupportHerbalismPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Herbalism",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 30, levelRequirement = 0, },
 	},
@@ -7155,7 +7148,6 @@ skills["SupportVitalityPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Vitality",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 20, levelRequirement = 0, },
 	},
@@ -7192,7 +7184,6 @@ skills["SupportVitalityPlayerTwo"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "Vitality",},
-	isLineage = true,
 	levels = {
 		[1] = { spiritReservationFlat = 40, levelRequirement = 0, },
 	},

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -334,15 +334,13 @@ directiveTable.skill = function(state, args, out)
 				end
 				out:write('},\n')
 			end
-			if supportGem.Lineage then
+			if supportGem.Lineage and supportGem.FlavourText then
 				out:write('\tisLineage = true,\n')
-				if supportGem.FlavourText then
-					out:write('\tflavourText = {')
-					for _, line in ipairs(cleanAndSplit(supportGem.FlavourText.Text)) do
-						out:write('"', line, '", ')
-					end
-					out:write('},\n')
+				out:write('\tflavourText = {')
+				for _, line in ipairs(cleanAndSplit(supportGem.FlavourText.Text)) do
+					out:write('"', line, '", ')
 				end
+				out:write('},\n')
 			end
 		end
 		if skill.isTrigger then


### PR DESCRIPTION
### Description of the problem being solved:
Needs more work, at the moment the dropdown does filter by Lineage supports. But the `Highest Tier Per Family` is not implemented yet. Some Gem Families have a Lineage, others do not, and the SupportTier in the dat file shows 0 for Lineage like Brutus' Brain, so we can't just use the highest number. We also can't look for 3, as some families only have 2. Need to do some wacky combination probably.

Also the isLineage is true for a bunch of persistent support gems. So slight change to exporter so that it looks for the flavour text too, as only true lineage have flavour text.

### After screenshot:
<img width="395" height="187" alt="image" src="https://github.com/user-attachments/assets/a49ba359-a001-4e90-9bfc-444b54be76c5" />
