### PR TITLE
Fix Header Influence Icon Showing on Jewel Sockets

### DIFF
--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -350,7 +350,7 @@ function TooltipClass:Draw(x, y, w, h, viewPort)
 
 		-- Draw left cap first, then influence icon on top
 		DrawImage(self.headerLeft, headerX, headerY, headerSideWidth, headerHeight)
-		if self.influenceHeader1 then
+		if self.influenceHeader1 and self.tooltipHeader ~= "JEWEL" then
 			DrawImage(self.influenceIcon1, headerX+5, headerY+(headerHeight/4), headerSideWidth/2+6, headerHeight/2)
 		end
 
@@ -370,7 +370,7 @@ function TooltipClass:Draw(x, y, w, h, viewPort)
 
 		-- Draw right cap
 		DrawImage(self.headerRight, headerX + headerTotalWidth - headerSideWidth, headerY, headerSideWidth, headerHeight)
-		if self.influenceHeader2 then
+		if self.influenceHeader2 and self.tooltipHeader ~= "JEWEL" then
 			DrawImage(self.influenceIcon2, headerX + headerTotalWidth - headerSideWidth+10, headerY+(headerHeight/4), headerSideWidth/2+6, headerHeight/2)
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:
All Jewel sockets on the tree would show the desecrated icon if a jewel with desecrated mods was socketed in it. This is the simplest fix, and I'm not sure where else I would change this anyway, as it's something to do with how jewels are assigned to the socket nodes. The icons still show properly when hovering the socketed jewel.

### Before screenshot:
<img width="367" height="306" alt="image" src="https://github.com/user-attachments/assets/0d0760b5-8a4c-4ad6-80f6-cc271fc54c66" />

### After screenshot:
<img width="367" height="323" alt="image" src="https://github.com/user-attachments/assets/3abaf80d-6853-40f3-9836-25ef51602e60" />
