### PR TITLE
Sort Gem list Alphabetically by default

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -333,7 +333,9 @@ function GemSelectClass:SortGemList(gemList)
 			if self.skillsTab.sortGemsByDPS and sortCache.dps[a] ~= sortCache.dps[b] then
 				return sortCache.dps[a] > sortCache.dps[b]
 			else
-				return a < b
+				local nameA = (self.gems[a] and self.gems[a].name) or a
+				local nameB = (self.gems[b] and self.gems[b].name) or b
+				return nameA < nameB
 			end
 		else
 			return sortCache.canSupport[a]


### PR DESCRIPTION
### Description of the problem being solved:
Gems were sorting by Id instead of name.

### Before screenshot:
<img width="344" height="272" alt="image" src="https://github.com/user-attachments/assets/9b603031-83b4-4ba3-a4d1-e37223d4f5aa" />

### After screenshot:
<img width="524" height="309" alt="image" src="https://github.com/user-attachments/assets/776f91e3-ac61-46c3-9ed8-849ae423acc5" />