### PR TITLE
Update Enemy Config Level and Tooltip

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1871,7 +1871,7 @@ Huge sets the radius to 11.
 	end },
 	-- Section: Enemy Stats
 	{ section = "Enemy Stats", col = 2 },
-	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit and ^x33FF77evade ^7chance.\n\nThe default level for normal enemies and standard bosses is 83.\nTheir default level is capped by your character level.\n\nThe default level for pinnacle bosses is 84, and the default level for uber pinnacle bosses is 85.\nTheir default level is not capped by your character level." },
+	{ var = "enemyLevel", type = "count", label = "Enemy Level:", tooltip = "This overrides the default enemy level used to estimate your hit, ^x33FF77evade ^7chance, and damage reduction.\n\nThe maximum level for normal enemies and all bosses is 85.\n\nThe default level of normal enemies and bosses scales with player level unless manually set.\n\nThe default and minimum level for pinnacle bosses and uber pinnacle bosses is 82." },
 	{ var = "conditionEnemyRareOrUnique", type = "check", label = "Is the enemy Rare or Unique?", ifEnemyCond = "EnemyRareOrUnique", tooltip = "The enemy will automatically be considered to be Unique if they are a Boss,\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:RareOrUnique", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
@@ -1887,8 +1887,8 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(defaultResist, true)
 
-			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			local defaultLevel = 82
+			build.configTab.varControls['enemyLevel']:SetPlaceholder(build.characterLevel, true)
 			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = build.configTab.enemyLevel
@@ -1896,10 +1896,10 @@ Huge sets the radius to 11.
 
 			local defaultDamage = round(data.monsterDamageTable[defaultLevel] * 1.5)
 			build.configTab.varControls['enemyPhysicalDamage']:SetPlaceholder(defaultDamage, true)
-			build.configTab.varControls['enemyLightningDamage']:SetPlaceholder("", true)
-			build.configTab.varControls['enemyColdDamage']:SetPlaceholder("", true)
-			build.configTab.varControls['enemyFireDamage']:SetPlaceholder("", true)
-			build.configTab.varControls['enemyChaosDamage']:SetPlaceholder("", true)
+			build.configTab.varControls['enemyLightningDamage']:SetPlaceholder(defaultDamage, true)
+			build.configTab.varControls['enemyColdDamage']:SetPlaceholder(defaultDamage, true)
+			build.configTab.varControls['enemyFireDamage']:SetPlaceholder(defaultDamage, true)
+			build.configTab.varControls['enemyChaosDamage']:SetPlaceholder(round(defaultDamage / 2.5), true)
 
 			local defaultPen = ""
 			build.configTab.varControls['enemyPhysicalOverwhelm']:SetPlaceholder(defaultPen, true)
@@ -1926,8 +1926,8 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(0, true)
 
-			local defaultLevel = 83
-			build.configTab.varControls['enemyLevel']:SetPlaceholder("", true)
+			local defaultLevel = 82
+			build.configTab.varControls['enemyLevel']:SetPlaceholder(build.characterLevel, true)
 			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then
 				defaultLevel = build.configTab.enemyLevel
@@ -2005,7 +2005,7 @@ Huge sets the radius to 11.
 			build.configTab.varControls['enemyFireResist']:SetPlaceholder(defaultEleResist, true)
 			build.configTab.varControls['enemyChaosResist']:SetPlaceholder(0, true)
 
-			local defaultLevel = 85
+			local defaultLevel = 82
 			build.configTab.varControls['enemyLevel']:SetPlaceholder(defaultLevel, true)
 			build.configTab:UpdateLevel()
 			if build.configTab.enemyLevel then


### PR DESCRIPTION
### Description of the problem being solved:
- "None" and "Standard Boss" default config level is now scaled with player level.
- Uber and Pinnacle boss level are 82 by default and at minimum, but can increase to 85.
- "None" now deals damage of all types, as pure physical gave really low EHP and most mobs do some form of elemental damage.
- Updated tooltip.

When ubers are released, we can update default levels again.

### After screenshot:
<img width="260" height="263" alt="image" src="https://github.com/user-attachments/assets/69f483f0-a661-4e15-b749-1627dc229950" />
