### PR TITLE
Add support for Disciples reduced Focus Effect Ascendancy

### DIFF
--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -45,7 +45,7 @@ function ModListClass:ReplaceModInternal(mod)
 	return false
 end
 
-function ModListClass:MergeMod(mod)
+function ModListClass:MergeMod(mod, skipNonAdditive)
 	if mod.type == "BASE" or mod.type == "INC" or mod.type == "MORE" then
 		for i = 1, #self do
 			if modLib.compareModParams(self[i], mod) then
@@ -55,7 +55,9 @@ function ModListClass:MergeMod(mod)
 			end
 		end
 	end
-	self:AddMod(mod)
+	if not skipNonAdditive then
+		self:AddMod(mod)
+	end
 end
 
 function ModListClass:AddList(modList)

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -45,7 +45,6 @@ function ModStoreClass:ScaleAddMod(mod, scale)
 	if scale == 1 or unscalable then
 		self:AddMod(mod)
 	else
-		scale = m_max(scale, 0)
 		local scaledMod = copyTable(mod)
 		local subMod = scaledMod
 		if type(scaledMod.value) == "table" then

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2997,7 +2997,7 @@ c["50% reduced Reload Speed"]={{[1]={flags=1,keywordFlags=0,name="ReloadSpeed",t
 c["50% reduced Shock duration on you"]={{[1]={flags=0,keywordFlags=0,name="SelfShockDuration",type="INC",value=-50}},nil}
 c["50% reduced Slowing Potency of Debuffs on You"]={{}," Slowing Potency of Debuffs on You "}
 c["50% reduced Slowing Potency of Debuffs on You 20 to 30 Physical Thorns damage"]={{[1]={flags=0,keywordFlags=0,name="ThornsDamage",type="INC",value=-50}}," Slowing Potency of Debuffs on You 20 to 30 Physical  "}
-c["50% reduced bonuses gained from Equipped Focus"]={{}," bonuses gained  "}
+c["50% reduced bonuses gained from Equipped Focus"]={{[1]={flags=0,keywordFlags=0,name="EffectOfBonusesFromFocus",type="INC",value=-50}},nil}
 c["50% reduced effect of Shock on you"]={{[1]={flags=0,keywordFlags=0,name="SelfShockEffect",type="INC",value=-50}},nil}
 c["50% reduced effect of Withered on you"]={{[1]={flags=0,keywordFlags=0,name="WitherEffectOnSelf",type="INC",value=-50}},nil}
 c["500% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC",value=500}},nil}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1137,6 +1137,18 @@ function calcs.initEnv(build, mode, override, specEnv)
 							env.itemModDB:ScaleAddMod(mod, scale)
 						end
 					end
+				elseif item.type == "Focus" and calcLib.mod(nodesModsList, nil, "EffectOfBonusesFromFocus") ~=1 then
+					scale = calcLib.mod(nodesModsList, nil, "EffectOfBonusesFromFocus") - 1
+					local combinedList = new("ModList")
+					for _, mod in ipairs(srcList) do
+						combinedList:MergeMod(mod)
+					end
+					local scaledList = new("ModList")
+					scaledList:ScaleAddList(combinedList, scale)
+					for _, mod in ipairs(scaledList) do
+						combinedList:MergeMod(mod, true)
+					end
+					env.itemModDB:AddList(combinedList)
 				elseif item.name:match("Kalandra's Touch") then
 					-- Reset mult counters since they don't work for kalandra
 					if item["corrupted"] then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4698,6 +4698,7 @@ local specialModList = {
 	["projectiles deal (%d+)%% increased damage with hits and ailments for each time they have chained"] = function(num) return { mod("Damage", "INC", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "PerStat", stat = "Chain" }, { type = "SkillType", skillType = SkillType.Projectile }) } end,
 	["projectiles deal (%d+)%% increased damage with hits and ailments for each enemy pierced"] = function(num) return { mod("Damage", "INC", num, nil, 0, bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "PerStat", stat = "PiercedCount" }, { type = "SkillType", skillType = SkillType.Projectile }) } end,
 	["(%d+)%% increased bonuses gained from equipped quiver"] = function(num) return {mod("EffectOfBonusesFromQuiver", "INC", num)} end,
+	["(%d+)%% reduced bonuses gained from equipped focus"] = function(num) return {mod("EffectOfBonusesFromFocus", "INC", -num)} end,
 	["(%d+)%% increased bonuses gained from equipped rings"] = function(num) return {
 		mod("EffectOfBonusesFromRing 1", "INC", num),
 		mod("EffectOfBonusesFromRing 2", "INC", num),


### PR DESCRIPTION
Pulls in logic from PoB for scaling all the mods on an item
Adjusts ScaleAddMod to work with negative values too
