### PR TITLE
JIT 2.1 Fixes

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -2085,6 +2085,7 @@ function PassiveSpecClass:SwitchAttributeNode(nodeId, attributeIndex)
 		
 		local option = newNode.options[attributeIndex]
 		self:ReplaceNode(newNode, option)
+		self.tree:ProcessStats(newNode)
 		
 		self.hashOverrides[nodeId] = newNode
 	end

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -14,6 +14,8 @@ ConExecute("set vid_resizable 3")
 
 launch = { }
 SetMainObject(launch)
+jit.opt.start('maxtrace=4000','maxmcode=8192')
+collectgarbage("setpause", 400)
 
 function launch:OnInit()
 	self.devMode = false


### PR DESCRIPTION
Launch options are required so JIT 2.1 runs at the same sped as the previous JIT version we were using
The change in PassiveSpec is required cause we are now not reliably processing the changed stats on the changed attribute nodes due to the way JIT 2.1 handles pairs
