### PR TITLE
Add missing GetVirtualScreenSize stub to HeadlessWrapper

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -51,6 +51,9 @@ end
 function GetScreenScale()
 	return 1
 end
+function GetVirtualScreenSize()
+	return GetScreenSize()
+end
 function GetDPIScaleOverridePercent()
 	return 1
 end


### PR DESCRIPTION
## Summary

- `HeadlessWrapper.lua` stubs `GetScreenSize()` and `GetScreenScale()`, but not `GetVirtualScreenSize()`
- `Launch.lua` calls `GetVirtualScreenSize()` in `DrawPopup()` (line 390) and during restart (line 125)
- When running headless and an error triggers `DrawPopup` on the first `OnFrame`, this causes a crash because `GetVirtualScreenSize` is not yet defined — `Modules/Common.lua` (where it is normally defined, line 1044) hasn't loaded yet at that point
- The stub delegates to `GetScreenSize()` since `GetScreenScale()` returns 1 (no scaling) in headless mode, matching what the real implementation in `Common.lua` would produce

## Reproduction

1. Run POB2 headless via `HeadlessWrapper.lua`
2. Trigger any code path that calls `DrawPopup` before `Modules/Common.lua` is loaded (e.g., an initialization error on the first `OnFrame`)
3. Crash: `attempt to call global 'GetVirtualScreenSize' (a nil value)`

## Test plan

- [x] Verified the fix resolves the crash when running headless
- [x] Confirmed the return value matches `Common.lua`'s implementation (since `GetScreenScale()` returns 1, `GetVirtualScreenSize()` == `GetScreenSize()`)