### PR TITLE
Fix Pathfinder's alternate start nodes not connecting

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -831,7 +831,14 @@ function PassiveSpecClass:AllocNode(node, altPath)
 
 	if node.isMultipleChoiceOption then
 		-- For multiple choice passives, make sure no other choices are allocated
-		local parent = node.linked[1]
+		local parent = nil
+		for _, possibleParent in ipairs(node.linked) do
+			if possibleParent.isMultipleChoice and possibleParent.alloc and possibleParent ~= node then
+				parent = possibleParent
+				break
+			end
+		end
+		assert(parent) -- If we're allocating a multiple choice option without an allocated parent, something has gone wrong
 		for _, optNode in ipairs(parent.linked) do
 			if optNode.isMultipleChoiceOption and optNode.alloc and optNode ~= node then
 				self:DeallocSingleNode(optNode)

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -272,16 +272,16 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 				goto endConnection
 			end
 
-			if node.ascendancyName ~= other.ascendancyName then
-				goto endConnection
-			end
-
 			if node.id == otherId then
 				goto endConnection
 			end
 
 			t_insert(other.linkedId, node.id)
 			t_insert(node.linkedId, otherId)
+			
+			if node.ascendancyName ~= other.ascendancyName then
+				goto endConnection
+			end
 
 			if node.classesStart ~= nil or other.classesStart ~= nil then
 				goto endConnection


### PR DESCRIPTION
Fixes #1614 .

### Description of the problem being solved:
Pathfinder's ascendancy node wasn't connecting to Warrior or Sorceress due to some overzealous connection validation logic

### After screenshot:
<img width="590" height="774" alt="image" src="https://github.com/user-attachments/assets/4a343739-abe2-496d-a108-e1c3e681a170" />
