### PR TITLE
Added Essences to Add Modifier option when crafting Two Handed Maces

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2604,7 +2604,12 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			end)
 		elseif sourceId == "ESSENCE" then
 			for _, essence in pairs(self.build.data.essences) do
-				local modId = essence.mods[self.displayItem.type]
+				local modId
+				if self.displayItem.type == "Two Handed Mace" then
+					modId = essence.mods["Two Hand Mace"]
+				else
+					modId = essence.mods[self.displayItem.type]
+				end
 				if modId then
 					local mod = self.displayItem.affixes[modId] or data.itemMods.Exclusive[modId]
 					if mod then -- passive_hash mods don't get described


### PR DESCRIPTION
Fixes #1733 

### Description of the problem being solved:
The issue comes from different wording regarding the Two Handed Maces:
In `maces.lua` the type is `"Two Handed Mace"`, in `essences.lua` it is `"Two Hand Mace"`, but both files are automatically generated and cant be edited. So i added a bit of code in` ItemsTab.lua` to change type to `"Two Hand Mace"` to display the essences.

<img width="720" height="386" alt="image" src="https://github.com/user-attachments/assets/21d94c6e-f557-49d2-a584-53147d3868fd" />


