### PR TITLE
Add Default Item Quality Value option into Options

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1094,7 +1094,7 @@ function ItemClass:NormaliseQuality()
 		if not self.quality then
 			self.quality = 0
 		elseif not self.uniqueID and not self.corrupted and not self.mirrored and not (self.base.type == "Charm") and self.quality < self.base.quality then -- charms cannot be modified by quality currency.
-			self.quality = self.base.quality
+			self.quality = main.defaultItemQuality
 		end
 	end	
 end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -625,7 +625,7 @@ function main:LoadSettings(ignoreBuild)
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
 				if node.attrib.defaultItemQuality then
-					self.defaultItemQuality = m_min(tonumber(node.attrib.defaultItemQuality) or 0, 20)
+					self.defaultItemQuality = m_min(tonumber(node.attrib.defaultItemQuality) or 0, 30)
 				end
 				if node.attrib.defaultCharLevel then
 					self.defaultCharLevel = m_min(m_max(tonumber(node.attrib.defaultCharLevel) or 1, 1), 100)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -102,6 +102,7 @@ function main:Init()
 	self.thousandsSeparator = ","
 	self.decimalSeparator = "."
 	self.defaultItemAffixQuality = 0.5
+	self.defaultItemQuality = 0
 	self.showTitlebarName = true
 	self.dpiScaleOverridePercent = GetDPIScaleOverridePercent and GetDPIScaleOverridePercent() or 0
 	self.showWarnings = true
@@ -623,6 +624,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.defaultGemQuality then
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
+				if node.attrib.defaultItemQuality then
+					self.defaultItemQuality = m_min(tonumber(node.attrib.defaultItemQuality) or 0, 20)
+				end
 				if node.attrib.defaultCharLevel then
 					self.defaultCharLevel = m_min(m_max(tonumber(node.attrib.defaultCharLevel) or 1, 1), 100)
 				end
@@ -782,7 +786,8 @@ function main:SaveSettings()
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
 		edgeSearchHighlight = tostring(self.edgeSearchHighlight),
-		defaultGemQuality = tostring(self.defaultGemQuality or 0),
+			defaultGemQuality = tostring(self.defaultGemQuality or 0),
+			defaultItemQuality = tostring(self.defaultItemQuality or 0),
 		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 		defaultItemAffixQuality = tostring(self.defaultItemAffixQuality or 0.5),
 		lastExportWebsite = self.lastExportWebsite,
@@ -1041,6 +1046,13 @@ function main:OpenOptionsPopup()
 	end)
 	controls.defaultGemQuality.tooltipText = "Set the default quality that can be overwritten by build-related quality settings in the skill panel."
 	controls.defaultGemQualityLabel = new("LabelControl", { "RIGHT", controls.defaultGemQuality, "LEFT" }, { defaultLabelSpacingPx, 0, 0, 16 }, "^7Default gem quality:")
+
+	nextRow()
+	controls.defaultItemQuality = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 80, 20 }, self.defaultItemQuality, nil, "%D", 2, function(itemQuality)
+		self.defaultItemQuality = m_min(tonumber(itemQuality) or 0, 20)
+	end)
+	controls.defaultItemQuality.tooltipText = "Set the default quality that will be applied to newly created or pasted items."
+	controls.defaultItemQualityLabel = new("LabelControl", { "RIGHT", controls.defaultItemQuality, "LEFT" }, { defaultLabelSpacingPx, 0, 0, 16 }, "^7Default item quality:")
 
 	nextRow()
 	controls.defaultCharLevel = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 80, 20 }, self.defaultCharLevel, nil, "%D", 3, function(charLevel)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -625,7 +625,7 @@ function main:LoadSettings(ignoreBuild)
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
 				if node.attrib.defaultItemQuality then
-					self.defaultItemQuality = m_min(tonumber(node.attrib.defaultItemQuality) or 0, 30)
+					self.defaultItemQuality = m_min(tonumber(node.attrib.defaultItemQuality) or 20, 30)
 				end
 				if node.attrib.defaultCharLevel then
 					self.defaultCharLevel = m_min(m_max(tonumber(node.attrib.defaultCharLevel) or 1, 1), 100)
@@ -1124,6 +1124,7 @@ function main:OpenOptionsPopup()
 	local initialBetaTest = self.betaTest
 	local initialEdgeSearchHighlight = self.edgeSearchHighlight
 	local initialDefaultGemQuality = self.defaultGemQuality or 0
+	local initialDefaultItemQuality = self.defaultGemQuality or 20
 	local initialDefaultCharLevel = self.defaultCharLevel or 1
 	local initialDefaultItemAffixQuality = self.defaultItemAffixQuality or 0.5
 	local initialShowWarnings = self.showWarnings
@@ -1180,6 +1181,7 @@ function main:OpenOptionsPopup()
 		self.betaTest = initialBetaTest
 		self.edgeSearchHighlight = initialEdgeSearchHighlight
 		self.defaultGemQuality = initialDefaultGemQuality
+		self.defaultItemQuality = initialDefaultItemQuality
 		self.defaultCharLevel = initialDefaultCharLevel
 		self.defaultItemAffixQuality = initialDefaultItemAffixQuality
 		self.showWarnings = initialShowWarnings

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -102,7 +102,7 @@ function main:Init()
 	self.thousandsSeparator = ","
 	self.decimalSeparator = "."
 	self.defaultItemAffixQuality = 0.5
-	self.defaultItemQuality = 0
+	self.defaultItemQuality = 20
 	self.showTitlebarName = true
 	self.dpiScaleOverridePercent = GetDPIScaleOverridePercent and GetDPIScaleOverridePercent() or 0
 	self.showWarnings = true
@@ -786,8 +786,8 @@ function main:SaveSettings()
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
 		edgeSearchHighlight = tostring(self.edgeSearchHighlight),
-			defaultGemQuality = tostring(self.defaultGemQuality or 0),
-			defaultItemQuality = tostring(self.defaultItemQuality or 0),
+		defaultGemQuality = tostring(self.defaultGemQuality or 0),
+		defaultItemQuality = tostring(self.defaultItemQuality or 20),
 		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 		defaultItemAffixQuality = tostring(self.defaultItemAffixQuality or 0.5),
 		lastExportWebsite = self.lastExportWebsite,


### PR DESCRIPTION
Fixes #1569  .

### Description of the problem being solved:
Forcing 20 quality on items crafted or imported without an option to change the default value assigned.

### Steps taken to verify a working solution:
- Crafted and imported an item from PoE2

### Link to a build that showcases this PR:
--- Any build just craft or ctrl v an item into items tab.

### Before screenshot:
<img width="414" height="219" alt="image" src="https://github.com/user-attachments/assets/eb9e0e23-f825-4f62-8a7d-2f746e6d069b" />

### After screenshot:
<img width="333" height="84" alt="image" src="https://github.com/user-attachments/assets/55f7da95-7a7e-48ae-bffc-cd1666cbe45a" />
<img width="390" height="205" alt="image" src="https://github.com/user-attachments/assets/7635158a-e047-4629-b8e5-64407dc5f4d8" />

