### PR TITLE
Remove forced CritInPast8Sec when skill has any crit

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3483,10 +3483,6 @@ function calcs.offence(env, actor, activeSkill)
 		end
 
 		output.ScaledDamageEffect = 1
-		
-		if output.CritChance ~= 0 then
-			skillModList.conditions["CritInPast8Sec"] = true
-		end
 
 		-- Calculate chance and multiplier for dealing triple damage on Normal and Crit
 		output.TripleDamageChanceOnCrit = m_min(skillModList:Sum("BASE", cfg, "TripleDamageChanceOnCrit"), 100)


### PR DESCRIPTION
Fixes #1466

### Description of the problem being solved:
CritInPast8Sec was being set if the skill had any crit chance at all. This made the config toggle do nothing as it was generally always true, which felt weird and wasn't explained anywhere.