### PR TITLE
Fix HTTP/2 response headers parsing

### DIFF
--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -40,7 +40,7 @@ function TradeQueryRequestsClass:ProcessQueue()
 							return
 						end
 						-- if limit rules don't return account then the POESESSID is invalid.
-						if response.header:match("X%-Rate%-Limit%-Rules: (.-)\n"):match("Account") == nil and main.POESESSID ~= "" then
+						if response.header:match("[xX]%-[rR]ate%-[lL]imit%-[rR]ules: (.-)\n"):match("Account") == nil and main.POESESSID ~= "" then
 							main.POESESSID = ""
 							if errMsg then
 								errMsg = errMsg .. "\nPOESESSID is invalid. Please Re-Log and reset"


### PR DESCRIPTION
The [HTTP/2 spec](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2) requires header field names to be lowercase. This change makes PoB agnostic about the used HTTP version by changing the pattern to be case-insensitive.

This doesn't affect the official Windows version of PoB (yet) because it bundles a `libcurl` library that is not compiled with HTTP/2 support. My main motivation behind this fix is https://github.com/meehl/rusty-path-of-building/issues/20.

I know third-party runtimes are not officially supported but i still hope to see this merged because i feel like PoB shouldn't make any assumptions about the HTTP version being used. If the bundled `libcurl` library is ever compiled with HTTP/2 support you'll most likely run into the same problem.