### PR TITLE
Add parsing for 'Forced Outcome' oracle passive, minion presence passives, and bugfix for Inspiring Ally

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2784,7 +2784,7 @@ c["5% increased Area Damage"]={{[1]={flags=512,keywordFlags=0,name="Damage",type
 c["5% increased Area of Effect"]={{[1]={flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=5}},nil}
 c["5% increased Attack Critical Hit Chance per 10 Tribute"]={{[1]={[1]={actor="parent",div=10,stat="Tribute",type="PerStat"},flags=1,keywordFlags=0,name="CritChance",type="INC",value=5}},nil}
 c["5% increased Attack Damage"]={{[1]={flags=1,keywordFlags=0,name="Damage",type="INC",value=5}},nil}
-c["5% increased Attack Damage for each Minion in your Presence, up to a maximum of 80%"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=1,keywordFlags=0,name="Damage",type="INC",value=5}}}},"  for each  in your Presence, up to a maximum of 80% "}
+c["5% increased Attack Damage for each Minion in your Presence, up to a maximum of 80%"]={{[1]={[1]={limit=80,limitTotal=true,type="Multiplier",var="MinionPresenceCount"},flags=1,keywordFlags=0,name="Damage",type="INC",value=5}},nil}
 c["5% increased Attack Speed"]={{[1]={flags=1,keywordFlags=0,name="Speed",type="INC",value=5}},nil}
 c["5% increased Attack Speed with Bows"]={{[1]={flags=131077,keywordFlags=0,name="Speed",type="INC",value=5}},nil}
 c["5% increased Attack Speed with Daggers"]={{[1]={flags=524293,keywordFlags=0,name="Speed",type="INC",value=5}},nil}
@@ -2805,7 +2805,7 @@ c["5% increased Duration of Damaging Ailments on Enemies"]={{[1]={flags=0,keywor
 c["5% increased Experience gain"]={{}," Experience gain "}
 c["5% increased Flask Effect Duration"]={{[1]={flags=0,keywordFlags=0,name="FlaskDuration",type="INC",value=5}},nil}
 c["5% increased Life Regeneration rate"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="INC",value=5}},nil}
-c["5% increased Life and Mana Regeneration Rate for each Minion in your Presence, up to a maximum of 40%"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Life",type="INC",value=5}}}},"  and Mana Regeneration Rate for each  in your Presence, up to a maximum of 40% "}
+c["5% increased Life and Mana Regeneration Rate for each Minion in your Presence, up to a maximum of 40%"]={{[1]={[1]={limit=40,limitTotal=true,type="Multiplier",var="MinionPresenceCount"},flags=0,keywordFlags=0,name="Life",type="INC",value=5}},"  and Mana Regeneration Rate  "}
 c["5% increased Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningDamage",type="INC",value=5}},nil}
 c["5% increased Magnitude of Ailments you inflict"]={{[1]={flags=0,keywordFlags=0,name="AilmentMagnitude",type="INC",value=5}},nil}
 c["5% increased Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=5}},nil}
@@ -4589,8 +4589,8 @@ c["Cold Damage from Hits Contributes to Flammability and Ignite Magnitudes inste
 c["Cold Resistance is unaffected by Area Penalties"]={nil,"Cold Resistance is unaffected by Area Penalties "}
 c["Cold Resistance is unaffected by Area Penalties Fire Resistance is unaffected by Area Penalties"]={nil,"Cold Resistance is unaffected by Area Penalties Fire Resistance is unaffected by Area Penalties "}
 c["Combo count loss occurs 20% slower"]={nil,"Combo count loss occurs 20% slower "}
-c["Companions deal 12% increased Damage"]={{[1]={[1]={skillType=219,type="SkillType"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=12}}}},nil}
-c["Companions deal 15% increased Damage"]={{[1]={[1]={skillType=219,type="SkillType"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="INC",value=15}}}},nil}
+c["Companions deal 12% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={[1]={skillType=219,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=12}}}},nil}
+c["Companions deal 15% increased Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={[1]={skillType=219,type="SkillType"},flags=0,keywordFlags=0,name="Damage",type="INC",value=15}}}},nil}
 c["Companions deal 60% increased damage against Immobilised enemies"]={{[1]={[1]={skillType=219,type="SkillType"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={[1]={actor="enemy",type="ActorCondition",var="Immobilised"},flags=0,keywordFlags=0,name="Damage",type="INC",value=60}}}},nil}
 c["Companions gain your Strength"]={{[1]={flags=0,keywordFlags=0,name="StrengthAddedToCompanions",type="FLAG",value=true}},nil}
 c["Companions have +1 to each Defence for every 2 of that Defence you have"]={{}," each Defence for every 2 of that Defence you have "}
@@ -5373,7 +5373,7 @@ c["Increases and Reductions to Minion Attack Speed also affect you"]={{[1]={flag
 c["Increases and Reductions to Minion Damage also affect you"]={{[1]={flags=0,keywordFlags=0,name="MinionDamageAppliesToPlayer",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ImprovedMinionDamageAppliesToPlayer",type="MAX",value=100}},nil}
 c["Increases and Reductions to Projectile Speed also apply to Damage with Bows"]={{[1]={flags=0,keywordFlags=0,name="ProjectileSpeedAppliesToBowDamage",type="FLAG",value=true}},nil}
 c["Increases and Reductions to Spell damage also apply to Attacks"]={{[1]={flags=0,keywordFlags=0,name="SpellDamageAppliesToAttacks",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="ImprovedSpellDamageAppliesToAttacks",type="MAX",value=100}},nil}
-c["Inevitable Critical Hits"]={nil,"Inevitable Critical Hits "}
+c["Inevitable Critical Hits"]={{[1]={flags=0,keywordFlags=0,name="InevitableCriticalHits",type="FLAG",value=true}},nil}
 c["Infinite Parry Range"]={nil,"Infinite Parry Range "}
 c["Infinite Parry Range 50% increased Parried Debuff Duration"]={nil,"Infinite Parry Range 50% increased Parried Debuff Duration "}
 c["Inflict Abyssal Wasting on Hit"]={nil,"Inflict Abyssal Wasting on Hit "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2805,7 +2805,7 @@ c["5% increased Duration of Damaging Ailments on Enemies"]={{[1]={flags=0,keywor
 c["5% increased Experience gain"]={{}," Experience gain "}
 c["5% increased Flask Effect Duration"]={{[1]={flags=0,keywordFlags=0,name="FlaskDuration",type="INC",value=5}},nil}
 c["5% increased Life Regeneration rate"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="INC",value=5}},nil}
-c["5% increased Life and Mana Regeneration Rate for each Minion in your Presence, up to a maximum of 40%"]={{[1]={[1]={limit=40,limitTotal=true,type="Multiplier",var="MinionPresenceCount"},flags=0,keywordFlags=0,name="Life",type="INC",value=5}},"  and Mana Regeneration Rate  "}
+c["5% increased Life and Mana Regeneration Rate for each Minion in your Presence, up to a maximum of 40%"]={{[1]={[1]={limit=40,limitTotal=true,type="Multiplier",var="MinionPresenceCount"},flags=0,keywordFlags=0,name="LifeRegen",type="INC",value=5},[2]={[1]={limit=40,limitTotal=true,type="Multiplier",var="MinionPresenceCount"},flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=5}},nil}
 c["5% increased Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningDamage",type="INC",value=5}},nil}
 c["5% increased Magnitude of Ailments you inflict"]={{[1]={flags=0,keywordFlags=0,name="AilmentMagnitude",type="INC",value=5}},nil}
 c["5% increased Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=5}},nil}

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -695,8 +695,20 @@ function calcs.offence(env, actor, activeSkill)
 		tempCfg.skillTypes[SkillType.CreatesCompanion] = true -- Add companion skill tag to cfg so it doesn't fail
 		for _, value in ipairs(skillModList:List(tempCfg, "MinionModifier")) do
 			if value.mod.name == "Damage" and value.mod.type == "INC" then
-				local mod = value.mod
-				skillModList:NewMod("Damage", "INC", mod.value, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
+				
+				-- Ensure we only accept skills tagged as companion skills
+				local valid = false
+				for _, tag in ipairs(value.mod) do
+					if tag.type == "SkillType" and tag.skillType == SkillType.CreatesCompanion then
+						valid = true
+						break
+					end
+				end
+
+				if valid then
+					local mod = value.mod
+					skillModList:NewMod("Damage", "INC", mod.value, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
+				end
 			end
 		end
 	end
@@ -3414,6 +3426,20 @@ function calcs.offence(env, actor, activeSkill)
 					output.CritChance = m_max(output.CritChance, 0)
 				end
 				output.PreEffectiveCritChance = output.CritChance
+
+				-- Inevitable Criticals: Use the calculated crit chance to calculate a multiplier offset, then override to 100%
+				-- Leave PreEffectiveCritChance alone so the breakdown can display it, then we display the override
+				if skillModList:Flag(nil, "InevitableCriticalHits") then
+					local avgNumRerolls = 100 / output.CritChance - 1
+					local critMultPenalty = -30 * avgNumRerolls
+
+					-- Add the override mod for display purposes
+					skillModList:NewMod("CritChance", "OVERRIDE", 100, "Tree:55135")
+					skillModList:NewMod("CritMultiplier", "INC", critMultPenalty, "Tree:55135")
+
+					output.CritChance = 100
+				end
+
 				local preHitCheckCritChance = output.CritChance
 				if env.mode_effective then
 					output.CritChance = output.CritChance * output.AccuracyHitChance / 100
@@ -3431,9 +3457,9 @@ function calcs.offence(env, actor, activeSkill)
 					breakdown.CritChance = { }
 					local baseCritFromMainHandStr = baseCritFromMainHand and " from main weapon" or baseCritFromParentMainHand and " from parent main weapon" or ""
 					if base ~= 0 then
-						t_insert(breakdown.CritChance, s_format("(%g + %g) ^8(base%s)", baseCrit, base, baseCritFromMainHandStr))
+						t_insert(breakdown.CritChance, s_format("(%g + %g)%% ^8(base%s)", baseCrit, base, baseCritFromMainHandStr))
 					else
-						t_insert(breakdown.CritChance, s_format("%g ^8(base%s)", baseCrit + base, baseCritFromMainHandStr))
+						t_insert(breakdown.CritChance, s_format("%g%% ^8(base%s)", baseCrit + base, baseCritFromMainHandStr))
 					end
 					if inc ~= 0 then
 						t_insert(breakdown.CritChance, s_format("x %.2f", 1 + inc/100).." ^8(increased/reduced)")
@@ -3442,6 +3468,13 @@ function calcs.offence(env, actor, activeSkill)
 						t_insert(breakdown.CritChance, s_format("x %.2f", more).." ^8(more/less)")
 					end
 					t_insert(breakdown.CritChance, s_format("= %.2f%% ^8(crit chance)", output.PreEffectiveCritChance))
+
+					if skillModList:Flag(nil, "InevitableCriticalHits") then
+						t_insert(breakdown.CritChance, "")
+						t_insert(breakdown.CritChance, "^6Inevitable Critical Hits^7:")
+						t_insert(breakdown.CritChance, "100% crit chance ^8(override)")
+					end
+
 					if preCapCritChance > 100 then
 						local overCap = preCapCritChance - 100
 						t_insert(breakdown.CritChance, s_format("Crit is overcapped by %.2f%% (%d%% increased Critical Hit Chance)", overCap, overCap / more / (baseCrit + base) * 100))

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -951,7 +951,7 @@ Huge sets the radius to 11.
 	{ var = "conditionSummonedGolemInPast10Sec", type = "check", label = "Summoned Golem in past 10 Seconds?", ifCond = "SummonedGolemInPast10Sec", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:SummonedGolemInPast10Sec", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "companionInPresence", type = "check", label = "Is a Companion in your Presence?", ifSkillType = SkillType.CreatesCompanion, defaultState = true, apply = function(val, modList, enemyModList)
+	{ var = "companionInPresence", type = "check", label = "Is a Companion in your Presence?", ifCond = "CompanionInPresence", defaultState = true, apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:CompanionInPresence", "FLAG", true, "Config", { type = "Condition", var = "HaveCompanion" })
 	end },
 	{ var = "multiplierNearbyAlly", type = "count", label = "# of Nearby Allies:", ifMult = "NearbyAlly", apply = function(val, modList, enemyModList)
@@ -962,6 +962,9 @@ Huge sets the radius to 11.
 	end },
 	{ var = "multiplierSummonedMinion", type = "count", label = "# of Summoned Minions:", ifMult = "SummonedMinion", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:SummonedMinion", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
+	{ var = "multiplierMinionsInPresence", type = "count", label = "# of Minions in your Presence:", ifMult = "MinionPresenceCount", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:MinionPresenceCount", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "conditionOnConsecratedGround", type = "check", label = "Are you on Consecrated Ground?", tooltip = "In addition to allowing any 'while on Consecrated Ground' modifiers to apply,\nConsecrated Ground grants 5% ^xE05030Life ^7Regeneration to players and allies.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:OnConsecratedGround", "FLAG", true, "Config", { type = "Condition", var = "Combat" })

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -172,6 +172,7 @@ local modNameList = {
 	["maximum life"] = "Life",
 	["life regeneration"] = "LifeRegen",
 	["life regeneration rate"] = "LifeRegen",
+	["life and mana regeneration rate"] = { "LifeRegen", "ManaRegen" },
 	["mana"] = "Mana",
 	["maximum mana"] = "Mana",
 	["mana regeneration"] = "ManaRegen",

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1503,6 +1503,7 @@ local modTagList = {
 	["per (%d+) rampage kills"] = function(num) return { tag = { type = "Multiplier", var = "Rampage", div = num, limit = 1000 / num, limitTotal = true } } end,
 	["per minion, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "SummonedMinion", limit = tonumber(num), limitTotal = true } } end,
 	["for each different type of persistent minion in your presence"] = { tag = { type = "Multiplier", var =  "PersistentMinionTypes" } },
+	["for each minion in your presence, up to a maximum of (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "MinionPresenceCount", limit = tonumber(num), limitTotal = true } } end,
 	["for each type of ammunition fired in the past (%d+) seconds"] = { tag = { type = "Multiplier", var = "DifferentAmmoFired", limitVar = "AmmoTypes" } },
 	["for every different grenade fired in the past (%d+) seconds"] = { tag = { type = "Multiplier", var = "DifferentGrenadeFired", limitVar = "GrenadeTypes" } },
 	["for each enemy you or your minions have killed recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", varList = { "EnemyKilledRecently","EnemyKilledByMinionsRecently" }, limit = tonumber(num), limitTotal = true } } end,
@@ -3306,6 +3307,7 @@ local specialModList = {
 	},
 	-- Druid -- Oracle
 	["walk the paths not taken"] = {},
+	["inevitable critical hits"] = { flag("InevitableCriticalHits") },
 	["gain the benefits of bonded modifiers on runes and idols"] = {
 		flag("Condition:CanUseBondedModifiers"),
 	},
@@ -4491,6 +4493,7 @@ local specialModList = {
 	["your dexterity is added to your minions"] = { flag("DexterityAddedToMinions") },
 	["companions gain your dexterity"] = { flag("DexterityAddedToCompanions") },
 	["companions gain your strength"] = { flag("StrengthAddedToCompanions") },
+	["companions deal (%d+)%% increased damage"] = function(num) return { mod("MinionModifier", "LIST", { mod = mod("Damage", "INC", num, { type = "SkillType", skillType = SkillType.CreatesCompanion }) }) } end,
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
 	["your minions are gigantic"] = {
 		mod("MinionModifier", "LIST", { mod = flag("Gigantic") }),


### PR DESCRIPTION
- Adds support for 'Forced Outcome' oracle passive (Inevitable Critical Hits)
- Adds support for 'Pack Encouragement' and 'Licking Wounds' passives (or anything that scales with number of minions in your Presence)
- Fixes issue where "increased life and mana regeneration rate" would give +life, and nothing for mana, instead of regen (but it's only on one node anyway)
- Fixes longstanding bug with 'Inspiring Ally' incorrectly adding damage from non-companion minion nodes
- Updates companionInPresence config condition to only appear when you have nodes that need it, instead of whenever you have a companion

Just wanted to get those passives working so I could plan my build, but the changes are probably straightforward enough to merge in for everyone