### PR TITLE
Add copy button to exporter and increase script list size

### DIFF
--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -225,17 +225,17 @@ function main:Init()
 	}
 
 	self.controls.copyScriptOutput = new("ButtonControl", {"TOPRIGHT", self.controls.scriptOutput, "BOTTOMRIGHT"}, {0, 4, 80, 20}, "Copy", function()
-	        local lines = {}
-	        local textList = self.controls.scriptOutput.list or {}  -- grab the actual list
-	        for _, entry in ipairs(textList) do
-	            local line = entry[1] or ""
-	            line = line:gsub("^%^[0-9]+", "")  -- remove color codes
-	            if line ~= "" then
-	                table.insert(lines, line)
-	            end
-	        end
-	        Copy(table.concat(lines, "\n"))
-	    end
+		local lines = {}
+		local textList = self.controls.scriptOutput.list or {}
+		for _, entry in ipairs(textList) do
+			local line = entry[1] or ""
+			line = line:gsub("^%^[0-9]+", "")  -- remove color codes
+			if line ~= "" then
+				table.insert(lines, line)
+			end
+		end
+		Copy(table.concat(lines, "\n"))
+	end
 	)
 
 	self.controls.datSearch = new("EditControl", {"TOPLEFT", self.controls.datSource, "BOTTOMLEFT"}, {0, 2, 250, 18}, nil, "^7Search", nil, nil, function(buf)

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -181,7 +181,7 @@ function main:Init()
 		self:SetCurrentDat()
 	end)
 	
-	self.controls.scriptAll = new("ButtonControl", nil, {270, 10, 100, 18}, "Run All", function()
+	self.controls.scriptAll = new("ButtonControl", nil, {270, 10, 140, 18}, "Run All", function()
 		do -- run stat desc first
 			local errMsg = PLoadModule("Scripts/".."statdesc"..".lua")
 			if errMsg then
@@ -198,7 +198,7 @@ function main:Init()
 			return not self.curDatFile
 		end
 	}
-	self.controls.clearOutput = new("ButtonControl", nil, {1190, 10, 100, 18}, "Clear", function()
+	self.controls.clearOutput = new("ButtonControl", nil, {1230, 10, 100, 18}, "Clear", function()
 		wipeTable(self.scriptOutput)
 	end) {
 		shown = function()
@@ -213,16 +213,30 @@ function main:Init()
 	end, nil, false)
 	self.controls.helpText = new("LabelControl", {"TOPLEFT",self.controls.clearOutput,"BOTTOMLEFT"}, {0, 42, 100, 16}, "Press Ctrl+F5 to re-export\ndata from the game")
 
-	self.controls.scriptList = new("ScriptListControl", nil, {270, 35, 100, 300}) {
+	self.controls.scriptList = new("ScriptListControl", nil, {270, 35, 140, 575}) {
 		shown = function()
 			return not self.curDatFile
 		end
 	}
-	self.controls.scriptOutput = new("TextListControl", nil, {380, 10, 800, 600}, nil, self.scriptOutput) {
+	self.controls.scriptOutput = new("TextListControl", nil, {420, 10, 800, 600}, nil, self.scriptOutput) {
 		shown = function()
 			return not self.curDatFile
 		end
 	}
+
+	self.controls.copyScriptOutput = new("ButtonControl",{"TOPRIGHT", self.controls.scriptOutput, "BOTTOMRIGHT"},{0, 4, 80, 20},"Copy",function()
+	        local lines = {}
+	        local textList = self.controls.scriptOutput.list or {}  -- grab the actual list
+	        for _, entry in ipairs(textList) do
+	            local line = entry[1] or ""
+	            line = line:gsub("^%^[0-9a-fA-F]+", "")  -- remove color codes
+	            if line ~= "" then
+	                table.insert(lines, line)
+	            end
+	        end
+	        Copy(table.concat(lines, "\n"))
+	    end
+	)
 
 	self.controls.datSearch = new("EditControl", {"TOPLEFT", self.controls.datSource, "BOTTOMLEFT"}, {0, 2, 250, 18}, nil, "^7Search", nil, nil, function(buf)
 		self.controls.datList.searchBuf = buf


### PR DESCRIPTION
### Description of the problem being solved:
Since we added a few more scripts, it's worth increasing the size of some of the boxes. I also added a Copy button to the result box, to easily copy errors. Example with forced error:

```
Classes/Dat64File.lua:103: Unknown key MonsterVarietiesKey2 for monsterpackentries.datc64
stack traceback:
	[C]: in function 'error'
	Classes/Dat64File.lua:103: in function '__index'
	Scripts/worldAreas.lua:20: in main chunk
	[C]: in function 'PLoadModule'
	Classes/ScriptListControl.lua:21: in function 'OnSelClick'
	../Classes/ListControl.lua:369: in function 'OnKeyDown'
	../Classes/ControlHost.lua:39: in function 'ProcessControlsInput'
	Main.lua:427: in function <Main.lua:418>
	[C]: in function 'PCall'
	Launch.lua:56: in function <Launch.lua:53>
stat_descriptions.csd loaded. (9918 stats)
Soul Cores exported.
Spectre List exported.
```

### After screenshot:
<img width="1357" height="674" alt="image" src="https://github.com/user-attachments/assets/f277060b-a57f-4cee-b8fd-602db3789d49" />
