### PR TITLE
Show Sanctified text on tooltip

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1033,6 +1033,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	end
 	item.mirrored = itemData.mirrored
 	item.corrupted = itemData.corrupted
+	item.sanctified = itemData.sanctified
 	item.doubleCorrupted = itemData.doubleCorrupted
 	item.fractured = itemData.fractured
 	item.desecrated = itemData.desecrated

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -380,6 +380,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			charmBuffLines[line] = nil
 		elseif line == "--------" then
 			self.checkSection = true
+		elseif line == "Sanctified" then
+			self.sanctified = true
+			self.corruptible = false
 		elseif line == "Mirrored" then
 			self.mirrored = true
 		elseif line == "Corrupted" then
@@ -713,7 +716,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								or data.itemMods[self.base.type]
 								or data.itemMods.Item
 						self.corruptible = self.base.type ~= "Flask" and self.base.type ~= "Charm" and self.base.type ~= "Rune" and self.base.type ~= "SoulCore" and self.base.type ~= "Transcendent Limb"
-						self.clusterJewel = data.clusterJewels and data.clusterJewels.jewels[self.baseName]
 						self.requirements.str = self.base.req.str or 0
 						self.requirements.dex = self.base.req.dex or 0
 						self.requirements.int = self.base.req.int or 0
@@ -1296,6 +1298,9 @@ function ItemClass:BuildRaw()
 	end
 	if self.mirrored then
 		t_insert(rawLines, "Mirrored")
+	end
+	if self.sanctified then
+		t_insert(rawLines, "Sanctified")
 	end
 	if self.doubleCorrupted then
 		t_insert(rawLines, "Twice Corrupted")

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -403,7 +403,7 @@ holding Shift will put it in the second.]])
 		self:AnointDisplayItem(1)
 	end)
 	self.controls.displayItemAnoint.shown = function()
-		return self.displayItem and (self.displayItem.base.type == "Amulet" or self.displayItem.canBeAnointed)
+		return self.displayItem and ((self.displayItem.base.type == "Amulet" or self.displayItem.canBeAnointed) and not self.displayItem.sanctified)
 	end
 	self.controls.displayItemCorrupt = new("ButtonControl", {"TOPLEFT",self.controls.displayItemAnoint,"TOPRIGHT",true}, {8, 0, 100, 20}, "Corrupt...", function()
 		self:CorruptDisplayItem()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3055,12 +3055,15 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	end
 
 	-- Corrupted item label
-	if item.corrupted or item.mirrored or item.doubleCorrupted then
+	if item.corrupted or item.mirrored or item.doubleCorrupted or item.sanctified then
 		if #item.explicitModLines == 0 then
 			tooltip:AddSeparator(10)
 		end
 		if item.mirrored then
 			tooltip:AddLine(fontSizeBig, colorCodes.NEGATIVE.."Mirrored", "FONTIN SC")
+		end
+		if item.sanctified then
+			tooltip:AddLine(fontSizeBig, colorCodes.FRACTURED.."Sanctified", "FONTIN SC")
 		end
 		if item.doubleCorrupted then
 			tooltip:AddLine(fontSizeBig, colorCodes.NEGATIVE.."Twice Corrupted", "FONTIN SC")

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -413,10 +413,14 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 				if item.mirrored then
 					t_insert(rawLines, "Mirrored")
 				end
-				if item.corrupted then
+				if item.doubleCorrupted then
+					t_insert(rawLines, "Twice Corrupted")
+				elseif item.corrupted then
 					t_insert(rawLines, "Corrupted")
 				end
-				
+				if item.sanctified then
+					t_insert(rawLines, "Sanctified")
+				end
 
 				table.insert(items, {
 					amount = trade_entry.listing.price.amount,

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -14573,7 +14573,7 @@ return {
 		},
 		[25]={
 			list=false,
-			name="AnnointOnly",
+			name="AnointOnly",
 			refTo="",
 			type="Bool",
 			width=50


### PR DESCRIPTION
Fixes #1757 by hiding the anoint button when the amulet is sanctified.

### Description of the problem being solved:
Items with a sanctified mod show Sanctified text now. Not sure when that changed, pretty sure it didn't before. They also cannot be corrupted. Which makes me wonder if we should be setting not corruptible for mirrored items too?

### After screenshot:
<img width="585" height="675" alt="image" src="https://github.com/user-attachments/assets/e8db0ae7-6a70-4cd1-9806-15f07c823503" />
