### PR TITLE
Add support for removing all of a file type from manifest

### DIFF
--- a/manifest.cfg
+++ b/manifest.cfg
@@ -15,5 +15,5 @@ exclude-directories = src/Export,src/TreeData,src/Builds,src/luacov.stats.out,sr
 
 [tree]
 path = src
-exclude-files = export_lines.bat,extract_lines.scm,log_lines_extract.txt,script_lines_extract_orbit_active.scm,script_lines_extract_orbit_intermediate.scm,script_lines_extract_orbit_normal.scm,missingStats.txt
+exclude-files = *.scm,export_lines.bat,log_lines_extract.txt,missingStats.txt
 include-directories = src/TreeData


### PR DESCRIPTION
Adds support for removing all of a file type from the manifest script
Recent update accidently included some csm files in the manifest which broke the update
We never care about the csm files so fine to always remove them