### PR TITLE
Add support for Instruments of Power + Lord of the Wilds weapon mods

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1886,7 +1886,7 @@ end
 
 -- Check if the given item could be equipped in the given slot, taking into account possible conflicts with currently equipped items
 -- For example, a shield is not valid for Weapon 2 if Weapon 1 is a staff, and a wand is not valid for Weapon 2 if Weapon 1 is a dagger
-function ItemsTabClass:IsItemValidForSlot(item, slotName, itemSet)
+function ItemsTabClass:IsItemValidForSlot(item, slotName, itemSet, flagState)
 	itemSet = itemSet or self.activeItemSet
 	local slotType, slotId = slotName:match("^([%a ]+) (%d+)$")
 	if not slotType then
@@ -1934,18 +1934,50 @@ function ItemsTabClass:IsItemValidForSlot(item, slotName, itemSet)
 		local weapon1Sel = itemSet[slotName == "Weapon 2" and "Weapon 1" or "Weapon 1 Swap"].selItemId or 0
 		local weapon1Base = self.items[weapon1Sel] and self.items[weapon1Sel].base or "Unarmed"
 		-- Calcs tab isn't loaded yet when the items tab gets loaded, so assume we have Giant's Blood until proven wrong
-		local giantsBlood = true
-		if self.build.calcsTab and self.build.calcsTab.mainEnv then
+		local giantsBlood, instrumentsOfPower, lordOfTheWilds = true, true, true
+		if flagState then
+			giantsBlood = flagState.giantsBlood
+			instrumentsOfPower = flagState.instrumentsOfPower
+			lordOfTheWilds = flagState.lordOfTheWilds
+		elseif self.build.calcsTab and self.build.calcsTab.mainEnv then
 			giantsBlood = self.build.calcsTab.mainEnv.modDB:Flag(nil, "GiantsBlood")
+			instrumentsOfPower = self.build.calcsTab.mainEnv.modDB:Flag(nil, "InstrumentsOfPower")
+			lordOfTheWilds = self.build.calcsTab.mainEnv.modDB:Flag(nil, "LordOfTheWilds")
 		end
 		if weapon1Base.type == "Bow" then
 			return item.type == "Quiver"
+		elseif weapon1Base.type == "Talisman" and lordOfTheWilds then
+			return item.type == "Sceptre" and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+		elseif weapon1Base.type == "Staff" and instrumentsOfPower then
+			return item.type == "Focus"
 		elseif weapon1Base == "Unarmed" or weapon1Base.tags.onehand or (giantsBlood and (weapon1Base.tags.axe or weapon1Base.tags.mace or weapon1Base.tags.sword)) then
 			return item.type == "Shield" or item.type == "Focus" or item.type == "Sceptre"
 					or (item.base.tags.one_hand_weapon and weapon1Base.type ~= "Wand" and weapon1Base.type ~= "Sceptre")
 					or (giantsBlood and (item.base.tags.axe or item.base.tags.mace or item.base.tags.sword))
 		end
 	end
+end
+
+-- Ensure weapon 2 slots remain valid if keystone-dependent restrictions change
+function ItemsTabClass:ValidateWeaponSlots(flagState)
+	local activeSetChanged = false
+	local itemSet = self.activeItemSet
+	if itemSet then
+		local slotName = itemSet.useSecondWeaponSet and "Weapon 2 Swap" or "Weapon 2"
+		local slotData = itemSet[slotName]
+		if slotData and slotData.selItemId and slotData.selItemId ~= 0 then
+			local item = self.items[slotData.selItemId]
+			if not item or not self:IsItemValidForSlot(item, slotName, itemSet, flagState) then
+				if self.slots[slotName] then
+					self.slots[slotName]:SetSelItemId(0)
+				else
+					slotData.selItemId = 0
+				end
+				activeSetChanged = true
+			end
+		end
+	end
+	return activeSetChanged
 end
 
 -- Opens the item set manager

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6166,11 +6166,8 @@ c["You can Socket 2 additional copies of each Lineage Support Gem, in different 
 c["You can Socket an additional copy of each Lineage Support Gem, in different Skills"]={nil,"You can Socket an additional copy of each Lineage Support Gem, in different Skills "}
 c["You can Socket an additional copy of each Lineage Support Gem, in different Skills You can Socket 2 additional copies of each Lineage Support Gem, in different Skills"]={nil,"You can Socket an additional copy of each Lineage Support Gem, in different Skills You can Socket 2 additional copies of each Lineage Support Gem, in different Skills "}
 c["You can apply an additional Curse"]={{[1]={flags=0,keywordFlags=0,name="EnemyCurseLimit",type="BASE",value=1}},nil}
-c["You can equip a Focus while wielding a Staff"]={nil,"You can equip a Focus while wielding a Staff "}
-c["You can equip a Focus while wielding a Staff 50% reduced bonuses gained from Equipped Focus"]={nil,"You can equip a Focus while wielding a Staff 50% reduced bonuses gained from Equipped Focus "}
-c["You can equip a non-Unique Sceptre while wielding a Talisman"]={nil,"You can equip a non-Unique Sceptre while wielding a Talisman "}
-c["You can equip a non-Unique Sceptre while wielding a Talisman 50% less Spirit"]={nil,"You can equip a non-Unique Sceptre while wielding a Talisman 50% less Spirit "}
-c["You can equip a non-Unique Sceptre while wielding a Talisman 50% less Spirit Non-Minion Skills have 50% less Reservation Efficiency"]={nil,"You can equip a non-Unique Sceptre while wielding a Talisman 50% less Spirit Non-Minion Skills have 50% less Reservation Efficiency "}
+c["You can equip a Focus while wielding a Staff"]={{[1]={flags=0,keywordFlags=0,name="InstrumentsOfPower",type="FLAG",value=true}},nil}
+c["You can equip a non-Unique Sceptre while wielding a Talisman"]={{[1]={flags=0,keywordFlags=0,name="LordOfTheWilds",type="FLAG",value=true}},nil}
 c["You can have two Companions of different types"]={nil,"You can have two Companions of different types "}
 c["You can have two Companions of different types 60% reduced Duration of Bleeding on You"]={nil,"You can have two Companions of different types 60% reduced Duration of Bleeding on You "}
 c["You can have two Companions of different types You have 30% less Defences"]={nil,"You can have two Companions of different types You have 30% less Defences "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -376,9 +376,10 @@ local function doActorAttribsConditions(env, actor)
 		if not modDB:Flag(nil, "NoStrengthAttributeBonuses") then
 			if not modDB:Flag(nil, "NoStrBonusToLife") then
 				if modDB:Flag(nil, "HalvesLifeFromStrength") then
-					inherentAttributeMultiplier = inherentAttributeMultiplier * 0.5
+					modDB:NewMod("Life", "BASE", output.Str * 1 * inherentAttributeMultiplier, "Strength")
+				else
+					modDB:NewMod("Life", "BASE", output.Str * 2 * inherentAttributeMultiplier, "Strength")
 				end
-				modDB:NewMod("Life", "BASE", output.Str * 2 * inherentAttributeMultiplier, "Strength")
 			end
 		end
 		if not modDB:Flag(nil, "NoDexterityAttributeBonuses") then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -117,12 +117,17 @@ local function refreshJewelStatCache(env)
 	end
 end
 
-function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
+function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeystoneMods)
 	local localSmallIncEffect = 0
 	local localNotableIncEffect = 0
 	local modList = new("ModList")
 	if node.type == "Keystone" then
-		modList:AddMod(node.keystoneMod)
+		if includeKeystoneMods then
+			modList:AddList(node.modList)
+		end
+		if node.keystoneMod then
+			modList:AddMod(node.keystoneMod)
+		end
 	else
 		modList:AddList(node.modList)
 	end
@@ -264,7 +269,7 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill)
 end
 
 -- Build list of modifiers from the listed tree nodes
-function calcs.buildModListForNodeList(env, nodeList, finishJewels)
+function calcs.buildModListForNodeList(env, nodeList, finishJewels, includeKeystoneMods)
 	-- Initialise radius jewels
 	for _, rad in pairs(env.radiusJewelList) do
 		wipeTable(rad.data)
@@ -280,7 +285,7 @@ function calcs.buildModListForNodeList(env, nodeList, finishJewels)
 	-- Add node modifiers
 	local modList = new("ModList")
 	for _, node in pairs(nodeList) do
-		local nodeModList = calcs.buildModListForNode(env, node, inc)
+		local nodeModList = calcs.buildModListForNode(env, node, inc, includeKeystoneMods)
 		modList:AddList(nodeModList)
 		if env.mode == "MAIN" then
 			node.finalModList = nodeModList
@@ -742,7 +747,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.allocNodes = nodes
 	end
 
-	local nodesModsList = calcs.buildModListForNodeList(env, env.allocNodes, true)
+	local nodesModsList = calcs.buildModListForNodeList(env, env.allocNodes, true, true)
 	
 	if allocatedNotableCount and allocatedNotableCount > 0 then
 		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount)
@@ -759,15 +764,25 @@ function calcs.initEnv(build, mode, override, specEnv)
 
 	-- add Conditional WeaponSet# base on weapon set from item
 	modDB:NewMod("Condition:WeaponSet" .. (build.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1) , "FLAG", true, "Weapon Set")
+	
+	local weaponFlagState = {
+		giantsBlood = nodesModsList:Flag(nil, "GiantsBlood") or false,
+		instrumentsOfPower = nodesModsList:Flag(nil, "InstrumentsOfPower") or false,
+		lordOfTheWilds = nodesModsList:Flag(nil, "LordOfTheWilds") or false,
+	}
+	local cache = build.itemsTab.lastWeaponFlagState
+	if not cache or cache.giantsBlood ~= weaponFlagState.giantsBlood or cache.instrumentsOfPower ~= weaponFlagState.instrumentsOfPower or cache.lordOfTheWilds ~= weaponFlagState.lordOfTheWilds then
+		build.itemsTab.lastWeaponFlagState = { giantsBlood = weaponFlagState.giantsBlood, instrumentsOfPower = weaponFlagState.instrumentsOfPower, lordOfTheWilds = weaponFlagState.lordOfTheWilds }
+		build.itemsTab:ValidateWeaponSlots(weaponFlagState)
+	end
 
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then
 		local items = {}
 		local jewelLimits = {}
-		local giantsBlood = true
-		if build.calcsTab and build.calcsTab.mainEnv then
-			giantsBlood = build.calcsTab.mainEnv.modDB:Flag(nil, "GiantsBlood")
-		end
+		local giantsBlood = weaponFlagState.giantsBlood
+		local instrumentsOfPower = weaponFlagState.instrumentsOfPower
+		local lordOfTheWilds = weaponFlagState.lordOfTheWilds
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
 			local item
@@ -775,7 +790,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 				item = override.repItem
 			elseif override.repItem and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") and
 			(
-				override.repItem.base.type == "Staff"
+				(not lordOfTheWilds and override.repItem.base.type == "Talisman" and item and item.base.type ~= "Sceptre" and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC")
+				or (not instrumentsOfPower and override.repItem.base.type == "Staff" and item and item.base.type ~= "Focus")
 				or (not giantsBlood and (override.repItem.base.type == "Two Handed Sword" or override.repItem.base.type == "Two Handed Axe" or override.repItem.base.type == "Two Handed Mace"))
 				or (override.repItem.base.type == "Bow" and item and item.base.type ~= "Quiver")
 			) then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -771,10 +771,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 		lordOfTheWilds = nodesModsList:Flag(nil, "LordOfTheWilds") or false,
 	}
 	local cache = build.itemsTab.lastWeaponFlagState
-	if not cache or cache.giantsBlood ~= weaponFlagState.giantsBlood or cache.instrumentsOfPower ~= weaponFlagState.instrumentsOfPower or cache.lordOfTheWilds ~= weaponFlagState.lordOfTheWilds then
-		build.itemsTab.lastWeaponFlagState = { giantsBlood = weaponFlagState.giantsBlood, instrumentsOfPower = weaponFlagState.instrumentsOfPower, lordOfTheWilds = weaponFlagState.lordOfTheWilds }
+	local losingGiantsBlood = cache and cache.giantsBlood and not weaponFlagState.giantsBlood
+	local losingInstrumentsOfPower = cache and cache.instrumentsOfPower and not weaponFlagState.instrumentsOfPower
+	local losingLordOfTheWilds = cache and cache.lordOfTheWilds and not weaponFlagState.lordOfTheWilds
+	if losingGiantsBlood or losingInstrumentsOfPower or losingLordOfTheWilds then -- Only validate socket when losing Keystone / Ascendancy
 		build.itemsTab:ValidateWeaponSlots(weaponFlagState)
 	end
+	build.itemsTab.lastWeaponFlagState = { giantsBlood = weaponFlagState.giantsBlood, instrumentsOfPower = weaponFlagState.instrumentsOfPower, lordOfTheWilds = weaponFlagState.lordOfTheWilds }
 
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2526,6 +2526,8 @@ local specialModList = {
 		mod("ArmourDefense", "MAX", math.min(math.floor(numChance / 100), 1.0) * 100, "Armour Mastery: Min Calc", { type = "Condition", var = "ArmourMax", neg = true }, { type = "Condition", var = "ArmourAvg", neg = true }, { type = "Multiplier", var = "BeenHitRecently", limit = cap / numChance }),
 	} end,
 	["you can wield two%-handed axes, maces and swords in one hand"] = { flag("GiantsBlood") },
+	["you can equip a focus while wielding a staff"] = { flag("InstrumentsOfPower") },
+	["you can equip a non%-unique sceptre while wielding a talisman"] = { flag("LordOfTheWilds") },
 	["(%d+)%% of strength requirements from boots, gloves and helmets also added to armour"] = function(num) return { 
 		mod("Armour", "BASE", 1, { type = "PerStat", stat = "StrRequirementsOnBoots", percent = num }),
 		mod("Armour", "BASE", 1, { type = "PerStat", stat = "StrRequirementsOnGloves", percent = num }),


### PR DESCRIPTION
Fixes #1631

### Description of the problem being solved:
Adds support for the mods:
You can equip a Focus while wielding a Staff
You can equip a non-Unique Sceptre while wielding a Talisman

Fixes logic with the 2 mods above and Giant's Blood where it would not remove the weapon from the 2nd slot of you removed the keystone / ascendancy from your build
We if one of the weapon mods is allocated / de-allocated we check the currently equipped weapon to make sure it is still valid for the slot

Also fixes an issue with Giant's blood where it was affecting the inherent bonuses for Dex and Int
It was setting `inherentAttributeMultiplier` to 0.5 which was getting picked up in the next loops for Dex and Int

### Steps taken to verify a working solution:
- Test with combinations of adding and removing the keystone and weapon mods
- Switch trees with the mods active
- Have the item active in off hand item set

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/sbdfw0uo
### Before screenshot:
<img width="264" height="52" alt="image" src="https://github.com/user-attachments/assets/470b0c60-1b82-4ab5-83a0-96c157c2dc58" />
<img width="255" height="48" alt="image" src="https://github.com/user-attachments/assets/3f8cfbfb-6af8-4792-b832-4aa3ad071324" />

### After screenshot:
<img width="291" height="52" alt="image" src="https://github.com/user-attachments/assets/0cf4c561-6279-40d1-b04f-f0fc5265b4ef" />
<img width="273" height="53" alt="image" src="https://github.com/user-attachments/assets/02356d2d-6c4a-4a57-882f-2d55f6fd9b94" />
