### PR TITLE
Fix offhand unequip during node power process with Giant's Blood

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -781,14 +781,17 @@ function calcs.initEnv(build, mode, override, specEnv)
 		instrumentsOfPower = nodesModsList:Flag(nil, "InstrumentsOfPower") or false,
 		lordOfTheWilds = nodesModsList:Flag(nil, "LordOfTheWilds") or false,
 	}
-	local cache = build.itemsTab.lastWeaponFlagState
-	local losingGiantsBlood = cache and cache.giantsBlood and not weaponFlagState.giantsBlood
-	local losingInstrumentsOfPower = cache and cache.instrumentsOfPower and not weaponFlagState.instrumentsOfPower
-	local losingLordOfTheWilds = cache and cache.lordOfTheWilds and not weaponFlagState.lordOfTheWilds
-	if losingGiantsBlood or losingInstrumentsOfPower or losingLordOfTheWilds then -- Only validate socket when losing Keystone / Ascendancy
-		build.itemsTab:ValidateWeaponSlots(weaponFlagState)
+	-- Only mutate equipped items in the real build pass; calculator overrides (e.g. node power) are transient.
+	if mode == "MAIN" then
+		local cache = build.itemsTab.lastWeaponFlagState
+		local losingGiantsBlood = cache and cache.giantsBlood and not weaponFlagState.giantsBlood
+		local losingInstrumentsOfPower = cache and cache.instrumentsOfPower and not weaponFlagState.instrumentsOfPower
+		local losingLordOfTheWilds = cache and cache.lordOfTheWilds and not weaponFlagState.lordOfTheWilds
+		if losingGiantsBlood or losingInstrumentsOfPower or losingLordOfTheWilds then -- Only validate socket when losing Keystone / Ascendancy
+			build.itemsTab:ValidateWeaponSlots(weaponFlagState)
+		end
+		build.itemsTab.lastWeaponFlagState = { giantsBlood = weaponFlagState.giantsBlood, instrumentsOfPower = weaponFlagState.instrumentsOfPower, lordOfTheWilds = weaponFlagState.lordOfTheWilds }
 	end
-	build.itemsTab.lastWeaponFlagState = { giantsBlood = weaponFlagState.giantsBlood, instrumentsOfPower = weaponFlagState.instrumentsOfPower, lordOfTheWilds = weaponFlagState.lordOfTheWilds }
 
 	-- Build and merge item modifiers, and create list of radius jewels
 	if not accelerate.requirementsItems then


### PR DESCRIPTION
Fixes #1765, Fixes #1700

### Description of the problem being solved:
When we run the node power search, it deallocates nodes to test the power of them and when it does that, it also unequips the shield in the offhand, as it believes it is an invalid item
The code to change the equip state for Giant's Blood now only runs on player-initiated gear changes

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/d44v0lpl

### Before screenshot:
<img width="525" height="404" alt="image" src="https://github.com/user-attachments/assets/0dab71f3-e4b4-4022-95ca-dbdb7bd6bfbb" />
<img width="401" height="52" alt="image" src="https://github.com/user-attachments/assets/f3e13b4e-a2d2-4189-ba8e-1973960d05d0" />


### After screenshot:
<img width="562" height="460" alt="image" src="https://github.com/user-attachments/assets/7565cf7b-0c78-4237-a01d-e6fc82c760a0" />
<img width="394" height="51" alt="image" src="https://github.com/user-attachments/assets/3fef50ac-1010-4a36-b511-1b209ba95f5c" />
