### PR TITLE
Fixed Rage Regeneration not applying the more damage granted from Rage

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5886,7 +5886,7 @@ c["Regenerate 3% of maximum Life over 1 second when Stunned"]={nil,"Regenerate 3
 c["Regenerate 3% of maximum Life over 1 second when Stunned +1 to Stun Threshold per Dexterity"]={nil,"Regenerate 3% of maximum Life over 1 second when Stunned +1 to Stun Threshold per Dexterity "}
 c["Regenerate 3% of maximum Life per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=3}},nil}
 c["Regenerate 3% of maximum Life per second while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=3}},nil}
-c["Regenerate 5 Rage per second"]={{[1]={flags=0,keywordFlags=0,name="RageRegen",type="BASE",value=5}},nil}
+c["Regenerate 5 Rage per second"]={{[1]={flags=0,keywordFlags=0,name="RageRegen",type="BASE",value=5},[2]={flags=0,keywordFlags=0,name="Condition:CanGainRage",type="FLAG",value=true}},nil}
 c["Regenerate 5% of maximum Life over 1 second when Stunned"]={nil,"Regenerate 5% of maximum Life over 1 second when Stunned "}
 c["Regenerate 5% of maximum Life per second while Surrounded"]={{[1]={[1]={type="Condition",var="Surrounded"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=5}},nil}
 c["Regenerate 6% of your maximum Rage per second"]={{[1]={flags=0,keywordFlags=0,name="RageRegenPercent",type="BASE",value=6}},nil}

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4732,6 +4732,13 @@ skills["EternalRagePlayer"] = {
 			label = "Eternal Rage",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "eternal_rage",
+			statMap = {
+				["ceaseless_rage_base_rage_regeneration_per_minute"] = {
+			        mod("RageRegen", "BASE", nil, 0, 0, {type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage"}),
+					flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" }),
+					div = 60,
+				},
+			},
 			baseFlags = {
 			},
 			stats = {

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4734,7 +4734,7 @@ skills["EternalRagePlayer"] = {
 			statDescriptionScope = "eternal_rage",
 			statMap = {
 				["ceaseless_rage_base_rage_regeneration_per_minute"] = {
-			        mod("RageRegen", "BASE", nil, 0, 0, {type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage"}),
+					mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage" }),
 					flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" }),
 					div = 60,
 				},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -334,7 +334,7 @@ statMap = {
 #flags
 statMap = {
 	["ceaseless_rage_base_rage_regeneration_per_minute"] = {
-        mod("RageRegen", "BASE", nil, 0, 0, {type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage"}),
+		mod("RageRegen", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage" }),
 		flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" }),
 		div = 60,
 	},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -332,6 +332,13 @@ statMap = {
 #skill EternalRagePlayer
 #set EternalRagePlayer
 #flags
+statMap = {
+	["ceaseless_rage_base_rage_regeneration_per_minute"] = {
+        mod("RageRegen", "BASE", nil, 0, 0, {type = "GlobalEffect", effectType = "Buff", effectName = "EternalRage"}),
+		flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" }),
+		div = 60,
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5624,6 +5624,10 @@ local specialModList = {
 		mod("RageRegen", "BASE", num, {type = "PercentStat", stat = "LifeRegen", percent = tonumber(num/div*100) }),
 		flag("Condition:CanGainRage"),
 	} end,
+	["regenerate (%d+) rage per second"] = function(num) return {
+		mod("RageRegen", "BASE", num),
+		flag("Condition:CanGainRage"),
+	} end,
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },
 	["with a murderous eye jewel socketed, melee attacks grant (%d+) rage on hit, no more than once every second"] = { flag("Condition:CanGainRage", { type = "Condition", var = "HaveMurderousEyeJewelIn{SlotName}" }) },
 	["gain %d+ rage after spending a total of %d+ mana"] = { flag("Condition:CanGainRage") },


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding-PoE2/issues/1692. Fixes #1760

### Description of the problem being solved:
Currently when u add death articulated it would correctly show the added rage regeneration but fail to apply the actual damage from rage. Eternal rage wasn't supported yet so it wasn't giving any rage regeneration in the first place. 

### Before screenshots:
Death Articulated + Rage set to 30:
<img width="242" height="136" alt="image" src="https://github.com/user-attachments/assets/6e3b7a9e-84da-4513-b8b9-87f1cc9893e8" />

Eternal Rage:
<img width="435" height="288" alt="image" src="https://github.com/user-attachments/assets/5f7d1a02-6b23-4aef-a46f-add2fb8838ee" />

### After screenshots:
Death Articulated + Rage set to 30:
<img width="238" height="145" alt="image" src="https://github.com/user-attachments/assets/153a951a-30b7-4622-8339-60687cd6d5cf" />

Eternal Rage:
<img width="1195" height="293" alt="image" src="https://github.com/user-attachments/assets/5306f994-05c5-437e-804b-961982daffbf" />

