### PR TITLE
Fix Poison III, Admixture and Poisonburst Arrow Poison Magnitude mods not working

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1387,6 +1387,9 @@ return {
 ["base_poison_damage_+%"] = {
 	mod("Damage", "INC", nil, 0, KeywordFlag.Poison),
 },
+["active_skill_poison_effect_+%_final"] = {
+	mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Poison),
+},
 ["critical_poison_dot_multiplier_+"] = {
 	mod("DotMultiplier", "BASE", nil, 0, KeywordFlag.Poison, { type = "Condition", var = "CriticalStrike" }),
 },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -130,10 +130,10 @@ skills["SupportAdmixturePlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["mixed_maladies_poison_effect_+%_final_vs_bleeding"] = {
-					mod("Damage", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
+					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
 				},
 				["mixed_maladies_bleed_effect_+%_final_vs_poisoned"] = {
-					mod("Damage", "MORE", nil, 0, KeywordFlag.Bleed, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
+					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
 				},
 			},
 			baseFlags = {
@@ -4028,7 +4028,7 @@ skills["SupportPoisonPlayerThree"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["mixed_maladies_poison_effect_+%_final_vs_bleeding"] = {
-					mod("Damage", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
+					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -38,10 +38,10 @@ statMap = {
 #set SupportAdmixturePlayer
 statMap = {
 	["mixed_maladies_poison_effect_+%_final_vs_bleeding"] = {
-		mod("Damage", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
+		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
 	},
 	["mixed_maladies_bleed_effect_+%_final_vs_poisoned"] = {
-		mod("Damage", "MORE", nil, 0, KeywordFlag.Bleed, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
+		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Bleed, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
 	},
 },
 #mods
@@ -888,7 +888,7 @@ statMap = {
 #set SupportPoisonPlayerThree
 statMap = {
 	["mixed_maladies_poison_effect_+%_final_vs_bleeding"] = {
-		mod("Damage", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
+		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Poison, { type = "ActorCondition", actor = "enemy", var = "Bleeding" }),
 	},
 },
 #mods


### PR DESCRIPTION
Fixes #1627

### Description of the problem being solved:
The mods on Poison III and Admixture were using the old parsing before we switched to using Ailment Magnitude
The Poisonburst Arrow mod was just not supported yet
