### PR TITLE
Aftershock parsing

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5438,7 +5438,7 @@ c["Skills have a 5% chance to not consume Glory"]={nil,"a 5% chance to not consu
 c["Skills reserve 50% less Spirit"]={{[1]={flags=0,keywordFlags=0,name="SpiritReserved",type="MORE",value=-50}},nil}
 c["Skills used by Totems have 30% more Skill Speed"]={{[1]={flags=0,keywordFlags=16384,name="Speed",type="MORE",value=30},[2]={flags=0,keywordFlags=16384,name="WarcrySpeed",type="MORE",value=30},[3]={flags=0,keywordFlags=16384,name="TotemPlacementSpeed",type="MORE",value=30}},nil}
 c["Slam Skills have 8% increased Area of Effect"]={{[1]={[1]={skillType=92,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=8}},nil}
-c["Slam Skills you use yourself cause Aftershocks"]={nil,"Slam Skills you use yourself cause Aftershocks "}
+c["Slam Skills you use yourself cause Aftershocks"]={{[1]={[1]={skillType=92,type="SkillType"},[2]={neg=true,skillType=95,type="SkillType"},[3]={neg=true,skillType=37,type="SkillType"},[4]={neg=true,skillType=33,type="SkillType"},flags=0,keywordFlags=0,name="AftershockChance",type="BASE",value=100}},nil}
 c["Sorcery Ward recovers 50% faster"]={nil,"recovers 50% faster "}
 c["Soul Eater"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanHaveSoulEater",type="FLAG",value=true}},nil}
 c["Spell Skills have 10% reduced Area of Effect"]={{[1]={flags=0,keywordFlags=131072,name="AreaOfEffect",type="INC",value=-10}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2408,6 +2408,9 @@ return {
 ["slam_aftershock_chance_%"] = {
 	mod("AftershockChance", "BASE", nil)
 },
+["chance_to_aftershock_+%_per_250_ms_attack_time"] = {
+	mod("AftershockChanceQuarterSecond", "BASE", nil)
+},
 -- Curse
 ["curse_effect_+%"] = {
 	mod("CurseEffect", "INC", nil),

--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -77,7 +77,6 @@ local displayStats = {
 	{ stat = "AreaOfEffectRadiusMetres", label = "AoE Radius", fmt = ".1fm" },
 	{ stat = "BrandAttachmentRangeMetre", label = "Attachment Range", fmt = ".1fm", flag = "brand" },
 	{ stat = "BrandTicks", label = "Activations per Brand", fmt = "d", flag = "brand" },
-	{ stat = "AftershockChance", label = "Aftershock Chance", fmt = ".0f%%" },
 	{ stat = "ManaCost", label = "Mana Cost", fmt = "d", color = colorCodes.MANA, pool = "ManaUnreserved", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ManaHasCost end },
 	{ stat = "ManaPercentCost", label = "Mana Cost", fmt = "d%%", color = colorCodes.MANA, pool = "ManaUnreservedPercent", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ManaPercentHasCost end },
 	{ stat = "ManaPerSecondCost", label = "Mana Cost per second", fmt = ".2f", color = colorCodes.MANA, pool = "ManaUnreserved", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.ManaPerSecondHasCost end },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2925,6 +2925,13 @@ function calcs.offence(env, actor, activeSkill)
 		end
 	end
 
+	if (skillModList:Sum("BASE", skillCfg, "AftershockChance", "AftershockChanceQuarterSecond") or 0) > 0 then
+		local aftershockChance = skillModList:Sum("BASE", skillCfg, "AftershockChance")
+		local inc = (skillModList:Sum("BASE", skillCfg, "AftershockChanceQuarterSecond") or 0) * m_floor(1 / output.Speed)  / 0.25
+		aftershockChance = aftershockChance * (1 + inc / 100)
+		skillModList:NewMod("DPS", "MORE", aftershockChance, "Aftershock Chance")
+	end
+
 	-- Grab quantity multiplier
 	local quantityMultiplier = m_max(activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "QuantityMultiplier"), 1)
 	if quantityMultiplier > 1 then
@@ -4024,8 +4031,7 @@ function calcs.offence(env, actor, activeSkill)
 		local repeatPenalty = skillModList:Flag(nil, "HasSeals") and activeSkill.skillTypes[SkillType.Unleashable]  and not skillModList:Flag(nil, "NoRepeatBonuses") and calcLib.mod(skillModList, skillCfg, "SealRepeatPenalty") or 1
 		globalOutput.AverageBurstDamage = output.AverageDamage + output.AverageDamage * (globalOutput.AverageBurstHits - 1) * repeatPenalty or 0
 		globalOutput.ShowBurst = globalOutput.AverageBurstHits > 1
-		local aftershockChance = (1 + skillModList:Sum("BASE", skillCfg, "AftershockChance")/100) or 1
-		output.TotalDPS = output.AverageDamage * (globalOutput.HitSpeed or globalOutput.Speed) * skillData.dpsMultiplier * quantityMultiplier * aftershockChance
+		output.TotalDPS = output.AverageDamage * (globalOutput.HitSpeed or globalOutput.Speed) * skillData.dpsMultiplier * quantityMultiplier
 		if breakdown then
 			if output.CritEffect ~= 1 then
 				breakdown.AverageHit = { }
@@ -5269,10 +5275,6 @@ function calcs.offence(env, actor, activeSkill)
 		combineStat("ImpaleStoredDamage", "AVERAGE")
 		combineStat("ImpaleModifier", "CHANCE", "ImpaleChance")
 	end
-
-	output.AftershockChance = skillModList:Sum("BASE", skillCfg, "AftershockChance")
-	print("aftershock chance:" .. output.AftershockChance)
-
 
 	if skillData.decay and canDeal.Chaos then
 		-- Calculate DPS for Decay effect

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1589,13 +1589,8 @@ local modTagList = {
 	["for each enemy pierced"] = { tag = { type = "PerStat", stat = "PiercedCount" } },
 	["for each time they've pierced"] = { tag = { type = "PerStat", stat = "PiercedCount" } },
 	["for slam skills"] = { tag = { type = "SkillType", skillType = SkillType.Slam } },
-	["for mace slam skills"] = { tagList = {
-		{ type = "Condition", var = "UsingMace" }, 
-		{ type = "SkillType", skillType = SkillType.Slam } }},
-	["you use yourself"] = { tagList = { 
-		{ type = "SkillType", skillType = SkillType.UsedByTotem, neg = true }, 
-		{ type = "SkillType", skillType = SkillType.Triggered, neg = true }, 
-		{ type = "SkillType", skillType = SkillType.Trapped, neg = true } }},
+	["for mace slam skills"] = { tagList = { { type = "Condition", var = "UsingMace" }, { type = "SkillType", skillType = SkillType.Slam } }},
+	["you use yourself"] = { tagList = { { type = "SkillType", skillType = SkillType.UsedByTotem, neg = true }, { type = "SkillType", skillType = SkillType.Triggered, neg = true }, { type = "SkillType", skillType = SkillType.Trapped, neg = true } }},
 	-- Stat conditions
 	["with (%d+) or more strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,
 	["with at least (%d+) strength"] = function(num) return { tag = { type = "StatThreshold", stat = "Str", threshold = num } } end,
@@ -5717,6 +5712,9 @@ local specialModList = {
 	} end,
 	["(%d+)%% reduced movement speed penalty from using skills while moving"] = function(num) return { mod("MovementSpeedPenalty", "INC", -num) } end,
 	["(%d+)%% less movement speed penalty from using skills while moving"] = function(num) return { mod("MovementSpeedPenalty", "MORE", -num) } end,
+	["slam skills you use yourself cause aftershocks"] = {
+		mod("AftershockChance", "BASE", 100, { type = "SkillType", skillType = SkillType.Slam }, { type = "SkillType", skillType = SkillType.UsedByTotem, neg = true }, { type = "SkillType", skillType = SkillType.Triggered, neg = true }, { type = "SkillType", skillType = SkillType.Trapped, neg = true })
+	},
 		-- Conditional Player Quantity / Rarity
 	["(%d+)%% increased quantity of items dropped by slain normal enemies"] = function(num) return { mod("LootQuantityNormalEnemies", "INC", num) } end,
 	["(%d+)%% increased rarity of items dropped by slain magic enemies"] = function(num) return { mod("LootRarityMagicEnemies", "INC", num) } end,


### PR DESCRIPTION
### Description of the problem being solved:
Some more aftershock mods are now properly parsed, under the assumption that "you use yourself" currently means no totems, no triggers, and no traps (which are coming eventually).
Aftershocks now affect TotalDPS.
Aftershock Chance is shown with Crit Chance.

### Steps taken to verify a working solution:
- Cause mods to parse.
- Assert that DPS is properly affected.
- Assert that type-restrictions are working correctly (with the skills in the build below).

### Link to a build that showcases this PR:
[Maxroll](https://maxroll.gg/poe2/pob/j4bq90gf)

### Before screenshot:
Red text.

### After screenshot:
<img width="658" height="312" alt="image" src="https://github.com/user-attachments/assets/d05781ed-4191-4d35-9e7e-21fbfd2a6c87" />
<br>

<img width="633" height="362" alt="image" src="https://github.com/user-attachments/assets/22a6c0f4-5bbc-4352-9865-94ab894ba63d" />
<br>

<img width="380" height="243" alt="image" src="https://github.com/user-attachments/assets/1089bce6-4d8b-4043-be06-757466df6b0f" />