### PR TITLE
Added needed accuracy

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2451,6 +2451,7 @@ function calcs.offence(env, actor, activeSkill)
 			local exceedsHitChance = skillModList:Flag(nil,"Condition:HitChanceCanExceed100") and calcs.hitChance(enemyEvasion, (m_floor(accuracyVsEnemyBase * accuracyPenalties["accuracyPenalty" .. distances[1] .. "m"])) * hitChanceMod) -- Check for flag and at least 100% hit chance at minimum distance
 			output.AccuracyHitChanceUncapped = exceedsHitChance and m_max(calcs.hitChance(enemyEvasion, accuracyVsEnemy, true) * calcLib.mod(skillModList, cfg, "HitChance"), output.AccuracyHitChance) -- keep higher chance in case of "CannotBeEvaded"
 			local handCondition = (pass.label == "Off Hand") and "OffHandAttack" or "MainHandAttack"
+			output.AccuracyNeeded = m_floor(enemyEvasion * 1.2 / accuracyPenalty - output.Accuracy)
 			if exceedsHitChance and output.AccuracyHitChanceUncapped - 100 > 0 then
 				skillModList:NewMod("Multiplier:ExcessHitChance", "BASE", round(output.AccuracyHitChanceUncapped - 100, 2), "HitChanceCanExceed100", { type = "Condition", var = handCondition})
 			end
@@ -2494,6 +2495,7 @@ function calcs.offence(env, actor, activeSkill)
 				end
 			end
 		end
+
 		--enemy block chance
 		output.enemyBlockChance = m_max(m_min((enemyDB:Sum("BASE", cfg, "BlockChance") or 0), 100) - skillModList:Sum("BASE", cfg, "reduceEnemyBlock"), 0)
 		if enemyDB:Flag(nil, "CannotBlockAttacks") and isAttack then

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -885,6 +885,10 @@ return {
 		{ label = "Enemy Evasion modifiers", modName = { "Evasion", "CannotEvade" }, enemy = true },
 		{ label = "Player modifiers", modName = { "HitChance", "CannotBeEvaded", "IgnoreBlindHitChance" } },
 	}, },
+
+	{ label = "Accuracy needed", bgCol = colorCodes.MAINHANDBG, flag = "weapon1Attack", { format = "{0:output:MainHand.AccuracyNeeded}",
+	}, },
+
 	{ label = "MH Chance to Hit", haveOutput = "MainHand.enemyBlockChance", bgCol = colorCodes.MAINHANDBG, flag = "weapon1Attack", { format = "{0:output:MainHand.HitChance}%",
 		{ breakdown = "MainHand.HitChance" }, 
 		{ label = "Enemy Evasion modifiers", modName = { "Evasion", "CannotEvade" }, enemy = true },


### PR DESCRIPTION
Added the needed accuracy to the calculation tab. It isnt netirely correct but i couldnt figure out why that is. Also having too much shows negative numbers. We could set it to 0 in those cases but i think it can be used to see how many accuracy can be shaved off for min-maxing. 

<img width="234" height="85" alt="negative" src="https://github.com/user-attachments/assets/9e48f5ee-e694-4da1-a4f2-982c77de3a5b" />
<img width="236" height="90" alt="positive" src="https://github.com/user-attachments/assets/403378b3-7c89-469d-873f-061c8496f744" />
