### PR TITLE
Fix Magnified Area II less Area damage mod not working

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -3828,7 +3828,7 @@ skills["SupportMagnifiedAreaPlayerTwo"] = {
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
-				["support_area_concentrate_area_damage_+%_final"] = {
+				["support_increased_area_damage_+%_final"] = {
 					mod("Damage", "MORE", nil, ModFlag.Area),
 				},
 			},

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -850,7 +850,7 @@ statMap = {
 #skill SupportMagnifiedAreaPlayerTwo
 #set SupportMagnifiedAreaPlayerTwo
 statMap = {
-	["support_area_concentrate_area_damage_+%_final"] = {
+	["support_increased_area_damage_+%_final"] = {
 		mod("Damage", "MORE", nil, ModFlag.Area),
 	},
 },


### PR DESCRIPTION
They updated the stat name for the less area damage mod at some point so it stopped working
