### PR TITLE
Fix Keeper of the Arc legacy mod value

### DIFF
--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -429,8 +429,8 @@ Variant: Current
 (15-25) Life Regeneration per second
 (15-25)% increased Mana Regeneration Rate
 {variant:1}Alternating every 5 seconds:
-{variant:1}Take 30% more Damage from Hits
-{variant:1}Take 30% more Damage over time
+{variant:1}Take 30% less Damage from Hits
+{variant:1}Take 30% less Damage over time
 {variant:2}Alternating every 5 seconds:
 {variant:2}Take 40% less Damage from Hits
 {variant:2}Take 40% less Damage over time

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -428,7 +428,7 @@ Variant: Current
 {variant:2}UniqueLocalIncreasedArmourAndEnergyShield17
 UniqueLifeRegeneration10
 UniqueManaRegeneration26
-{variant:1}UniqueAlternatingDamageTaken1[30,30]
+{variant:1}UniqueAlternatingDamageTaken1[-30,-30]
 {variant:2}UniqueAlternatingDamageTaken1
 ]],[[
 Veil of the Night


### PR DESCRIPTION
### Description of the problem being solved:

The legacy mod is 30 less damage, it was set as 30 more damage.