### PR TITLE
Fix Kalandra's Touch working in Ring slot 3

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1172,7 +1172,7 @@ function calcs.perform(env, skipEHP)
 			if item.name:match("Kalandra's Touch") then
 				if slot == "Ring 2" then
 					item = env.player.itemList["Ring 1"]
-				else
+				elseif slot == "Ring 1" then
 					item = env.player.itemList["Ring 2"]
 				end
 			end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1139,7 +1139,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					else
 						env.itemModDB.multipliers["NonCorruptedItem"] = (env.itemModDB.multipliers["NonCorruptedItem"] or 0) + 1
 					end
-					local otherRing = items[(slotName == "Ring 1" and "Ring 2") or (slotName == "Ring 2" and "Ring 1") or (slotName == "Ring 3" and "Ring 2")]
+					local otherRing = items[(slotName == "Ring 1" and "Ring 2") or (slotName == "Ring 2" and "Ring 1")]
 					if otherRing and not otherRing.name:match("Kalandra's Touch") then
 						for _, mod in ipairs(otherRing.modList or otherRing.slotModList[slot.slotNum] or {}) do
 							-- Filter out SocketedIn type mods


### PR DESCRIPTION
Was watching Empy's video and noticed we never fixed Kalandra's Touch to stop working when equipped in Ritualist's extra ring slot: https://youtu.be/1mzSblm0hZY?t=238

This comment from Viperesque in the PoB discord was in the context of Ingenuity, and I think we thought they meant Ingenuity doesn't interact with the third slot (also true), but it appears they also meant Kalandra's Touch too:
<img width="640" height="103" alt="image" src="https://github.com/user-attachments/assets/750261b5-9394-4b36-b1f5-14c1eb994a7b" />
