### PR TITLE
Add support for 'Non-Channelling Spells have 3% increased Magnitude of Ailments per 100 maximum Life'

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -778,6 +778,7 @@ local modNameList = {
 	["ignite magnitude"] = { "AilmentMagnitude", keywordFlags = KeywordFlag.Ignite },
 	["magnitude of poison you inflict"] = { "AilmentMagnitude", keywordFlags = KeywordFlag.Poison },
 	["effect of poison you inflict"] = { "AilmentEffect", keywordFlags = KeywordFlag.Poison },
+	["magnitude of ailments"] = "AilmentMagnitude",
 	["magnitude of ailments you inflict"] = "AilmentMagnitude",
 	["magnitude of damaging ailments you inflict"] = { "AilmentMagnitude", keywordFlags = bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite) },
 	["effect of lightning ailments"] = "EnemyShockMagnitude",


### PR DESCRIPTION


Fixes unsupported vaal mod on Rathpith Globe .

### Description of the problem being solved:

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
