### PR TITLE
Fix Small Passive effect mod not visually changing mods on the tree

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1384,7 +1384,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 			
 			-- Apply Inc Node scaling from Hulking Form + Radius Jewels only visually
 			if (((incSmallPassiveSkillEffect + localIncEffect) > 0 and node.type == "Normal") or (localIncEffect > 0 and node.type == "Notable")) and not node.isAttribute and not node.ascendancyName and node.mods[i].list then
-				local scale = 1 + (node.type == "Normal" and incSmallPassiveSkillEffect or 0 + localIncEffect) / 100
+				local scale = 1 + (node.type == "Normal" and (incSmallPassiveSkillEffect or 0) + localIncEffect) / 100
 				local modsList = copyTable(node.mods[i].list)
 				local scaledList = new("ModList")
 				scaledList:ScaleAddList(modsList, scale)


### PR DESCRIPTION
### Description of the problem being solved:
The way it was structured before meant that the mod for increased effect of Small Passives in radius wasn't visually scaling the mods in its radius

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/ffe070uy

### Before screenshot:
<img width="400" height="122" alt="image" src="https://github.com/user-attachments/assets/a631d42f-7028-4a87-adb1-7642cd965f31" />

### After screenshot:
<img width="400" height="120" alt="image" src="https://github.com/user-attachments/assets/96da94ef-9f09-469d-82d7-b954ee7da95e" />
