### PR TITLE
Add support for Arakaali's Lust

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -410,6 +410,14 @@ skills["SupportArakaalisLustPlayer"] = {
 			label = "Arakaali's Lust",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_debilitate_hit_damage_+%_final_per_poison_stack"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
+				},
+				["support_debilitate_hit_damage_max_poison_stacks"] = {
+					mod("Multiplier:ArakaaliMaxHitDamage", "BASE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -412,7 +412,7 @@ skills["SupportArakaalisLustPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_debilitate_hit_damage_+%_final_per_poison_stack"] = {
-					mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
+					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
 				},
 				["support_debilitate_hit_damage_max_poison_stacks"] = {
 					mod("Multiplier:ArakaaliMaxHitDamage", "BASE", nil),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -104,7 +104,7 @@ statMap = {
 #set SupportArakaalisLustPlayer
 statMap = {
 	["support_debilitate_hit_damage_+%_final_per_poison_stack"] = {
-		mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
+		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
 	},
 	["support_debilitate_hit_damage_max_poison_stacks"] = {
 		mod("Multiplier:ArakaaliMaxHitDamage", "BASE", nil),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -102,6 +102,14 @@ statMap = {
 
 #skill SupportArakaalisLustPlayer
 #set SupportArakaalisLustPlayer
+statMap = {
+	["support_debilitate_hit_damage_+%_final_per_poison_stack"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", actor = "enemy", var = "PoisonStacks", limitVar = "ArakaaliMaxHitDamage", limitTotal = true } ),
+	},
+	["support_debilitate_hit_damage_max_poison_stacks"] = {
+		mod("Multiplier:ArakaaliMaxHitDamage", "BASE", nil),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for Arakaali's Lust hit damage scaling per Poison stack on the enemy

### Steps taken to verify a working solution:
- Added a skill that hits
- Added Poison Support
- Added Arakaali's Lust
- Adjusted the number of Poison stacks on the enemy

### Link to a build that showcases this PR:
https://pobb.in/9Qsv16yyc9V2

### Before screenshot:
![before2n](https://github.com/user-attachments/assets/16716503-2310-4d0f-9719-fa7cea8927a4)

### After screenshot:
![after2](https://github.com/user-attachments/assets/82d069bf-efb6-4ab4-a4e8-37a60f95e64c)

