### PR TITLE
Adding a test that may have issues passing on luajit 2.1 due to pairs() ordering

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -59,6 +59,22 @@ describe("TestSkills", function()
 		assert.are.equals(6, stackedCost) -- 9/(1 + 0.25 + 0.25) = 9/1.5 = 6
 	end)
 
+	it("Test Atalui Bloodletting damage with life cost", function()
+		-- Mana cost 96 * 1.5 = 144, max lightning damage 70
+		build.skillsTab:PasteSocketGroup("Ball Lightning 20/0  1\nAtalui's Bloodletting 1/0  1")
+
+		build.configTab.input.customMods = "Blood Magic"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local lifeCost = build.calcsTab.mainOutput.LifeCost
+		local damage = build.calcsTab.mainOutput.PhysicalSummedMaxBase
+		-- 14.4% * 2 gain as physical = 70 * .288 = 20.16
+		assert.are.equals(144, lifeCost)
+		assert.are.equals(20, damage)
+		assert.are.equals(20, build.calcsTab.mainOutput.PhysicalStoredHitMax)
+	end)
+
 	it("Test cost efficiency with cost modifiers", function()
 		-- Test interaction between cost efficiency and cost multipliers
 		build.skillsTab:PasteSocketGroup("Ball Lightning 1/0  1\n")


### PR DESCRIPTION
### Description of the problem being solved:
This issue came up on a build on poe.ninja because of the version of luajit they were running.  This test ensures when we upgrade to luajit 2.1 it doesn't end up breaking this or other builds.
