### PR TITLE
Fix Revive Time calculation and show time for Spectres / Companion

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5051,15 +5051,15 @@ c["Meta Skills have 20% increased Reservation Efficiency"]={nil,"Meta Skills hav
 c["Minions Break Armour equal to 3% of Physical damage dealt"]={nil,"Break Armour equal to 3% of Physical damage dealt "}
 c["Minions Recoup 15% of Damage taken as Life"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="LifeRecoup",type="BASE",value=15}}}},nil}
 c["Minions Regenerate 3% of maximum Life per second"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=3}}}},nil}
-c["Minions Revive 10% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-10}},nil}
-c["Minions Revive 13% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-13}},nil}
-c["Minions Revive 15% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-15}},nil}
+c["Minions Revive 10% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=10}},nil}
+c["Minions Revive 13% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=13}},nil}
+c["Minions Revive 15% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=15}},nil}
 c["Minions Revive 15% faster if all your Minions are Companions"]={nil,"Revive 15% faster if all your Minions are Companions "}
-c["Minions Revive 25% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-25}},nil}
-c["Minions Revive 3% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-3}},nil}
+c["Minions Revive 25% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=25}},nil}
+c["Minions Revive 3% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=3}},nil}
 c["Minions Revive 35% faster if all your Minions are Companions"]={nil,"Revive 35% faster if all your Minions are Companions "}
-c["Minions Revive 5% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-5}},nil}
-c["Minions Revive 50% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalTime",type="INC",value=-50}},nil}
+c["Minions Revive 5% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=5}},nil}
+c["Minions Revive 50% faster"]={{[1]={flags=0,keywordFlags=0,name="MinionRevivalSpeed",type="INC",value=50}},nil}
 c["Minions cannot Die while affected by a Life Flask"]={nil,"cannot Die while affected by a Life Flask "}
 c["Minions cannot Die while affected by a Life Flask 30% increased Flask Charges gained"]={nil,"cannot Die while affected by a Life Flask 30% increased Flask Charges gained "}
 c["Minions cause 15% increased Stun Buildup"]={nil,"cause 15% increased Stun Buildup "}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2394,6 +2394,9 @@ return {
 ["minion_command_skill_cooldown_speed_+%"] = {
 	mod("MinionModifier", "LIST", { mod = mod("CooldownRecovery", "INC", nil, 0, 0, {type = "Condition", var = "CommandableSkill"}) }),
 },
+["is_resummoning_minion"] = {
+	flag("RevivingMinion")
+},
 --Golem
 ["golem_buff_effect_+%"] = {
 	mod("BuffEffect", "INC", nil, 0, 0)

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -16850,8 +16850,7 @@ skills["SacrificePlayer"] = {
 			statDescriptionScope = "harvester",
 			statMap = {
 				["harvester_minion_resummon_speed_+%_final"] = {
-					mod("MinionRevivalTime", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
-					mult = -1,
+					mod("MinionRevivalSpeed", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1068,8 +1068,7 @@ statMap = {
 #flags minion
 statMap = {
 	["harvester_minion_resummon_speed_+%_final"] = {
-		mod("MinionRevivalTime", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
-		mult = -1,
+		mod("MinionRevivalSpeed", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 	},
 },
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1336,16 +1336,16 @@ function calcs.offence(env, actor, activeSkill)
 			}
 		end
 	end
-	if activeSkill.skillTypes[SkillType.CreatesSkeletonMinion] then
-		local minionRevivalTimeMod = calcLib.mod(skillModList, skillCfg, "MinionRevivalTime")
+	if skillModList:Flag(skillCfg, "RevivingMinion") then
+		local MinionRevivalSpeedMod = calcLib.mod(skillModList, skillCfg, "MinionRevivalSpeed")
 		local baseMinionRevivalTime = data.misc.MinionRevivalTimeBase
-		output.MinionRevivalTime = baseMinionRevivalTime * minionRevivalTimeMod
+		output.MinionRevivalSpeed = baseMinionRevivalTime * (1 / MinionRevivalSpeedMod)
 		if breakdown then
-			breakdown.MinionRevivalTime = {
+			breakdown.MinionRevivalSpeed = {
 				s_format("%.3fs ^8(Base Revival Time)", baseMinionRevivalTime),
-				s_format("x %.2f ^8(effect modifiers)", minionRevivalTimeMod),
+				s_format("x 1 / %.2f ^8(effect modifiers)", MinionRevivalSpeedMod),
 				s_format("\n"),
-				s_format("= %.3fs ^8(Total Revival Time)", output.MinionRevivalTime),
+				s_format("= %.3fs ^8(Total Revival Time)", output.MinionRevivalSpeed),
 			}
 		end
 	end

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -641,7 +641,7 @@ return {
 	{ label = "Armour Break / hit", haveOutput = "ArmourBreakPerHit", { format = "{0:output:ArmourBreakPerHit}", { modName = "ArmourBreakPerHit", modType = "BASE"} }, },
 	{ label = "Soul Cost", color = colorCodes.RAGE, haveOutput = "SoulHasCost", { format = "{0:output:SoulCost}", { breakdown = "SoulCost" }, { modName = { "SoulCost" }, cfg = "skill" }, }, },
 	{ label = "Active Minion Limit", haveOutput = "ActiveMinionLimit", { format = "{0:output:ActiveMinionLimit}" } },
-	{ label = "Minion Revival Time", haveOutput = "MinionRevivalTime", { format = "{2:output:MinionRevivalTime}", { breakdown = "MinionRevivalTime" }, { modName = { "MinionRevivalTime" } } },},
+	{ label = "Minion Revival Time", haveOutput = "MinionRevivalSpeed", { format = "{2:output:MinionRevivalSpeed}s", { breakdown = "MinionRevivalSpeed" }, { modName = { "MinionRevivalSpeed" } } },},
 	{ label = "Quantity Multiplier", haveOutput = "QuantityMultiplier", { format = "{0:output:QuantityMultiplier}",
 	    { breakdown = "QuantityMultiplier" },
 	    { modName = { "QuantityMultiplier" }, cfg = "skill" },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4366,7 +4366,7 @@ local specialModList = {
 	["totems gain %+(%d+)%% to (%w+) resistance"] = function(num, _, resistance) return { mod("Totem"..firstToUpper(resistance).."Resist", "BASE", num) } end,
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
 	-- Minions
-	["minions revive (%d+)%% faster"] = function(num) return { mod("MinionRevivalTime", "INC", -num) } end,
+	["minions revive (%d+)%% faster"] = function(num) return { mod("MinionRevivalSpeed", "INC", num) } end,
 	["your strength is added to your minions"] = { flag("StrengthAddedToMinions") },
 	["your dexterity is added to your minions"] = { flag("DexterityAddedToMinions") },
 	["companions gain your dexterity"] = { flag("DexterityAddedToCompanions") },


### PR DESCRIPTION
We were previously handling the revive time mods as time mods instead of speed mods so stacking 100% revive faster would make the revival time 0 instead of half as long
Also fixes an issue where we were not showing the revival times for
Spectres, Companions, Rhoa Mount, Infernal Hound and Manifest Weapon
Fixes #1468 

Build: https://pobb.in/j2ln1AORvOB3

Before:
<img width="752" height="288" alt="image" src="https://github.com/user-attachments/assets/9efc750b-db46-4339-b1cf-7905e63fe086" />

After:
<img width="766" height="283" alt="image" src="https://github.com/user-attachments/assets/c72661c3-e28a-420a-8fac-1942164c6747" />
