### PR TITLE
Fix Berserk HP loss while inactive and Rage effect mod

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1450,7 +1450,7 @@ skills["BerserkPlayer"] = {
 			statDescriptionScope = "berserk",
 			statMap = {
 				["skill_base_life_loss_%_per_minute_per_rage_while_not_losing_rage_to_apply"] = {
-					mod("LifeDegenPercent", "BASE", 0.1, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
+					mod("LifeDegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
 					div = 60,
 				},
 				["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1457,7 +1457,7 @@ skills["BerserkPlayer"] = {
 					mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
 					div = 100,
 				},
-				["rage_effect_+%"] = {
+				["skill_base_rage_effect_+%_to_apply"] = {
 					mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 				}
 			},

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1450,8 +1450,8 @@ skills["BerserkPlayer"] = {
 			statDescriptionScope = "berserk",
 			statMap = {
 				["skill_base_life_loss_%_per_minute_per_rage_while_not_losing_rage_to_apply"] = {
-					mod("LifeDegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
-					div = 60
+					mod("LifeDegenPercent", "BASE", 0.1, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
+					div = 60,
 				},
 				["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
 					mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -93,8 +93,8 @@ statMap = {
 #flags
 statMap = {
 	["skill_base_life_loss_%_per_minute_per_rage_while_not_losing_rage_to_apply"] = {
-		mod("LifeDegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
-		div = 60
+		mod("LifeDegenPercent", "BASE", 0.1, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
+		div = 60,
 	},
 	["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {
 		mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -93,7 +93,7 @@ statMap = {
 #flags
 statMap = {
 	["skill_base_life_loss_%_per_minute_per_rage_while_not_losing_rage_to_apply"] = {
-		mod("LifeDegenPercent", "BASE", 0.1, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
+		mod("LifeDegenPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "Rage" }),
 		div = 60,
 	},
 	["life_leech_from_physical_attack_damage_permyriad_per_rage"] = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -100,7 +100,7 @@ statMap = {
 		mod("PhysicalDamageLifeLeech", "BASE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }, { type = "Multiplier", var = "RageEffect" }),
 		div = 100,
 	},
-	["rage_effect_+%"] = {
+	["skill_base_rage_effect_+%_to_apply"] = {
 		mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 	}
 },


### PR DESCRIPTION
Fixes #1658 .

### Description of the problem being solved:
Incorrect base HP loss per rage instead of a percentage.

### Steps taken to verify a working solution:
- Used the mentioned issues building code to verify

### Link to a build that showcases this PR:
*same one used in the issue

### Before screenshot:
<img width="235" height="226" alt="image" src="https://github.com/user-attachments/assets/a3318f71-b616-4893-b474-bd3952935ee9" />

### After screenshot:
<img width="185" height="218" alt="image" src="https://github.com/user-attachments/assets/c0e58d22-d26d-4c7c-9451-a302e43023a0" />
<img width="371" height="34" alt="image" src="https://github.com/user-attachments/assets/d1f05570-9f22-4148-96fa-04c0e2ed0a3e" />

2053 hp * 0.001 percentLostPerSecond = 2.053 hpLossPerSecond * 30 Rage = 61.59 Degen

<img width="720" height="253" alt="image" src="https://github.com/user-attachments/assets/bac1c514-d065-46c4-a35b-ad0d17c4356d" />
Correctly Calculated in breakdown.