### PR TITLE
Add parsing for Molten One's Gift notable

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4485,7 +4485,7 @@ c["Fork an additional time Chain an additional time Chain from Terrain an additi
 c["Fork an additional time Chain an additional time Chain from Terrain an additional time Cannot collide with targets"]={nil,"Fork an additional time Chain an additional time Chain from Terrain an additional time Cannot collide with targets "}
 c["Frenzy or Power Charge"]={nil,"Frenzy or Power Charge "}
 c["Fully Armour Broken enemies you kill with Hits Shatter"]={nil,"Fully Armour Broken enemies you kill with Hits Shatter "}
-c["Fully Broken Armour effects also apply to Fire Damage Taken from Hits"]={{[1]={flags = 0,keywordFlags = 0,name = "ArmourBreakeFireDamageTaken",type = "FLAG",value = true,}},nil}
+c["Fully Broken Armour effects also apply to Fire Damage Taken from Hits"]={{[1]={flags = 0,keywordFlags = 0,name = "ArmourBreakFireDamageTaken",type = "FLAG",value = true,}},nil}
 c["Gain 0% to 40% increased Movement Speed at random when Hit, until Hit again"]={{[1]={flags=0,keywordFlags=0,name="Condition:HaveGamblesprint",type="FLAG",value=true}},nil}
 c["Gain 1 Endurance Charge every second if you've been Hit Recently"]={{}," Endurance Charge every second  "}
 c["Gain 1 Fragile Regrowth each second"]={{}," Fragile Regrowth each second "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -585,7 +585,7 @@ local function doActorMisc(env, actor)
 		if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
 			local effect = 20 * (1 + modDB:Sum("INC", nil, "FullyBrokenArmourEffect") / 100)
 			enemyDB:NewMod("PhysicalDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
-			if modDB:Flag(nil, "ArmourBreakeFireDamageTaken") then
+			if modDB:Flag(nil, "ArmourBreakFireDamageTaken") then
 				enemyDB:NewMod("FireDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
 			end
 		end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5246,7 +5246,7 @@ local specialModList = {
 	["(%d+)%% increased effect of jewel socket passive skills containing corrupted magic jewels, if not from cluster jewels"] = function(num) return { mod("JewelData", "LIST", { key = "corruptedMagicJewelIncEffect", value = num }) } end,
 	["(%d+)%% increased effect of jewel socket passive skills containing corrupted magic jewels"] = function(num) return { mod("JewelData", "LIST", { key = "corruptedMagicJewelIncEffect", value = num }) } end,
 	-- Misc
-	["fully broken armour effects also apply to fire damage taken from hits"] = { flag("ArmourBreakeFireDamageTaken"), },
+	["fully broken armour effects also apply to fire damage taken from hits"] = { flag("ArmourBreakFireDamageTaken"), },
 	["can't use chest armour"] = { mod("CanNotUseBody", "Flag", 1, { type = "DisablesItem", slotName = "Body Armour" }) },
 	--["can't use helmets"] = { mod("CanNotUseHelmet", "Flag", 1, { type = "DisablesItem", slotName = "Helmet" }) }, -- this one does not work due to being on a passive?
 	["can't use helmet"] = { mod("CanNotUseHelmet", "Flag", 1, { type = "DisablesItem", slotName = "Helmet" }) }, -- this is to allow for custom mod without saying the other is parsed


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Added parsing for Molten One's Gift Notable fully broken armour effect for fire hits
### Steps taken to verify a working solution:
- Cause the mod to parse.
- Check "Is Enemy Armour Broken" on configuration
- Assert that fire damage has the same "fully broken amour" effect as phys damage on calc

### Link to a build that showcases this PR:
[My Current Build](https://maxroll.gg/poe2/pob/ts11t90c)
### Before screenshot:
red text
### After screenshot:
<img width="1680" height="791" alt="image" src="https://github.com/user-attachments/assets/d36d941d-0718-44bf-8976-717168671aa1" />
<img width="934" height="696" alt="image" src="https://github.com/user-attachments/assets/06d4e378-b4a4-4c1c-af38-2c08a503d80d" />

