### PR TITLE
Add CTRL + C to error message to copy error text

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -351,6 +351,9 @@ function launch:ShowPrompt(r, g, b, str, func)
 	self.promptFunc = func or function(key)
 		if key == "RETURN" or key == "ESCAPE" then
 			return true
+		elseif key == "c" and IsKeyDown("CTRL") then
+			local cleanStr = str:gsub("%^%d", "")
+			Copy(cleanStr)
 		elseif key == "F5" then
 			self.doRestart = "Restarting..."
 			return true
@@ -363,7 +366,7 @@ function launch:ShowErrMsg(fmt, ...)
 		local version = self.versionNumber and 
 			"^8v"..self.versionNumber..(self.versionBranch and " "..self.versionBranch or "")
 			or ""
-		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0"..string.format(fmt, ...).."\n"..version.."\n^0Press Enter/Escape to dismiss, or F5 to restart the application.")
+		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0"..string.format(fmt, ...).."\n"..version.."\n^0Press Enter/Escape to dismiss, or F5 to restart the application.\nPress CTRL + C to copy error text.")
 	end
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Adds the option to copy the error text instead of taking a screenshot.

```
Error:

In 'OnFrame': Classes/ItemsTab.lua:819: attempt to index a nil value
stack traceback:
	Classes/ItemsTab.lua:819: in function 'changeFunc'
	Classes/SliderControl.lua:50: in function 'SetVal'
	Classes/SliderControl.lua:66: in function 'SetValFromKnobX'
	Classes/SliderControl.lua:84: in function 'Draw'
	Classes/ControlHost.lua:91: in function 'DrawControls'
	Classes/ItemsTab.lua:1171: in function 'Draw'
	Modules/Build.lua:1183: in function 'CallMode'
	Modules/Main.lua:359: in function <Modules/Main.lua:329>
	[C]: in function 'PCall'
	Launch.lua:109: in function <Launch.lua:106>
v0.12.2
Press Enter/Escape to dismiss, or F5 to restart the application.
Press CTRL + C to copy error text.
```

### After screenshot:
<img width="579" height="387" alt="image" src="https://github.com/user-attachments/assets/20a63b68-64a3-4e6c-9d66-919536e089af" />
