### PR TITLE
DPS calculation for Storm-spells and other similar skills

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -17,6 +17,26 @@ return {
 	skill("durationSecondary", nil),
 	div = 1000,
 },
+["fire_storm_fireball_delay_ms"] = {
+	skill("hitTimeOverride", nil),
+	div = 1000,
+},
+["lightning_storm_hit_prevention_duration_ms"] = {
+	skill("maxHitRate", nil),
+	div = 1000,
+},
+["rain_of_arrows_delay_per_arrow"] = {
+	skill("hitTimeOverride", nil),
+	div = 1000,
+},
+["lightning_storm_hit_frequency_ms"] = {
+	skill("hitTimeOverride", nil),
+	div = 1000,
+},
+["rain_hit_delay_ms"] = {
+	skill("maxHitRate", nil),
+	div = 1000,
+},
 ["base_tertiary_skill_effect_duration"] = {
 	skill("durationTertiary", nil),
 	div = 1000,

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2708,7 +2708,7 @@ function calcs.offence(env, actor, activeSkill)
 				output.Cooldown = globalOutput.Cooldown
 				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
 			end
-			if output.Cooldown and skillFlags.selfCast then
+			if (output.Cooldown and skillFlags.selfCast) or (skillFlags.duration and skillFlags.duration) then
 				skillFlags.notAverage = true
 				skillFlags.showAverage = false
 				skillData.showAverage = false
@@ -2830,7 +2830,12 @@ function calcs.offence(env, actor, activeSkill)
 			end
 
 		end
+		
 		if skillData.hitTimeOverride and not skillData.triggeredOnDeath then
+			--checks if skill has a max hit rate per enemy and adjust hitTimeOverride
+			if skillData.maxHitRate and skillData.hitTimeOverride < skillData.maxHitRate then
+				skillData.hitTimeOverride = skillData.maxHitRate
+			end
 			output.HitTime = skillData.hitTimeOverride
 			output.HitSpeed = 1 / output.HitTime
 			--Brands always have hitTimeOverride

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2708,7 +2708,7 @@ function calcs.offence(env, actor, activeSkill)
 				output.Cooldown = globalOutput.Cooldown
 				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
 			end
-			if (output.Cooldown and skillFlags.selfCast) or (skillFlags.duration and skillFlags.duration) then
+			if (output.Cooldown and skillFlags.selfCast) or (SkillType.Sustained) then
 				skillFlags.notAverage = true
 				skillFlags.showAverage = false
 				skillData.showAverage = false


### PR DESCRIPTION
Fixes #1740 

### Description of the problem being solved:
Damage calculations dont account for `hits enemies every x seconds` and `can hit enemies only once every y seconds `. [Thunderstorm](https://poe2db.tw/us/Thunderstorm) has a higher `hit rate` than `max hit rate per target` and it seems to work fine.

### Before:
<img width="235" height="434" alt="image" src="https://github.com/user-attachments/assets/83aef7e8-9bdc-4a85-830e-faad96e4d319" />

### After:
<img width="411" height="493" alt="image" src="https://github.com/user-attachments/assets/42632f1e-bfd4-42db-8239-29c71facfb8d" />




