### PR TITLE
Fix incorrect max resist calculation when using Saffell's Frame unique

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -897,7 +897,7 @@ function calcs.defence(env, actor)
 		output[elem.."ResistTotal"] = total
 		if modDB:Flag(nil, "MaxBlockChanceModsApplyMaxResist") then
 			local blockMaxBonus = modDB:Override(nil, "BlockChanceMax") and 0 or modDB:Sum("BASE", nil, "BlockChanceMax")
-			max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax") + blockMaxBonus )
+			max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax") + blockMaxBonus)
 		else
 			max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
 		end		


### PR DESCRIPTION
Fixes #1505

### Description of the problem being solved:
It was adding the max block to the already calculate max res without taking into acound the max res cap. I just added it inside the m_min, so it can't never go over ResistMax

### Steps taken to verify a working solution:
Imported the same build that had the problem and verify that the max res can't go over 90

### Link to a build that showcases this PR:
Before: https://pobb.in/7VIVf1JBz-d5
After: https://pobb.in/HF0qCGlUL9ry

### Before screenshot:
<img width="697" height="802" alt="imagen" src="https://github.com/user-attachments/assets/7820cb3d-2890-4c23-b480-7b5ccd8f9d76" />

### After screenshot:
<img width="700" height="805" alt="imagen" src="https://github.com/user-attachments/assets/fd382d02-cfb3-4d16-a96d-9dd63d799495" />
