### PR TITLE
Fix Quest import on low level characters

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -624,9 +624,6 @@ function ImportTabClass:ImportQuestRewardConfig(questStats)
 
 	local updated = false
 	for _, quest in ipairs(data.questRewards) do
-		if #statLines == 0 then
-			break
-		end
 		if quest.useConfig == true then
 			local var = "quest" .. quest.Description .. quest.Area .. quest.Info
 			if quest.Stat then


### PR DESCRIPTION
### Description of the problem being solved:
The import quest loop would stop break the loop when all the quest rewards had been matched to a quest, this had the side affect of no longer setting the config to false for later quest rewards that had no been obtained yet

### Before screenshot:
<img width="388" height="373" alt="image" src="https://github.com/user-attachments/assets/46e3d0a4-c896-44d4-80fd-d4363dc8314c" />

### After screenshot:
<img width="373" height="371" alt="image" src="https://github.com/user-attachments/assets/26446111-183f-47d4-92a6-628848733ce5" />
