### PR TITLE
Force updater to only update runtime files if there is only 1 PoB instance

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -152,9 +152,6 @@ function ConPrintTable(tbl, noRecurse) end
 function ConExecute(cmd) end
 function ConClear() end
 function SpawnProcess(cmdName, args) end
-function GetProcessCount(names)
-	return 1
-end
 function OpenURL(url) end
 function SetProfiling(isEnabled) end
 function Restart() end

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -19,8 +19,7 @@ local updateProcessCandidates = {
 -- Returns the total number of running processes that match any known PoB executable names.
 local function getMatchingProcessCount()
 	if not isWindows then
-		-- Non-Windows platforms rely on manual confirmation instead of auto-detection.
-		return 1
+		return nil, "Process detection only supported on Windows"
 	end
 
 	if not GetProcessCount then
@@ -358,9 +357,6 @@ function launch:ApplyUpdate(mode)
 		if not self:EnsureUpdateExclusiveAccess() then
 			return
 		end
-		if not isWindows then
-			self.runtimeUpdateManualConfirmPromptShown = nil
-		end
 		-- Need to revert to the basic environment to fully apply the update
 		LoadModule("UpdateApply", "Update/opFile.txt")
 		SpawnProcess(GetRuntimePath()..'/Update', 'UpdateApply.lua Update/opFileRuntime.txt')
@@ -386,16 +382,6 @@ function launch:GetAdditionalInstanceCount()
 end
 
 function launch:EnsureUpdateExclusiveAccess()
-	if not isWindows then
-		-- On Unix-like platforms the updater cannot reliably detect sibling processes, so require manual confirmation.
-		if not self.runtimeUpdateManualConfirmPromptShown then
-			self.runtimeUpdateManualConfirmPromptShown = true
-			local prompt = "^3Linux/Unix confirmation required:^0\n\nClose every other Path of Building window before updating core runtime files.\nOnce all other instances are closed, press Update again to continue.\n\nPress Enter or Escape to dismiss this message."
-			self:ShowPrompt(1, 0.5, 0, prompt)
-			return false
-		end
-		return true
-	end
 	-- Block runtime updates until all other PoB processes exit to avoid DLL write failures.
 	local otherCount, err = self:GetAdditionalInstanceCount()
 	if otherCount == nil then


### PR DESCRIPTION
### Description of the problem being solved:
When PoB updates its runtime files it will fail to update if you have more than 1 instance of PoB open. This PR adds a check for if you have more than 1 instance open and will not let you update until you've closed them
### Steps taken to verify a working solution:
- Test on Wine (Paliak)
- Test on Windows beta branch

### After screenshot:
<img width="775" height="223" alt="image" src="https://github.com/user-attachments/assets/27fcc5f0-17a2-4832-9dfb-4f83e901d572" />
