### PR TITLE
Fix Qimah quest import for all resist

### DIFF
--- a/src/Data/QuestRewards.lua
+++ b/src/Data/QuestRewards.lua
@@ -250,7 +250,7 @@ return {
 		["Area"] = "Qimah",
 		["Info"] = "Seven Pillars",
 		["Options"] = {
-			"+5% to Elemental Resistances",
+			"+5% to all Elemental Resistances",
 			"3% increased Movement Speed",
 			"15% increased Global Defences",
 			"20% increased Presence Area Of Effect",


### PR DESCRIPTION
Fixes the issue with Qimah Quest reward not importing the "+5% to all elemental resistances" reward into Configuration when pulling from POE site.

The issue was a missing word (ie: "all") in the QuestRewards so the JSON to QuestRewards text match would fail.

