### PR TITLE
Add nil file error message (ty OneDrive)

### DIFF
--- a/runtime/lua/xml.lua
+++ b/runtime/lua/xml.lua
@@ -101,6 +101,11 @@ function xml.LoadXMLFile(fileName)
 	end
 	local fileText = fileHnd:read("*a")
 	fileHnd:close()
+	if not fileText then
+		return nil, fileName.." file returns nil.  OneDrive?"
+	elseif fileText == "" then
+		return nil, fileName.." file is empty"
+	end
 	return xml.ParseXML(fileText)
 end
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -506,6 +506,11 @@ end
 
 function main:LoadSettings(ignoreBuild)
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
+	if errMsg and not errMsg:match(".*No such file or directory") then
+		ConPrintf("Error: '%s'", errMsg)
+		launch:ShowErrMsg("^1"..errMsg)
+		return true
+	end
 	if not setXML then
 		return true
 	elseif setXML[1].elem ~= "PathOfBuilding2" then
@@ -640,6 +645,11 @@ end
 
 function main:LoadSharedItems()
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
+	if errMsg and not errMsg:match(".*No such file or directory") then
+		ConPrintf("Error: '%s'", errMsg)
+		launch:ShowErrMsg("^1"..errMsg)
+		return true
+	end
 	if not setXML then
 		return true
 	elseif setXML[1].elem ~= "PathOfBuilding2" then


### PR DESCRIPTION
Improve reporting of errors caused by **OneDrive** moving `settings.xml` to the cloud.

Was a PITA to reproduce the error. If anyone can easily and reliably reproduce it let me know on Discord please!
  
<img width="521" height="145" alt="image" src="https://github.com/user-attachments/assets/bd8b1cef-06f4-4436-bae2-7c6bb9070270" />  

 &nbsp;   
Also throws an error if the file is empty.  
<img width="521" height="146" alt="image" src="https://github.com/user-attachments/assets/54a6489e-1b1a-4afa-8207-cb22e0b3fd95" />
