### PR TITLE
Fix occasional crash when hovering over breakdown while using Radius Jewels

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6517,25 +6517,31 @@ local jewelOtherFuncs = {
 			end
 		end
 	end,
-	["^(%w+) Passive Skills in Radius also grant (.*)$"] = function(type, mod)
+	["^(%w+) Passive Skills in Radius also grant (.*)$"] = function(passiveType, mod)
 		return function(node, out, data)
-			if node and (node.type == firstToUpper(type) or (node.type == "Normal" and not node.isAttribute and firstToUpper(type) == "Small")) then
+			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small")) then
 				local modList, line = parseMod(mod)
 				if not line and modList[1] then -- something failed to parse, do not add to list
 					modList[1].parsedLine = capitalizeWordsInString(mod)
 					modList[1].source = data.modSource
+					if type(modList[1].value) == "table" and modList[1].value.mod then
+						modList[1].value.mod.source = data.modSource
+					end
 					out:AddMod(modList[1])
 				end
 			end
 		end
 	end,
-	["conquered (%w+) Passive Skills also grant (.*)$"] = function(type, mod)
+	["conquered (%w+) Passive Skills also grant (.*)$"] = function(passiveType, mod)
 		return function(node, out, data)
-			if node and (node.type == firstToUpper(type) or (node.type == "Normal" and not node.isAttribute and firstToUpper(type) == "Small") or (node.type == "Normal" and node.isAttribute and firstToUpper(type) == "Attribute")) then
+			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small") or (node.type == "Normal" and node.isAttribute and firstToUpper(passiveType) == "Attribute")) then
 				local modList, line = parseMod(mod)
 				if not line and modList[1] then -- something failed to parse, do not add to list
 					modList[1].parsedLine = capitalizeWordsInString(mod)
 					modList[1].source = data.modSource
+					if type(modList[1].value) == "table" and modList[1].value.mod then
+						modList[1].value.mod.source = data.modSource
+					end
 					out:AddMod(modList[1])
 				end
 			end


### PR DESCRIPTION
Fixes #1497, #817 .

### Description of the problem being solved:
When parsing the mods of Time Lost jewels, some mods don't keep the source node, and when showing the breakdown it crashes because it can't find the source node.

This also should happen with other jewels that has the mod:
conquered (%w+) Passive Skills also grant (.*)$

This normally is handled fine on non jewel mods, but was missing on the radius mods.

This is how this mod looked like, where you can see that there is no source in `value.mod`:
<img width="467" height="403" alt="imagen" src="https://github.com/user-attachments/assets/ffd26291-b40e-4138-a11d-cb7dd3fe4e67" />


### Steps taken to verify a working solution:
For `^(%w+) Passive Skills in Radius also grant (.*)$` and `conquered (%w+) Passive Skills also grant (.*)$` mods, if `mod.value` is of type `table`, that means that it has a inner mod, so we add the source also there

### Link to a build that showcases this PR:
https://pobb.in/cJPcSu2F-T47

### Before screenshot:
<img width="1051" height="559" alt="imagen" src="https://github.com/user-attachments/assets/401f71e4-83ca-4b64-ab2f-1228a2eb9e17" />

### After screenshot:
<img width="843" height="438" alt="imagen" src="https://github.com/user-attachments/assets/fc4d24ae-a1c7-4cb9-b3ae-f5baff6cba2a" />

<img width="1030" height="908" alt="imagen" src="https://github.com/user-attachments/assets/c46bd45f-edbc-4fda-a815-10909b3bcc15" />

