### PR TITLE
Add support for Falling Thunder projectiles

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6888,7 +6888,7 @@ skills["FallingThunderPlayer"] = {
 					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
 				},
 				["lightning_strike_damage_+%_final_when_charged"] = {
-					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "MultiplierThreshold", var = "RemovablePowerCharge", threshold = 1 }),
 				},
 				["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
 					mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6891,8 +6891,8 @@ skills["FallingThunderPlayer"] = {
 					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
 				},
 				["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
-			        mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
-			    },
+					mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
+				},
 			},
 			baseFlags = {
 				attack = true,

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6883,6 +6883,17 @@ skills["FallingThunderPlayer"] = {
 			baseEffectiveness = 0.62000000476837,
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "falling_thunder",
+			statMap = {
+				["lightning_strike_damage_+%_final_per_power_charge"] = {
+					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+				},
+				["lightning_strike_damage_+%_final_when_charged"] = {
+					mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+				},
+				["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
+			        mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
+			    },
+			},
 			baseFlags = {
 				attack = true,
 				projectile = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -461,8 +461,8 @@ statMap = {
 		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
 	},
 	["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
-        mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
-    },
+		mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
+	},
 },
 #mods
 #skillEnd

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -458,7 +458,7 @@ statMap = {
 		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
 	},
 	["lightning_strike_damage_+%_final_when_charged"] = {
-		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "MultiplierThreshold", var = "RemovablePowerCharge", threshold = 1 }),
 	},
 	["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
 		mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -453,6 +453,17 @@ statMap = {
 #mods
 #set FallingThunderProjectilePlayer
 #flags attack projectile
+statMap = {
+	["lightning_strike_damage_+%_final_per_power_charge"] = {
+		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+	},
+	["lightning_strike_damage_+%_final_when_charged"] = {
+		mod("Damage", "MORE", nil, ModFlag.Projectile, 0, { type = "Multiplier", var = "RemovablePowerCharge" }),
+	},
+	["lightning_strike_base_number_of_projectiles_per_power_charge"] = {
+        mod("ProjectileCount", "BASE", nil, 0, 0, { type = "Multiplier", var = "RemovablePowerCharge", base = -1 }),
+    },
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Add the power charge related bonus in falling thunder skill.
The number of projectiles is now calculated and shown in the calcs section.

NOTE: there is still a duplicate quality row in the melee section but I think it is related to a more general bug that shows quality in each skill section (for example fireball quality bonus is shown in all skill sections)

### Link to a build that showcases this PR:
https://pobb.in/vS6PzYsilVmQ

