### PR TITLE
Added support for the Decompose Poison Cloud

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4801,10 +4801,20 @@ skills["CorpseCloudPlayer"] = {
 			incrementalEffectiveness = 0.12999999523163,
 			damageIncrementalEffectiveness = 0.0096000004559755,
 			statDescriptionScope = "corpse_cloud_statset_0",
+			statMap = {
+				["corpse_explosion_monster_life_permillage_chaos"] = {
+					skill("corpseExplosionLifeMultiplier", nil),
+					div = 1000,
+				},
+			},
 			baseFlags = {
-				spell = true,
 				area = true,
 				duration = true,
+			},
+			baseMods = {
+				mod("PoisonChance", "BASE", 100),
+				skill("explodeCorpse", true),
+				skill("corpseExplosionDamageType", "Chaos"),
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 16 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -329,7 +329,16 @@ statMap = {
 #from item
 #skill CorpseCloudPlayer
 #set CorpseCloudPlayer
-#flags spell area duration
+#flags area duration
+#baseMod mod("PoisonChance", "BASE", 100)
+#baseMod skill("explodeCorpse", true)
+#baseMod skill("corpseExplosionDamageType", "Chaos")
+statMap = {
+	["corpse_explosion_monster_life_permillage_chaos"] = {
+		skill("corpseExplosionLifeMultiplier", nil),
+		div = 1000,
+	},
+},
 #mods
 #set CorpseCloudExplosionPlayer
 #flags spell area


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/1407

### Description of the problem being solved:
The poison cloud from decompose only displays hit dps and no poison dps even though the skill does not hit and instead poisons. This fix makes it so it always poisons based of enemy corpse life in the configuration. 

### After screenshot:
Naked character with no passives
<img width="240" height="219" alt="image" src="https://github.com/user-attachments/assets/66d2cd96-d01c-4b28-bd5b-a092bd39d66c" />

Pathfinder with some poison, chaos nodes and poison supports. Corpse life set to 50k
<img width="238" height="220" alt="image" src="https://github.com/user-attachments/assets/23a375df-7aa3-499e-9b2d-bb1027e27362" />
