### PR TITLE
Fix Artillery Ballista missing skill part name

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1028,7 +1028,7 @@ skills["ArtilleryBallistaPlayer"] = {
 	}
 }
 skills["ArtilleryBallistaProjectilePlayer"] = {
-	name = "",
+	name = "Ballista Bolt",
 	hidden = true,
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Rain] = true, [SkillType.Area] = true, [SkillType.ProjectileSpeed] = true, [SkillType.ProjectileNumber] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.Sustained] = true, [SkillType.Bow] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.AttackInPlaceIsDefault] = true, [SkillType.UsedByTotem] = true, [SkillType.AttackInPlace] = true, },
 	weaponTypes = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -57,7 +57,7 @@ addFlags = {
 #mods
 #skillEnd
 
-#skill ArtilleryBallistaProjectilePlayer
+#skill ArtilleryBallistaProjectilePlayer Ballista Bolt
 #set ArtilleryBallistaProjectilePlayer
 #flags attack area projectile totem
 #mods


### PR DESCRIPTION
Fixes #noissue.

### Description of the problem being solved:
Currently Artillery Ballista adds a no name Damage Source
<img width="317" height="97" alt="image" src="https://github.com/user-attachments/assets/4efc301f-34cd-440f-8af0-661abdc7e2ac" />
Empty field under Artillery Option

<img width="171" height="54" alt="image" src="https://github.com/user-attachments/assets/2b2f3252-62ff-4af7-86f8-c21af930099b" />

Full DPS damage breakdown with the empty name for source.

### Steps taken to verify a working solution:
- Built and loaded the same build code

### Link to a build that showcases this PR:
https://pobb.in/QiZiGiYLs5ID

### Before screenshot:
<img width="171" height="54" alt="image" src="https://github.com/user-attachments/assets/2a3420e0-72f4-49b7-b206-dfb3dba7edd2" />

### After screenshot:
<img width="176" height="64" alt="image" src="https://github.com/user-attachments/assets/1fd0267a-a71c-461c-bae7-1701f5a2f9b3" />
