### PR TITLE
Add support for 0.4 warbringer imploding impacts and fixed fully broken armour's damage increase not applying to negative armour

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4918,8 +4918,7 @@ c["Fork an additional time Chain an additional time Chain from Terrain an additi
 c["Frenzy or Power Charge"]={nil,"Frenzy or Power Charge "}
 c["Fully Armour Broken enemies you kill with Hits Shatter"]={nil,"Fully Armour Broken enemies you kill with Hits Shatter "}
 c["Fully Broken Armour you inflict also increases Fire Damage Taken from Hits"]={nil,"Fully Broken Armour you inflict also increases Fire Damage Taken from Hits "}
-c["Fully Broken Armour you inflict increases all Damage Taken from Hits instead"]={nil,"Fully Broken Armour you inflict increases all Damage Taken from Hits instead "}
-c["Fully Broken Armour you inflict increases all Damage Taken from Hits instead You can Break Enemy Armour to below 0"]={nil,"Fully Broken Armour you inflict increases all Damage Taken from Hits instead You can Break Enemy Armour to below 0 "}
+c["Fully Broken Armour you inflict increases all Damage Taken from Hits instead"]={{[1]={[1]={effectName="ImplodingImpacts",effectType="Buff",type="GlobalEffect"},flags=0,keywordFlags=0,name="FullyBrokenArmourIncreasesAllDamageFromHits",type="FLAG",value=true}},nil}
 c["Gain 0% to 40% increased Movement Speed at random when Hit, until Hit again"]={{[1]={flags=0,keywordFlags=0,name="Condition:HaveGamblesprint",type="FLAG",value=true}},nil}
 c["Gain 1 Endurance Charge every second if you've been Hit Recently"]={{}," Endurance Charge every second  "}
 c["Gain 1 Fragile Regrowth each second"]={{}," Fragile Regrowth each second "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -595,9 +595,13 @@ local function doActorMisc(env, actor)
 		end
 		if enemyDB:Flag(nil, "Condition:ArmourFullyBroken") then
 			local effect = 20 * (1 + modDB:Sum("INC", nil, "FullyBrokenArmourEffect") / 100)
-			enemyDB:NewMod("PhysicalDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
-			if modDB:Flag(nil, "ArmourBreakFireDamageTaken") then
-				enemyDB:NewMod("FireDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
+			if modDB:Flag(nil, "FullyBrokenArmourIncreasesAllDamageFromHits") then
+				enemyDB:NewMod("DamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
+			else
+				enemyDB:NewMod("PhysicalDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
+				if modDB:Flag(nil, "ArmourBreakFireDamageTaken") then
+					enemyDB:NewMod("FireDamageTaken", "INC", effect, "Fully Broken Armour", ModFlag.Hit)
+				end
 			end
 		end
 		if modDB:Flag(nil, "Blind") and not modDB:Flag(nil, "CannotBeBlinded") then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1597,9 +1597,9 @@ Huge sets the radius to 11.
 		enemyModList:NewMod("Condition:LowLife", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
 	{ var = "conditionEnemyArmourBroken", type = "check", label = "Is enemy Armour Broken?", ifFlag = "Condition:CanArmourBreak", tooltip = "Some Skills, Items, Support Gems and other effects can Break Armour, which lowers a target's Armour by a specified amount.\nIf this brings the target's Armour value to 0, their Armour is Fully Broken for 12 seconds.", apply = function(val, modList, enemyModList)
-		enemyModList:NewMod("Condition:ArmourFullyBroken", "FLAG", true, "ArmourBreak", { type = "Condition", var = "Effective" }, { type = "ActorCondition", actor = "enemy", var = "CanArmourBreakBelowZero", neg = true })
+		enemyModList:NewMod("Condition:ArmourFullyBroken", "FLAG", true, "ArmourBreak", { type = "Condition", var = "Effective" })
 		enemyModList:NewMod("Condition:ArmourBrokenBelowZeroMax", "FLAG", true, "ArmourBreak", { type = "Condition", var = "Effective" }, { type = "ActorCondition", actor = "enemy", var = "CanArmourBreakBelowZero" })
-		enemyModList:NewMod("Armour", "OVERRIDE", 0, "ArmourBreak", { type = "Condition", var = "ArmourFullyBroken" }, { type = "GlobalEffect", effectType= "Debuff", effectName = "ArmourBreak" })
+		enemyModList:NewMod("Armour", "OVERRIDE", 0, "ArmourBreak", { type = "Condition", var = "ArmourFullyBroken" }, { type = "GlobalEffect", effectType= "Debuff", effectName = "ArmourBreak" }, { type = "ActorCondition", actor = "enemy", var = "CanArmourBreakBelowZero", neg = true })
 	end },
 	{ var = "multiplierArmourBreak", type = "count", label = "# of Broken Armour (if not maximum):", ifOption = "conditionEnemyArmourBroken", tooltip = "Use this field to set a custom Armour Break value.\nIf left empty or set to 0, Fully Broken Armour will be assumed.\nArmour cannot be broken below 0 unless stated otherwise.\nIf so, Armour can be broken up to the inverse of its original value.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:ArmourBroken", "FLAG", val > 0, "ArmourBreak", { type = "Condition", var = "Effective" }) -- only activate if value > 0 is entered

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3187,6 +3187,7 @@ local specialModList = {
 	["ignore warcry cooldowns"] ={ mod("CooldownRecovery", "OVERRIDE", 0, { type = "SkillType", skillType = SkillType.Warcry}) },
 	["break armour equal to (%d+)%% of hit damage dealt"] = { flag("Condition:CanArmourBreak", { type = "GlobalEffect", effectType = "Buff", effectName = "ArmourBreak" })}, -- 'Anvil's Weight'
 	["you can break enemy armour to below 0"] = { flag("Condition:CanArmourBreakBelowZero", { type = "GlobalEffect", effectType = "Buff", effectName = "ImplodingImpacts" })}, -- 'Imploding Impacts'
+	["fully broken armour you inflict increases all damage taken from hits instead"] = { flag("FullyBrokenArmourIncreasesAllDamageFromHits", { type = "GlobalEffect", effectType = "Buff", effectName = "ImplodingImpacts" })},
 	["trigger ancestral spirits when you summon a totem"] = { },
 	-- Trickster
 	["(%d+)%% chance to gain (%d+)%% of non%-chaos damage with hits as extra chaos damage"] = function(num, _, perc) return { mod("NonChaosDamageGainAsChaos", "BASE", num / 100 * tonumber(perc)) } end,


### PR DESCRIPTION
### Description of the problem being solved:
Added support for Warbringer's Imploding Impact's new mod "Fully Broken Armour you inflict increases all Damage Taken from Hits instead"

Fixed an issue where the "Fully Broken Armour" 20% increased damage taken bonus was not applying when armor could break below zero.

#### Rationale: 
Negative armour and Fully Broken Armour should likely be considered separate debuffs, as the [Armour Break](https://poe2db.tw/us/Armour_Break#ArmourBreakRef) tooltip reads

> On top of not benefitting from Armour, non-player targets with Fully Broken Armour take 20% increased Physical damage from Hits.

Example of both debuffs being applied ([src](https://youtu.be/cNAOc4wjsXQ?t=145)):

<img width="1427" height="240" alt="image" src="https://github.com/user-attachments/assets/a6e249ce-d57a-4bb4-ac9f-a0056d1271fe" />


### Steps taken to verify a working solution:
- Add a weapon and a source of armour break (e.g. Armour Breaker skill gem w/ a one handed mace)
- Add a source of additional non-physical damage (e.g. flat damage runes)
- With Imploding impacts allocated, Effective DPS multiplier has the 20% increased damage alongside negative armour for physical, and the 20% increased damage for other damage types.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/hn8n80uy

### Before screenshot:
#### Without Imploding Impacts Allocated

<img width="1167" height="525" alt="image" src="https://github.com/user-attachments/assets/aab9a63f-7d24-41f8-8273-7da4b762dd75" />

#### With Imploding Impacts Allocated:

<img width="1002" height="308" alt="image" src="https://github.com/user-attachments/assets/6493ab6f-5e38-4b7d-9339-4f8a595b037f" />

### After screenshot:
#### Without Imploding Impacts Allocated:

<img width="1501" height="528" alt="image" src="https://github.com/user-attachments/assets/adb13833-e869-49dd-8820-866595d51522" />

#### With Imploding Impacts Allocated:

Phys:
<img width="1190" height="342" alt="image" src="https://github.com/user-attachments/assets/14f448da-bd69-470e-90a8-d714f49c2336" />

Non-Phys:
<img width="1331" height="281" alt="image" src="https://github.com/user-attachments/assets/7ee787b2-0ab8-49cf-b5c4-8b90e0fa90ef" />
