### PR TITLE
Add support for Rageforged support gems

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -5472,7 +5472,7 @@ skills["SupportRageforgedPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_rageforged_enraged_damage_+%_final"] = {
-					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+					mod("Damage", "MORE", nil, nil, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
 				},
 			},
 			baseFlags = {
@@ -5509,7 +5509,7 @@ skills["SupportRageforgedPlayerTwo"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_rageforged_enraged_damage_+%_final"] = {
-					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+					mod("Damage", "MORE", nil, nil, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
 				},
 			},
 			baseFlags = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -5470,6 +5470,11 @@ skills["SupportRageforgedPlayer"] = {
 			label = "Rageforged I",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_rageforged_enraged_damage_+%_final"] = {
+					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -5502,6 +5507,11 @@ skills["SupportRageforgedPlayerTwo"] = {
 			label = "Rageforged II",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_rageforged_enraged_damage_+%_final"] = {
+					mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -1258,7 +1258,7 @@ statMap = {
 #set SupportRageforgedPlayer
 statMap = {
 	["support_rageforged_enraged_damage_+%_final"] = {
-		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+		mod("Damage", "MORE", nil, nil, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
 	},
 },
 #mods
@@ -1268,7 +1268,7 @@ statMap = {
 #set SupportRageforgedPlayerTwo
 statMap = {
 	["support_rageforged_enraged_damage_+%_final"] = {
-		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+		mod("Damage", "MORE", nil, nil, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
 	},
 },
 #mods

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -1256,11 +1256,21 @@ statMap = {
 
 #skill SupportRageforgedPlayer
 #set SupportRageforgedPlayer
+statMap = {
+	["support_rageforged_enraged_damage_+%_final"] = {
+		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+	},
+},
 #mods
 #skillEnd
 
 #skill SupportRageforgedPlayerTwo
 #set SupportRageforgedPlayerTwo
+statMap = {
+	["support_rageforged_enraged_damage_+%_final"] = {
+		mod("Damage", "MORE", nil, ModFlag.Hit, 0, { type = "MultiplierThreshold", var = "Rage", threshold = 10 }),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Add support for Rageforged support gems
### Steps taken to verify a working solution:
- Add a skill with Rageforged support;
- Add "Gain 1 Rage on Hit" Custom modifier (or add additional skill with rage support);
- Set Rage >= 10 in Configuration tab;

### Link to a build that showcases this PR: https://pobb.in/ZpeE9PjWglud

### Before screenshot:
<img width="708" height="192" alt="image" src="https://github.com/user-attachments/assets/b6f96dda-5525-4cca-b321-63cf382ba145" />

### After screenshot:
<img width="710" height="208" alt="image" src="https://github.com/user-attachments/assets/af113ca4-46d3-493f-a85b-f5bb2f639315" />
