### PR TITLE
Fix low life defence mods not applying sometimes when using Starkonja's, Rise of the Pheonix and Coward Legacy

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -951,9 +951,9 @@ function calcs.defence(env, actor)
 		breakdown.Mana = { slots = { } }
 		breakdown.Spirit = { slots = { } }
 	end
-	if actor == env.minion then
-		calcs.doActorLifeManaSpirit(env.minion)
-		calcs.doActorLifeManaSpiritReservation(env.minion)
+	if actor == env.minion or actor == env.player then
+		calcs.doActorLifeManaSpirit(actor)
+		calcs.doActorLifeManaSpiritReservation(actor)
 	end
 
 	-- Block

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -750,11 +750,6 @@ function calcs.defence(env, actor)
 
 	local condList = modDB.conditions
 
-	-- Pre-calculate Life/Mana/Spirit and reservations to set conditions (like LowLife) before defences are calculated
-	-- This ensures modifiers that depend on conditions (e.g., "when on Low Life") work correctly
-	calcs.doActorLifeManaSpirit(actor, true)
-	calcs.doActorLifeManaSpiritReservation(actor)
-
 	-- Action Speed
 	output.ActionSpeedMod = calcs.actionSpeedMod(actor)
 	
@@ -1116,7 +1111,8 @@ function calcs.defence(env, actor)
 	end
 	-- Primary defences: Energy shield, evasion and armour
 	do
-		-- Life/Mana/Spirit already calculated above for conditions
+		-- Pre-calculate Life/Mana/Spirit for mods such as Beidat's hand
+		calcs.doActorLifeManaSpirit(actor, true)
 		local ward = 0
 		local energyShield = 0
 		local armour = 0

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -750,6 +750,11 @@ function calcs.defence(env, actor)
 
 	local condList = modDB.conditions
 
+	-- Pre-calculate Life/Mana/Spirit and reservations to set conditions (like LowLife) before defences are calculated
+	-- This ensures modifiers that depend on conditions (e.g., "when on Low Life") work correctly
+	calcs.doActorLifeManaSpirit(actor, true)
+	calcs.doActorLifeManaSpiritReservation(actor)
+
 	-- Action Speed
 	output.ActionSpeedMod = calcs.actionSpeedMod(actor)
 	
@@ -1111,8 +1116,7 @@ function calcs.defence(env, actor)
 	end
 	-- Primary defences: Energy shield, evasion and armour
 	do
-		-- Pre-calculate Life/Mana/Spirit for mods such as Beidat's hand
-		calcs.doActorLifeManaSpirit(actor, true)
+		-- Life/Mana/Spirit already calculated above for conditions
 		local ward = 0
 		local energyShield = 0
 		local armour = 0


### PR DESCRIPTION
Fixes # 1474.

### Description of the problem being solved:
The issue was to fix the Coward's Legacy belt lowlife modifiers not working correctly. This was wrong since it worked correctly, verified by using the Pain Atunement note that 75% Lowlife is accounted correctly with Beidat's Hand. So the thing that doesn't work is the defense's calculation of items like Starkonja's Head or Rise of the Phoenix. So I solved the problem by changing calcs.defence functions. 
### Steps taken to verify a working solution:
- Before the changes, the build is equipped with Starkonja's Head, Rise of Phoenix, and the evasion rating and fire resistance don't change when Beidat's Hand is taken, and having Coward's Legacy equipped. 
- Currently, if I take out Coward's Legacy, the lowlife effect of Starkonja's and Rise of the Phoenix doesn't affect my character
- If I unallocate Beidat's Hand, the lowlife effect will also stop working since you are not a lowlife anymore. 

### Link to a build that showcases this PR:
https://pobb.in/R8tUNGCcbxCR
### Before screenshot:
<img width="1916" height="1027" alt="image" src="https://github.com/user-attachments/assets/cbb47485-e4af-4366-81d0-d1bee55d0474" />
<img width="1552" height="1005" alt="image" src="https://github.com/user-attachments/assets/614e5c0d-27fe-427c-ab87-a5d4deeeb168" />


### After screenshot:
<img width="1692" height="1032" alt="image" src="https://github.com/user-attachments/assets/2ab50106-6ac0-445a-8406-b73b6d2408a5" />
<img width="1518" height="1030" alt="image" src="https://github.com/user-attachments/assets/19033878-4c79-433a-a627-a4371293c4a4" />

