### PR TITLE
Add shapeshift condition to ConfigOptions

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1200,6 +1200,9 @@ Huge sets the radius to 11.
 		modList:NewMod("Condition:StunnedRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("Condition:BeenHitRecently", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "conditionShapeshifted", type = "check", label = "Are you Shapeshifted?", ifCond = "Shapeshifted", tooltip = "You will automatically be considered to be Shapeshifted if your main skill is a shapeshifting skill (Bear, Wolf, or Wyvern form),\nbut you can use this option to force it if necessary.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "multiplierStunnedRecently", type = "count", label = "# of times Stunned Recently:", ifOption = "conditionStunnedRecently", defaultPlaceholderState = 1, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:StunnedRecently", "BASE", m_min(val, 100), "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "StunnedRecently" } )
 	end },


### PR DESCRIPTION
Conditional:Shapeshifted is not always making it downstream to calculations. Added a bypass configuration option "conditionShapeshifted" to force the shapeshifted conditional to true. Tested locally with various nodes and corroborated toggle effect on calculations sheet. Can provide screenshots if needed!