### PR TITLE
Speed up load times of exporter

### DIFF
--- a/src/Export/Classes/GGPKData.lua
+++ b/src/Export/Classes/GGPKData.lua
@@ -36,7 +36,7 @@ local GGPKClass = newClass("GGPKData", function(self, path, datPath, reExport)
 		self.oozPath = datPath:match("\\$") and datPath or (datPath .. "\\")
 	else
 		self.path = path
-		self.oozPath = io.popen("cd"):read('*l'):gsub('\r?', '') .. "\\ggpk\\"
+		self.oozPath = GetWorkDir() .. "\\ggpk\\"
 		self:CleanDir(reExport)
 		self:ExtractFiles(reExport)
 	end
@@ -126,14 +126,13 @@ function GGPKClass:ExtractList(listToExtract, cache, useRegex)
 end
 
 function GGPKClass:AddDat64Files()
-	local datFiles = scanDir(self.oozPath .. "Data\\Balance\\", '%w+%.datc64$')
-	for _, f in ipairs(datFiles) do
+	local datFiles = self:GetNeededFiles()
+	for _, fname in ipairs(datFiles) do
 		local record = { }
-		record.name = f
-		local rawFile = io.open(self.oozPath .. "Data\\Balance\\" .. f, 'rb')
+		record.name = fname:match("([^/\\]+)$") .. "c64"
+		local rawFile = io.open(self.oozPath .. fname:gsub("/", "\\") .. "c64", 'rb')
 		record.data = rawFile:read("*all")
 		rawFile:close()
-		--ConPrintf("FILENAME: %s", fname)
 		t_insert(self.dat, record)
 	end
 end
@@ -163,6 +162,8 @@ function GGPKClass:GetNeededFiles()
 		"Data/Balance/ModFamily.dat",
 		"Data/Balance/ModSellPriceTypes.dat",
 		"Data/Balance/ModEffectStats.dat",
+		"Data/Balance/ModDomains.dat",
+		"Data/Balance/ModGenerationTypes.dat",
 		"Data/Balance/ActiveSkills.dat",
 		"Data/Balance/ActiveSkillType.dat",
 		"Data/Balance/AlternateSkillTargetingBehaviours.dat",


### PR DESCRIPTION
### Description of the problem being solved:
Opening the exporter was wasting so much time in 2 lines
`self.oozPath = io.popen("cd"):read('*l'):gsub('\r?', '') .. "\\ggpk\\"`
Which opened a cmd windows to grab the current directory
and
`local datFiles = scanDir(self.oozPath .. "Data\\Balance\\", '%w+%.datc64$')`
which opened a cmd to scan the directory for the dat files we export

The first one is replaced with `GetWorkDir()`
and the second one is replaced with a lookup of the location from the list in `GetNeededFiles` 12 lines below

### Before screenshot:
<img width="122" height="46" alt="image" src="https://github.com/user-attachments/assets/247aef80-f9ae-4c9c-9b2e-802fe3cf72fe" />

### After screenshot:
<img width="124" height="45" alt="image" src="https://github.com/user-attachments/assets/99ee11d7-3d08-4f54-874c-802b3a106239" />
