### PR TITLE
Fix crash when pasting item from Trade site

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1812,7 +1812,7 @@ function ItemClass:BuildModList()
 
 	for _, entry in ipairs(minimumReqLevel) do
 		if entry.name == self.title then
-			minReqLevel = entry.level
+			minReqLevel = tonumber(entry.level)
 			break
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:
Small fix, when copying the text for an item from trade site, the level reqs would break. Ooooopsie.
<img width="791" height="399" alt="image" src="https://github.com/user-attachments/assets/36921b6f-af64-4022-b0f8-c07ebd04b598" />
