### PR TITLE
Memoize MatchKeywordFlags function

### DIFF
--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -292,17 +292,44 @@ KeywordFlag.MatchAll =	0x40000000
 local band = AND64
 local bnot = NOT64
 local MatchAllMask = bnot(KeywordFlag.MatchAll)
+
+-- Two-level numeric-key cache to avoid building string keys or allocating tables per call.
+local matchKeywordFlagsCache = {}
+function ClearMatchKeywordFlagsCache()
+	-- cheap full reset without reallocating the outer table
+	for k in pairs(matchKeywordFlagsCache) do
+		matchKeywordFlagsCache[k] = nil
+	end
+end
+
 ---@param keywordFlags number The KeywordFlags to be compared to.
 ---@param modKeywordFlags number The KeywordFlags stored in the mod.
 ---@return boolean Whether the KeywordFlags in the mod are satisfied.
 function MatchKeywordFlags(keywordFlags, modKeywordFlags)
-	local matchAll = band(modKeywordFlags, KeywordFlag.MatchAll) ~= 0
-	modKeywordFlags = band(modKeywordFlags, MatchAllMask)
-	keywordFlags = band(keywordFlags, MatchAllMask)
-	if matchAll then
-		return band(keywordFlags, modKeywordFlags) == modKeywordFlags
+	-- Cache lookup
+	local row = matchKeywordFlagsCache[keywordFlags]
+	if row then
+		local cached = row[modKeywordFlags]
+		if cached ~= nil then
+			return cached
+		end
+	else
+		row = {}
+		matchKeywordFlagsCache[keywordFlags] = row
 	end
-	return modKeywordFlags == 0 or band(keywordFlags, modKeywordFlags) ~= 0
+	-- Not in cache, compute normally
+	local matchAll = band(modKeywordFlags, KeywordFlag.MatchAll) ~= 0
+	local modMasked = band(modKeywordFlags, MatchAllMask)
+	local keywordMasked = band(keywordFlags, MatchAllMask)
+
+	local matches
+	if matchAll then
+		matches = band(keywordMasked, modMasked) == modMasked
+	else
+		matches = (modMasked == 0) or (band(keywordMasked, modMasked) ~= 0)
+	end
+	row[modKeywordFlags] = matches -- Add to cache
+	return matches
 end
 
 -- Active skill types, used in ActiveSkills.dat and GrantedEffects.dat

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -481,6 +481,7 @@ end
 -- 5. Builds a list of active skills and their supports (calcs.createActiveSkill)
 -- 6. Builds modifier lists for all active skills (calcs.buildActiveSkillModList)
 function calcs.initEnv(build, mode, override, specEnv)
+	ClearMatchKeywordFlagsCache()
 	-- accelerator variables
 	local cachedPlayerDB = specEnv and specEnv.cachedPlayerDB or nil
 	local cachedEnemyDB = specEnv and specEnv.cachedEnemyDB or nil


### PR DESCRIPTION
MatchKeywordFlags is currently called on every Sum, More, Flag, Override, List and Tabulate call so ends up being called hundreds of thousands of times when running the gem DPS sort and also a lot when running the tree node sort

At the start of each initEnv we have a fresh cache and store each unique Keyword flag match so it can quickly be used in a lookup instead of computed over and over again saving a ton of band calls

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/xl17ge0c

### Before screenshot:
<img width="189" height="33" alt="image" src="https://github.com/user-attachments/assets/c05f1f54-9237-4fad-9d8b-4e63cfaedbed" />
<img width="190" height="13" alt="image" src="https://github.com/user-attachments/assets/68719b67-9c7d-469f-8b6c-ef911078962a" />


### After screenshot:
<img width="193" height="26" alt="image" src="https://github.com/user-attachments/assets/24ca05b6-56ed-419f-bf8e-9e36b08e53c2" />
<img width="188" height="12" alt="image" src="https://github.com/user-attachments/assets/c2679676-aa86-44f9-98f8-3775f7f70dcd" />

Used with #1504 
<img width="193" height="27" alt="image" src="https://github.com/user-attachments/assets/ddabbbf8-2363-4dfb-8fd0-1c09fa0563f8" />

Compared to dev
~250ms improvement on Fresh load
~130ms improvement after JIT cache is warm

Compared to #1504 
~190ms further improvement on Fresh load
~100ms further improvement after JIT cache is warm
