### PR TITLE
Fix skill gems not showing requirements in breakdown if selected without searching

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1081,7 +1081,6 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 			gemInstance.gemData = nil
 		end
 		if gemInstance.gemData or gemInstance.grantedEffect then
-			gemInstance.new = nil
 			local grantedEffect = gemInstance.grantedEffect or gemInstance.gemData.grantedEffect
 			if grantedEffect.color == 1 then
 				gemInstance.color = colorCodes.STRENGTH
@@ -1095,6 +1094,10 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 			if prevDefaultLevel and gemInstance.gemData and gemInstance.gemData.naturalMaxLevel ~= prevDefaultLevel then
 				gemInstance.level = gemInstance.gemData.naturalMaxLevel
 				gemInstance.naturalMaxLevel = gemInstance.level
+			elseif gemInstance.new then
+				gemInstance.level = gemInstance.gemData.naturalMaxLevel
+				gemInstance.naturalMaxLevel = gemInstance.level
+				gemInstance.new = nil
 			end
 			calcLib.validateGemLevel(gemInstance)
 			if gemInstance.gemData then


### PR DESCRIPTION
### Description of the problem being solved:
When adding a new skill, if the user clicks a skill gem without searching or using arrow keys, the requirements would not show in the breakdown. They would show once a support is added, or the gem level changed, but it was still an "issue". This just checks if the gem instance is new, and if so, sets the level, which is required to get the reqs.

EDIT: The issue does not appear in PoB1, so while this does fix it easily and cleanly imo, I'm not certain where the actual difference in code is that made this an issue. We handle gems differently between the two so could be anywhere.