### PR TITLE
Show "Twice Corrupted" text on imported items

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1033,6 +1033,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	end
 	item.mirrored = itemData.mirrored
 	item.corrupted = itemData.corrupted
+	item.doubleCorrupted = itemData.doubleCorrupted
 	item.fractured = itemData.fractured
 	item.desecrated = itemData.desecrated
 	item.mutated = itemData.mutated

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -384,6 +384,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			self.mirrored = true
 		elseif line == "Corrupted" then
 			self.corrupted = true
+		elseif line == "Twice Corrupted" then
+			self.corrupted = true
+			self.doubleCorrupted = true
 		elseif line == "Desecrated Prefix" or line == "Desecrated Suffix" then
 			self.desecrated = true
 		elseif line == "Requirements:" then
@@ -1294,7 +1297,9 @@ function ItemClass:BuildRaw()
 	if self.mirrored then
 		t_insert(rawLines, "Mirrored")
 	end
-	if self.corrupted then
+	if self.doubleCorrupted then
+		t_insert(rawLines, "Twice Corrupted")
+	elseif self.corrupted then
 		t_insert(rawLines, "Corrupted")
 	end
 	return table.concat(rawLines, "\n")

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3048,14 +3048,16 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	end
 
 	-- Corrupted item label
-	if item.corrupted or item.mirrored then
+	if item.corrupted or item.mirrored or item.doubleCorrupted then
 		if #item.explicitModLines == 0 then
 			tooltip:AddSeparator(10)
 		end
 		if item.mirrored then
 			tooltip:AddLine(fontSizeBig, colorCodes.NEGATIVE.."Mirrored", "FONTIN SC")
 		end
-		if item.corrupted then
+		if item.doubleCorrupted then
+			tooltip:AddLine(fontSizeBig, colorCodes.NEGATIVE.."Twice Corrupted", "FONTIN SC")
+		elseif item.corrupted then
 			tooltip:AddLine(fontSizeBig, colorCodes.NEGATIVE.."Corrupted", "FONTIN SC")
 		end
 		tooltip:AddSeparator(10)


### PR DESCRIPTION
### Description of the problem being solved:
Copying the item text in game does not provide "Twice Corrupted" text. But importing the item does provide doubleCorrupted flag. self.corrupted is set even when its double corrupted, so other logic should not be affected. Just the visual text.

```
Item Class: Amulets
Rarity: Unique
Xoph's Blood
Amber Amulet
--------
Requires: Level 52
--------
Item Level: 80
--------
+14 to Strength (enchant)
--------
+12 to Strength (implicit)
--------
16% increased maximum Life
+63% to Fire Resistance
Enemies in your Presence have -25% to Fire Resistance
--------
We are his blood.
Through us he carries his burning message.
--------
Corrupted
```

### In Game:
<img width="587" height="337" alt="image" src="https://github.com/user-attachments/assets/03c0f3bf-3d9d-4130-b1ae-f283b901e636" />

### After screenshot:
<img width="419" height="347" alt="image" src="https://github.com/user-attachments/assets/6f3ad150-6684-4ab9-89de-3cd5965d52c9" />
