### PR TITLE
Remove CMD flash on updating runtime files

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -152,6 +152,9 @@ function ConPrintTable(tbl, noRecurse) end
 function ConExecute(cmd) end
 function ConClear() end
 function SpawnProcess(cmdName, args) end
+function SpawnProcessHidden(cmdName, args)
+	return SpawnProcess(cmdName, args)
+end
 function OpenURL(url) end
 function SetProfiling(isEnabled) end
 function Restart() end

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -312,11 +312,22 @@ function launch:DownloadPage(url, callback, params)
 	end
 end
 
+function launch:StartRuntimeUpdateProcess()
+	local runtimePath = GetRuntimePath()
+	local args = "UpdateApply.lua Update/opFileRuntime.txt"
+	if isWindows and SpawnProcessHidden then
+		SpawnProcessHidden(runtimePath.."/Update", args)
+	else
+		SpawnProcess(runtimePath.."/Update", args)
+	end
+	return true
+end
+
 function launch:ApplyUpdate(mode)
 	if mode == "basic" then
 		-- Need to revert to the basic environment to fully apply the update
 		LoadModule("UpdateApply", "Update/opFile.txt")
-		SpawnProcess(GetRuntimePath()..'/Update', 'UpdateApply.lua Update/opFileRuntime.txt')
+		self:StartRuntimeUpdateProcess()
 		Exit()
 	elseif mode == "normal" then
 		-- Update can be applied while normal environment is running


### PR DESCRIPTION
When we update runtime files, SpawnProcess flashes a cmd windows quickly on the users screen before disappearing. This PR is reliant on https://github.com/PathOfBuildingCommunity/PathOfBuilding-SimpleGraphic/pull/89 to work

Sometimes the CMD window showing up is helpful though as it can show a error thats occurred when trying to update.