### PR TITLE
Fix Splinter of Lorrata missing "Deal no Elemental Damage" mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@
 - Add support for "Cannot Use - Skills" modifiers [\#1051](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1051) ([Blitz54](https://github.com/Blitz54))
 - Add support for Essentia Sanguis leech mod [\#1102](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1102) ([Blitz54](https://github.com/Blitz54))
 - Add support for Leopold's Applause [\#1136](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1136) ([LocalIdentity](https://github.com/LocalIdentity))
-- Add support for Splinter of Loratta (Unique Spear) [\#1054](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1054) ([majochem](https://github.com/majochem))
+- Add support for Splinter of Lorrata (Unique Spear) [\#1054](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1054) ([majochem](https://github.com/majochem))
 ### Fixed Crashes
 - Fix crash due to outdated state of sub skill dropdown [\#1116](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1116) ([Paliak](https://github.com/Paliak))
 - Fix crash when deleting newly created config set [\#1115](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1115), [\#1120](https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/pull/1120) ([Paliak](https://github.com/Paliak))

--- a/changelog.txt
+++ b/changelog.txt
@@ -240,7 +240,7 @@ VERSION[0.9.0][2025/08/23]
 * Add support for "Cannot Use - Skills" modifiers (Blitz54)
 * Add support for Essentia Sanguis leech mod (Blitz54)
 * Add support for Leopold's Applause (LocalIdentity)
-* Add support for Splinter of Loratta (Unique Spear) (majochem)
+* Add support for Splinter of Lorrata (Unique Spear) (majochem)
 
 --- Fixed Crashes ---
 * Fix crash due to outdated state of sub skill dropdown (Paliak)

--- a/src/Data/Uniques/spear.lua
+++ b/src/Data/Uniques/spear.lua
@@ -38,12 +38,15 @@ Adds (33-41) to (47-53) Fire Damage
 Aggravating any Bleeding with this Weapon also Aggravates all Ignites on the target
 (25-40)% chance to Aggravate Bleeding on Hit
 ]],[[
-Splinter of Loratta
+Splinter of Lorrata
 Hardwood Spear
 League: Dawn of the Hunt
+Variant: Pre 0.3.0
+Variant: Current
 Implicits: 1
 Grants Skill: Spear Throw
 Adds (2-3) to (6-8) Physical Damage
+{variant:2}Deal no Elemental Damage
 20% increased Melee Strike Range with this weapon
 Any number of Poisons from this Weapon can affect a target at the same time
 Always Poison on Hit with this weapon

--- a/src/Export/Uniques/spear.lua
+++ b/src/Export/Uniques/spear.lua
@@ -38,12 +38,15 @@ UniqueLocalChanceToBleed2
 UniqueAggravateIgnites1
 UniqueLocalChanceToAggravateBleed1
 ]],[[
-Splinter of Loratta
+Splinter of Lorrata
 Hardwood Spear
 League: Dawn of the Hunt
+Variant: Pre 0.3.0
+Variant: Current
 Implicits: 1
 Grants Skill: Spear Throw
 UniqueLocalAddedPhysicalDamage3
+{variant:2}DealNoElementalDamageUnique__3
 UniqueLocalWeaponRangeIncrease1
 UniqueLocalInfinitePoisonStackCount1
 UniqueLocalPoisonOnHit1

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3946,7 +3946,7 @@ local specialModList = {
 		mod("Damage", "INC", num, nil, 0, KeywordFlag.Poison, { type = "Condition", var = "SinglePoison" }, { type = "SkillName", skillNameList = { "Sunder", "Ground Slam" }, includeTransfigured = true })
 	} end,
 	["poisons on you expire (%d+)%% slower"] = function(num) return { mod("SelfPoisonDebuffExpirationRate", "BASE", -num) } end,
-	["any number of poisons from this weapon can affect a target at the same time"] = { -- Splinter of Loratta
+	["any number of poisons from this weapon can affect a target at the same time"] = { -- Splinter of Lorrata
 		flag("PoisonCanStack"),
 		mod("PoisonStacks", "OVERRIDE", math.huge , { type = "Condition", var = "{Hand}Attack" }, { type = "SkillType", skillType = SkillType.NonWeaponAttack, neg = true })
 	},


### PR DESCRIPTION
0.3.0 stealth added this mod to the item but only for new drops, prior ones from 0.2.0 do not have it
Also updated the spelling of `Lorrata` in a few places
 Fixes #1537