### PR TITLE
Fix variant text ordering for The Adorned and Yoke of Suffering

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -271,8 +271,8 @@ Implicits: 1
 {tags:fire,cold,lightning}+(10-15)% to all Elemental Resistances
 (15-30)% increased Elemental Damage
 {variant:1}Enemies take (5-10)% increased Damage for each Elemental Ailment type among
-{variant:2}Enemies take (15-20)% increased Damage for each Elemental Ailment type among
 {variant:1}your Ailments on them
+{variant:2}Enemies take (15-20)% increased Damage for each Elemental Ailment type among
 {variant:2}your Ailments on them
 {variant:1}(20-30)% reduced Duration of Ignite, Shock and Chill on Enemies
 {variant:2}(30-40)% reduced Duration of Ignite, Shock and Chill on Enemies

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -204,10 +204,10 @@ Variant: Current
 +(25-30)% to Cold Resistance
 +(10-15)% to Lightning Resistance
 {variant:1}Increases Movement Speed by 25%, plus 1% per 500 Evasion Rating, up to a maximum of 75%
-{variant:2}Increases Movement Speed by 25%, plus 1% per 800 Evasion Rating, up to a maximum of 75%
-{variant:3}Increases Movement Speed by 25%, plus 1% per 600 Evasion Rating, up to a maximum of 75%
 {variant:1}Other Modifiers to Movement Speed except for Sprinting do not apply
+{variant:2}Increases Movement Speed by 25%, plus 1% per 800 Evasion Rating, up to a maximum of 75%
 {variant:2}Other Modifiers to Movement Speed except for Sprinting do not apply
+{variant:3}Increases Movement Speed by 25%, plus 1% per 600 Evasion Rating, up to a maximum of 75%
 {variant:3}Other Modifiers to Movement Speed except for Sprinting do not apply
 ]],[[
 The Rat Cage
@@ -510,8 +510,8 @@ Variant: Current
 +(17-23)% to Chaos Resistance
 +(200-300) to Ailment Threshold
 {variant:1}Life that would be lost by taking Damage is instead Reserved
-{variant:2}Life that would be lost by taking Damage is instead Reserved
 {variant:1}until you take no Damage to Life for 5 seconds
+{variant:2}Life that would be lost by taking Damage is instead Reserved
 {variant:2}until you take no Damage to Life for 3 seconds
 ]],
 -- Body: Armour/Energy Shield

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -429,10 +429,10 @@ Variant: Current
 (15-25) Life Regeneration per second
 (15-25)% increased Mana Regeneration Rate
 {variant:1}Alternating every 5 seconds:
-{variant:2}Alternating every 5 seconds:
 {variant:1}Take 30% more Damage from Hits
-{variant:2}Take 40% less Damage from Hits
 {variant:1}Take 30% more Damage over time
+{variant:2}Alternating every 5 seconds:
+{variant:2}Take 40% less Damage from Hits
 {variant:2}Take 40% less Damage over time
 ]],[[
 Veil of the Night

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -10,8 +10,8 @@ Variant: Pre 0.4.0
 Variant: Current
 Limited to: 1
 {variant:1}(0-100)% increased Effect of Jewel Socket Passive Skills
-{variant:2}(0-150)% increased Effect of Jewel Socket Passive Skills
 {variant:1}containing Corrupted Magic Jewels
+{variant:2}(0-150)% increased Effect of Jewel Socket Passive Skills
 {variant:2}containing Corrupted Magic Jewels
 ]],[[
 Controlled Metamorphosis


### PR DESCRIPTION
Multi-line mod continuation lines were interleaved between variants, causing duplicate/missing lines in the variant display. Group each variant's continuation lines together with their first line.

Fixes #1774

Fixes # .

### Description of the problem being solved:
The Adorned and Yoke of Suffering have multi-line mods where the continuation lines were interleaved between variants instead of grouped with their respective variant. This caused duplicate lines to appear for one variant and missing lines for the other in the item display.

### Steps taken to verify a working solution:
- Loaded the items in PoB and switched between variants to confirm correct text displays for each

### Before screenshot:
<img width="471" height="280" alt="image" src="https://github.com/user-attachments/assets/5531a24a-a9c3-44c8-9e9c-abeb9307a926" />
<img width="565" height="282" alt="image" src="https://github.com/user-attachments/assets/c773741c-2755-4e7d-86d3-f3792c98d0b3" />

### After screenshot:
<img width="377" height="263" alt="image" src="https://github.com/user-attachments/assets/6991e28f-bfb5-45a9-aad1-b5c9b5e5dd1d" />
<img width="567" height="465" alt="image" src="https://github.com/user-attachments/assets/c0f1ba10-1c1e-4907-9b39-079c79809b73" />
