### PR TITLE
Fix Armour Break not appearing when using Mark for Death

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4840,6 +4840,11 @@ skills["SupportMarkForDeathPlayer"] = {
 			label = "Mark for Death",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+            statMap = {
+                ["marked_target_%_physical_damage_taken_as_armour_break"] = {
+                    flag("Condition:CanArmourBreak", { type = "GlobalEffect", effectType = "Buff", effectName = "ArmourBreak" } ),
+                },
+            },
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -1105,6 +1105,11 @@ statMap = {
 
 #skill SupportMarkForDeathPlayer
 #set SupportMarkForDeathPlayer
+statMap = {
+	["marked_target_%_physical_damage_taken_as_armour_break"] = {
+		flag("Condition:CanArmourBreak", { type = "GlobalEffect", effectType = "Buff", effectName = "ArmourBreak" } ),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #1464 .

### Description of the problem being solved:
Mark for Death support gem allows armour breaks but doesn't display the condition in options.

### Steps taken to verify a working solution:
- Added Option and assigned support to Pounce

### Link to a build that showcases this PR:
https://pobb.in/y9O_1f1URXP-

### Before screenshot:
<img width="660" height="325" alt="image" src="https://github.com/user-attachments/assets/4c8d5a91-6ea2-4fa5-b8af-d3e3dd30aa82" />


### After screenshot:
<img width="674" height="306" alt="image" src="https://github.com/user-attachments/assets/f03add97-ae84-42e1-acb9-c15f4c0e9fad" />
