### PR TITLE
Add support for Baryanic Leylines (Disciple of Varashta)

### DIFF
--- a/spec/System/TestBaryanicLeylines_spec.lua
+++ b/spec/System/TestBaryanicLeylines_spec.lua
@@ -1,0 +1,33 @@
+describe("BaryanicLeylines", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	teardown(function()
+		-- newBuild() takes care of resetting everything in setup()
+	end)
+
+	it("parses Non-Unique Time-Lost Jewel radius modifier", function()
+		build.configTab.input.customMods = "\z
+		Non-Unique Time-Lost Jewels have 40% increased radius\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(40, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))
+	end)
+
+	it("resolveTimeLostRadiusIndex returns upgraded tier at 40% and falls back otherwise", function()
+		-- Each base tier (Small..Very Large) maps to a +40% counterpart whose outer
+		-- radius is base * 1.4 (Small 1000 -> 1400).
+		assert.are.equals(1400, data.jewelRadius[data.resolveTimeLostRadiusIndex(1, 40)].outer)
+		assert.are.equals(1610, data.jewelRadius[data.resolveTimeLostRadiusIndex(2, 40)].outer)
+		assert.are.equals(1820, data.jewelRadius[data.resolveTimeLostRadiusIndex(3, 40)].outer)
+		assert.are.equals(2100, data.jewelRadius[data.resolveTimeLostRadiusIndex(4, 40)].outer)
+
+		-- No upgrade tier exists below 40%, so the base index is returned unchanged.
+		assert.are.equals(1, data.resolveTimeLostRadiusIndex(1, 0))
+		assert.are.equals(1, data.resolveTimeLostRadiusIndex(1, 39))
+		assert.are.equals(1, data.resolveTimeLostRadiusIndex(1, nil))
+	end)
+end)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3460,7 +3460,16 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 			tooltip:AddLine(fontSizeBig, "^x7F7F7FRequires Class "..(self.build.spec.curClassName == item.classRestriction and colorCodes.POSITIVE or colorCodes.NEGATIVE)..item.classRestriction, "FONTIN SC")
 		end
 		if item.jewelRadiusLabel then
-			tooltip:AddLine(fontSizeBig, "^x7F7F7FRadius: ^7"..item.jewelRadiusLabel, "FONTIN SC")
+			local radiusLine = "^x7F7F7FRadius: ^7"..item.jewelRadiusLabel
+			if item.base and item.base.subType == "Radius"
+				and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+				and self.build.calcsTab and self.build.calcsTab.mainEnv and self.build.calcsTab.mainEnv.modDB then
+				local upgradePct = self.build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius")
+				if upgradePct > 0 then
+					radiusLine = radiusLine .. " ^x7F7F7F(+"..upgradePct.."% from tree)"
+				end
+			end
+			tooltip:AddLine(fontSizeBig, radiusLine, "FONTIN SC")
 		end
 		if item.jewelRadiusData and slot and item.jewelRadiusData[slot.nodeId] then
 			local radiusData = item.jewelRadiusData[slot.nodeId]

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2979,7 +2979,16 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			tooltip:AddLine(fontSizeBig, "^x7F7F7FRequires Class "..(self.build.spec.curClassName == item.classRestriction and colorCodes.POSITIVE or colorCodes.NEGATIVE)..item.classRestriction, "FONTIN SC")
 		end
 		if item.jewelRadiusLabel then
-			tooltip:AddLine(fontSizeBig, "^x7F7F7FRadius: ^7"..item.jewelRadiusLabel, "FONTIN SC")
+			local radiusLine = "^x7F7F7FRadius: ^7"..item.jewelRadiusLabel
+			if item.base and item.base.subType == "Radius"
+				and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+				and self.build.calcsTab and self.build.calcsTab.mainEnv and self.build.calcsTab.mainEnv.modDB then
+				local upgradePct = self.build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius")
+				if upgradePct > 0 then
+					radiusLine = radiusLine .. " ^x7F7F7F(+"..upgradePct.."% from tree)"
+				end
+			end
+			tooltip:AddLine(fontSizeBig, radiusLine, "FONTIN SC")
 		end
 		if item.jewelRadiusData and slot and item.jewelRadiusData[slot.nodeId] then
 			local radiusData = item.jewelRadiusData[slot.nodeId]

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1222,10 +1222,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 	-- Draw ring overlays for jewel sockets
 	local function drawJewelRadius(jewel, scrX, scrY, tint)
-		local effectiveRadiusIndex = jewel.jewelRadiusIndex
 		-- (check for Time-Lost upgrades such as Baryanic Leylines) --
 		local effectiveRadiusIndex = jewel.jewelRadiusIndex
-		if effectiveRadiusIndex  and jewel.base and jewel.base.subType == "Radius"
+		if effectiveRadiusIndex and jewel.base and jewel.base.subType == "Radius"
 			and jewel.rarity ~= "UNIQUE" and jewel.rarity ~= "RELIC"
 			and build.calcsTab and build.calcsTab.mainEnv and build.calcsTab.mainEnv.modDB then
 			effectiveRadiusIndex = data.resolveTimeLostRadiusIndex(effectiveRadiusIndex, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1806,20 +1806,24 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	-- essentially trying to avoid calling ProcessStats for a Normal/Notable node that can't possibly be affected
 	-- loops potentially every socket (24) until itemsTab is loaded or a jewel socket is hovered, then it will only loop the allocated sockets
 	-- Radius indexes to probe: Very Large (4) plus any Time-Lost upgrade tiers (e.g. Baryanic Leylines'
-	-- "Very Large +40%" at 16) so nodes only reachable via an increased radius still show jewel mods.
+	-- "Very Large +40%" at 16) that the current build actually has access to.
 	local radiusProbeIndexes = { 4 }
-	if data.nonUniqueTimeLostJewelRadiusUpgrades then
-		for _, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
-			for _, upgradedIndex in pairs(map) do
-				local seen = false
-				for _, existing in ipairs(radiusProbeIndexes) do
-					if existing == upgradedIndex then
-						seen = true
-						break
+	local timeLostRadiusUpgrade = build.calcsTab and build.calcsTab.mainEnv and build.calcsTab.mainEnv.modDB
+		and build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius") or 0
+	if timeLostRadiusUpgrade > 0 and data.nonUniqueTimeLostJewelRadiusUpgrades then
+		for pct, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+			if pct <= timeLostRadiusUpgrade then
+				for _, upgradedIndex in pairs(map) do
+					local seen = false
+					for _, existing in ipairs(radiusProbeIndexes) do
+						if existing == upgradedIndex then
+							seen = true
+							break
+						end
 					end
-				end
-				if not seen then
-					t_insert(radiusProbeIndexes, upgradedIndex)
+					if not seen then
+						t_insert(radiusProbeIndexes, upgradedIndex)
+					end
 				end
 			end
 		end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1222,7 +1222,15 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 	-- Draw ring overlays for jewel sockets
 	local function drawJewelRadius(jewel, scrX, scrY, tint)
-		local radData = build.data.jewelRadius[jewel.jewelRadiusIndex]
+		local effectiveRadiusIndex = jewel.jewelRadiusIndex
+		-- (check for Time-Lost upgrades such as Baryanic Leylines) --
+		local effectiveRadiusIndex = jewel.jewelRadiusIndex
+		if effectiveRadiusIndex  and jewel.base and jewel.base.subType == "Radius"
+			and jewel.rarity ~= "UNIQUE" and jewel.rarity ~= "RELIC"
+			and build.calcsTab and build.calcsTab.mainEnv and build.calcsTab.mainEnv.modDB then
+			effectiveRadiusIndex = data.resolveTimeLostRadiusIndex(effectiveRadiusIndex, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))
+		end
+		local radData = build.data.jewelRadius[effectiveRadiusIndex]
 		local outerSize = radData.outer * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale
 		local innerSize = radData.inner * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale * 1.06
 		SetDrawColor(tint[1], tint[2], tint[3], tint[4])
@@ -1259,6 +1267,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			self:DrawImageRotated(self.jewelShadedInnerRingFlipped, scrX, scrY, innerSize * 2, innerSize * 2, 0.7)
 		end
 	end
+
 	SetDrawLayer(nil, 25)
 	for nodeId in pairs(tree.sockets) do
 		local node = spec.nodes[nodeId]
@@ -1796,11 +1805,38 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	-- we only want to run the timeLost function on a node that can could be in a jewel socket radius of up to Large
 	-- essentially trying to avoid calling ProcessStats for a Normal/Notable node that can't possibly be affected
 	-- loops potentially every socket (24) until itemsTab is loaded or a jewel socket is hovered, then it will only loop the allocated sockets
+	-- Radius indexes to probe: Very Large (4) plus any Time-Lost upgrade tiers (e.g. Baryanic Leylines'
+	-- "Very Large +40%" at 16) so nodes only reachable via an increased radius still show jewel mods.
+	local radiusProbeIndexes = { 4 }
+	if data.nonUniqueTimeLostJewelRadiusUpgrades then
+		for _, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+			for _, upgradedIndex in pairs(map) do
+				local seen = false
+				for _, existing in ipairs(radiusProbeIndexes) do
+					if existing == upgradedIndex then
+						seen = true
+						break
+					end
+				end
+				if not seen then
+					t_insert(radiusProbeIndexes, upgradedIndex)
+				end
+			end
+		end
+	end
 	local function isNodeInARadius(node)
 		local isInRadius = false
 		for id, socket in pairs(build.itemsTab.sockets) do
 			if build.itemsTab.activeSocketList and socket.inactive == false or socket.inactive == nil then
-				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[4][node.id] ~= nil)
+				local socketNode = build.spec.nodes[id]
+				if socketNode and socketNode.nodesInRadius then
+					for _, radiusIndex in ipairs(radiusProbeIndexes) do
+						if socketNode.nodesInRadius[radiusIndex] and socketNode.nodesInRadius[radiusIndex][node.id] ~= nil then
+							isInRadius = true
+							break
+						end
+					end
+				end
 				if isInRadius then break end
 			end
 		end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1013,8 +1013,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				end
 			elseif node.alloc then
 				if jewel and jewel.jewelRadiusIndex then
-					-- Draw only the selected jewel radius
-					local radData = build.data.jewelRadius[jewel.jewelRadiusIndex]
+					-- Draw only the selected jewel radius (factoring in Time-Lost upgrades such as Baryanic Leylines)
+					local effectiveRadiusIndex = jewel.jewelRadiusIndex
+					if jewel.base and jewel.base.subType == "Radius"
+						and jewel.rarity ~= "UNIQUE" and jewel.rarity ~= "RELIC"
+						and build.calcsTab and build.calcsTab.mainEnv and build.calcsTab.mainEnv.modDB then
+						effectiveRadiusIndex = data.resolveTimeLostRadiusIndex(effectiveRadiusIndex, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))
+					end
+					local radData = build.data.jewelRadius[effectiveRadiusIndex]
 					local outerSize = radData.outer * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale
 					local innerSize = radData.inner * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale * 1.06
 					SetDrawColor(1,1,1,0.7)
@@ -1505,11 +1511,38 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	-- we only want to run the timeLost function on a node that can could be in a jewel socket radius of up to Large
 	-- essentially trying to avoid calling ProcessStats for a Normal/Notable node that can't possibly be affected
 	-- loops potentially every socket (24) until itemsTab is loaded or a jewel socket is hovered, then it will only loop the allocated sockets
-	local function isNodeInARadius(node) 
+	-- Radius indexes to probe: Very Large (4) plus any Time-Lost upgrade tiers (e.g. Baryanic Leylines'
+	-- "Very Large +40%" at 16) so nodes only reachable via an increased radius still show jewel mods.
+	local radiusProbeIndexes = { 4 }
+	if data.nonUniqueTimeLostJewelRadiusUpgrades then
+		for _, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+			for _, upgradedIndex in pairs(map) do
+				local seen = false
+				for _, existing in ipairs(radiusProbeIndexes) do
+					if existing == upgradedIndex then
+						seen = true
+						break
+					end
+				end
+				if not seen then
+					t_insert(radiusProbeIndexes, upgradedIndex)
+				end
+			end
+		end
+	end
+	local function isNodeInARadius(node)
 		local isInRadius = false
 		for id, socket in pairs(build.itemsTab.sockets) do
 			if build.itemsTab.activeSocketList and socket.inactive == false or socket.inactive == nil then
-				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[4][node.id] ~= nil)
+				local socketNode = build.spec.nodes[id]
+				if socketNode and socketNode.nodesInRadius then
+					for _, radiusIndex in ipairs(radiusProbeIndexes) do
+						if socketNode.nodesInRadius[radiusIndex] and socketNode.nodesInRadius[radiusIndex][node.id] ~= nil then
+							isInRadius = true
+							break
+						end
+					end
+				end
 				if isInRadius then break end
 			end
 		end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1512,20 +1512,24 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 	-- essentially trying to avoid calling ProcessStats for a Normal/Notable node that can't possibly be affected
 	-- loops potentially every socket (24) until itemsTab is loaded or a jewel socket is hovered, then it will only loop the allocated sockets
 	-- Radius indexes to probe: Very Large (4) plus any Time-Lost upgrade tiers (e.g. Baryanic Leylines'
-	-- "Very Large +40%" at 16) so nodes only reachable via an increased radius still show jewel mods.
+	-- "Very Large +40%" at 16) that the current build actually has access to.
 	local radiusProbeIndexes = { 4 }
-	if data.nonUniqueTimeLostJewelRadiusUpgrades then
-		for _, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
-			for _, upgradedIndex in pairs(map) do
-				local seen = false
-				for _, existing in ipairs(radiusProbeIndexes) do
-					if existing == upgradedIndex then
-						seen = true
-						break
+	local timeLostRadiusUpgrade = build.calcsTab and build.calcsTab.mainEnv and build.calcsTab.mainEnv.modDB
+		and build.calcsTab.mainEnv.modDB:Sum("INC", nil, "NonUniqueTimeLostJewelRadius") or 0
+	if timeLostRadiusUpgrade > 0 and data.nonUniqueTimeLostJewelRadiusUpgrades then
+		for pct, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+			if pct <= timeLostRadiusUpgrade then
+				for _, upgradedIndex in pairs(map) do
+					local seen = false
+					for _, existing in ipairs(radiusProbeIndexes) do
+						if existing == upgradedIndex then
+							seen = true
+							break
+						end
 					end
-				end
-				if not seen then
-					t_insert(radiusProbeIndexes, upgradedIndex)
+					if not seen then
+						t_insert(radiusProbeIndexes, upgradedIndex)
+					end
 				end
 			end
 		end

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6348,11 +6348,11 @@ c["Non-Unique Time-Lost Jewels have 40% increased radius"]={{[1]={flags=0,keywor
 c["Oasis"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Oasis"}},nil}
 c["Off-hand Hits inflict Runefather's Challenge"]={nil,"Off-hand Hits inflict Runefather's Challenge "}
 c["Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds"]={nil,"Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds "}
-c["Offering Skills have 15% increased Buff effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=15}},nil}
-c["Offering Skills have 20% increased Area of Effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=20}},nil}
-c["Offering Skills have 20% increased Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
-c["Offering Skills have 30% increased Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=30}},nil}
-c["Offering Skills have 30% reduced Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=-30}},nil}
+c["Offering Skills have 15% increased Buff effect"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=15}},nil}
+c["Offering Skills have 20% increased Area of Effect"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=20}},nil}
+c["Offering Skills have 20% increased Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
+c["Offering Skills have 30% increased Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=30}},nil}
+c["Offering Skills have 30% reduced Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=-30}},nil}
 c["Offerings cannot be damaged if they have been created Recently"]={nil,"Offerings cannot be damaged if they have been created Recently "}
 c["Offerings created by Culling Enemies have 1% increased Effect per Power of Culled Enemy"]={{[1]={flags=0,keywordFlags=0,name="UnwillingOffering",type="FLAG",value=true},[2]={[1]={skillNameList={[1]="Bone Offering",[2]="Pain Offering",[3]="Soul Offering"},type="SkillName"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={[1]={limit=20,type="Multiplier",var="UnwillingOfferingPower"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=1}}}},nil}
 c["Offerings have 15% increased Maximum Life"]={nil,"Offerings have 15% increased Maximum Life "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6344,15 +6344,15 @@ c["Non-Keystone Passive Skills in Medium Radius of allocated Keystone Passive Sk
 c["Non-Minion Skills have 50% less Reservation Efficiency"]={{[1]={[1]={neg=true,skillType=6,type="SkillType"},flags=0,keywordFlags=0,name="ReservationEfficiency",type="MORE",value=-50}},nil}
 c["Non-Unique Life Flasks apply their Effects constantly"]={nil,"Non-Unique Life Flasks apply their Effects constantly "}
 c["Non-Unique Life Flasks apply their Effects constantly Recovery from Life Flasks cannot be Instant"]={nil,"Non-Unique Life Flasks apply their Effects constantly Recovery from Life Flasks cannot be Instant "}
-c["Non-Unique Time-Lost Jewels have 40% increased radius"]={nil,"Non-Unique Time-Lost Jewels have 40% increased radius "}
+c["Non-Unique Time-Lost Jewels have 40% increased radius"]={{[1]={flags=0,keywordFlags=0,name="NonUniqueTimeLostJewelRadius",type="INC",value=40}},nil}
 c["Oasis"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Oasis"}},nil}
 c["Off-hand Hits inflict Runefather's Challenge"]={nil,"Off-hand Hits inflict Runefather's Challenge "}
 c["Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds"]={nil,"Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds "}
-c["Offering Skills have 15% increased Buff effect"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=15}},nil}
-c["Offering Skills have 20% increased Area of Effect"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=20}},nil}
-c["Offering Skills have 20% increased Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
-c["Offering Skills have 30% increased Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=30}},nil}
-c["Offering Skills have 30% reduced Duration"]={{[1]={[1]={skillType=155,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=-30}},nil}
+c["Offering Skills have 15% increased Buff effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=15}},nil}
+c["Offering Skills have 20% increased Area of Effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=20}},nil}
+c["Offering Skills have 20% increased Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
+c["Offering Skills have 30% increased Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=30}},nil}
+c["Offering Skills have 30% reduced Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=-30}},nil}
 c["Offerings cannot be damaged if they have been created Recently"]={nil,"Offerings cannot be damaged if they have been created Recently "}
 c["Offerings created by Culling Enemies have 1% increased Effect per Power of Culled Enemy"]={{[1]={flags=0,keywordFlags=0,name="UnwillingOffering",type="FLAG",value=true},[2]={[1]={skillNameList={[1]="Bone Offering",[2]="Pain Offering",[3]="Soul Offering"},type="SkillName"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={[1]={limit=20,type="Multiplier",var="UnwillingOfferingPower"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=1}}}},nil}
 c["Offerings have 15% increased Maximum Life"]={nil,"Offerings have 15% increased Maximum Life "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5665,7 +5665,7 @@ c["Non-Channelling Spells have 3% increased Critical Hit Chance per 100 maximum 
 c["Non-Channelling Spells have 5% increased Critical Hit Chance per 100 maximum Life"]={{[1]={[1]={neg=true,skillType=48,type="SkillType"},[2]={div=100,stat="Life",type="PerStat"},flags=2,keywordFlags=0,name="CritChance",type="INC",value=5}},nil}
 c["Non-Keystone Passive Skills in Medium Radius of allocated Keystone Passive Skills can be allocated without being connected to your tree"]={{[1]={flags=0,keywordFlags=0,name="AllocateFromNodeRadius",type="LIST",value={from="Keystone",radiusIndex=2,to={[1]="Notable",[2]="Normal"}}}},nil}
 c["Non-Minion Skills have 50% less Reservation Efficiency"]={{[1]={[1]={neg=true,skillType=6,type="SkillType"},flags=0,keywordFlags=0,name="ReservationEfficiency",type="MORE",value=-50}},nil}
-c["Non-Unique Time-Lost Jewels have 40% increased radius"]={nil,"Non-Unique Time-Lost Jewels have 40% increased radius "}
+c["Non-Unique Time-Lost Jewels have 40% increased radius"]={{[1]={flags=0,keywordFlags=0,name="NonUniqueTimeLostJewelRadius",type="INC",value=40}},nil}
 c["Offering Skills have 15% increased Buff effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="BuffEffect",type="INC",value=15}},nil}
 c["Offering Skills have 20% increased Area of Effect"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=20}},nil}
 c["Offering Skills have 20% increased Duration"]={{[1]={[1]={skillType=154,type="SkillType"},flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -890,6 +890,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 					end
 					if item and ( item.jewelRadiusIndex or (override and override.extraJewelFuncs and #override.extraJewelFuncs > 0) ) then
+						-- Non-unique Time-Lost Jewels use an upgraded radius tier when the build
+						-- has e.g. Baryanic Leylines allocated.
+						local effectiveRadiusIndex = item.jewelRadiusIndex
+						if effectiveRadiusIndex and item.base and item.base.subType == "Radius"
+							and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC" then
+							effectiveRadiusIndex = data.resolveTimeLostRadiusIndex(effectiveRadiusIndex, nodesModsList:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))
+						end
 						-- Jewel has a radius, add it to the list
 						local funcList = (item.jewelData and item.jewelData.funcList) or { { type = "Self", func = function(node, out, data)
 							-- Default function just tallies all stats in radius
@@ -902,19 +909,19 @@ function calcs.initEnv(build, mode, override, specEnv)
 						for _, func in ipairs(funcList) do
 							local node = env.spec.nodes[slot.nodeId]
 							t_insert(env.radiusJewelList, {
-								nodes = node.nodesInRadius and node.nodesInRadius[item.jewelRadiusIndex] or { },
+								nodes = node.nodesInRadius and node.nodesInRadius[effectiveRadiusIndex] or { },
 								func = func.func,
 								type = func.type,
 								item = item,
 								nodeId = slot.nodeId,
-								attributes = node.attributesInRadius and node.attributesInRadius[item.jewelRadiusIndex] or { },
+								attributes = node.attributesInRadius and node.attributesInRadius[effectiveRadiusIndex] or { },
 								data = { },
 								-- store this to compare with cache later
 								jewelHash = getHashFromString(item.modSource..item.raw)
 							})
 							if func.type ~= "Self" and node.nodesInRadius then
 								-- Add nearby unallocated nodes to the extra node list
-								for nodeId, node in pairs(node.nodesInRadius[item.jewelRadiusIndex]) do
+								for nodeId, node in pairs(node.nodesInRadius[effectiveRadiusIndex]) do
 									if not env.allocNodes[nodeId] then
 										env.extraRadiusNodeList[nodeId] = env.spec.nodes[nodeId]
 									end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -868,6 +868,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 					end
 					if item and ( item.jewelRadiusIndex or (override and override.extraJewelFuncs and #override.extraJewelFuncs > 0) ) then
+						-- Non-unique Time-Lost Jewels use an upgraded radius tier when the build
+						-- has e.g. Baryanic Leylines allocated.
+						local effectiveRadiusIndex = item.jewelRadiusIndex
+						if effectiveRadiusIndex and item.base and item.base.subType == "Radius"
+							and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC" then
+							effectiveRadiusIndex = data.resolveTimeLostRadiusIndex(effectiveRadiusIndex, nodesModsList:Sum("INC", nil, "NonUniqueTimeLostJewelRadius"))
+						end
 						-- Jewel has a radius, add it to the list
 						local funcList = (item.jewelData and item.jewelData.funcList) or { { type = "Self", func = function(node, out, data)
 							-- Default function just tallies all stats in radius
@@ -880,19 +887,19 @@ function calcs.initEnv(build, mode, override, specEnv)
 						for _, func in ipairs(funcList) do
 							local node = env.spec.nodes[slot.nodeId]
 							t_insert(env.radiusJewelList, {
-								nodes = node.nodesInRadius and node.nodesInRadius[item.jewelRadiusIndex] or { },
+								nodes = node.nodesInRadius and node.nodesInRadius[effectiveRadiusIndex] or { },
 								func = func.func,
 								type = func.type,
 								item = item,
 								nodeId = slot.nodeId,
-								attributes = node.attributesInRadius and node.attributesInRadius[item.jewelRadiusIndex] or { },
+								attributes = node.attributesInRadius and node.attributesInRadius[effectiveRadiusIndex] or { },
 								data = { },
 								-- store this to compare with cache later
 								jewelHash = getHashFromString(item.modSource..item.raw)
 							})
 							if func.type ~= "Self" and node.nodesInRadius then
 								-- Add nearby unallocated nodes to the extra node list
-								for nodeId, node in pairs(node.nodesInRadius[item.jewelRadiusIndex]) do
+								for nodeId, node in pairs(node.nodesInRadius[effectiveRadiusIndex]) do
 									if not env.allocNodes[nodeId] then
 										env.extraRadiusNodeList[nodeId] = env.spec.nodes[nodeId]
 									end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -607,8 +607,41 @@ data.jewelRadii = {
 		{ inner = 1400, outer = 1700, col = "^xFFCC00", label = "Variable" },
 		{ inner = 1650, outer = 1950, col = "^xFF6600", label = "Variable" },
 		{ inner = 1800, outer = 2100, col = "^x0099FF", label = "Variable" },
+
+		-- Baryanic Leylines (Disciple of Varashta): non-unique Time-Lost radius +40%
+		{ inner = 0, outer = 1400, col = "^xBB6600", label = "Small" },
+		{ inner = 0, outer = 1610, col = "^x66FFCC", label = "Medium" },
+		{ inner = 0, outer = 1820, col = "^x2222CC", label = "Large" },
+		{ inner = 0, outer = 2100, col = "^xC100FF", label = "Very Large" },
 	}
 }
+
+-- Maps a base Time-Lost Jewel radius index to the upgraded index granted by
+-- "Non-Unique Time-Lost Jewels have X% increased radius" effects. Keyed by
+-- percentage so additional tiers can be added later.
+data.nonUniqueTimeLostJewelRadiusUpgrades = {
+	[40] = { [1] = 13, [2] = 14, [3] = 15, [4] = 16 },
+}
+
+-- Returns the radius index that should be used for a non-unique Time-Lost Jewel
+-- given the base index and the total "% increased radius" value in effect.
+-- Picks the largest supported tier at or below upgradePct; returns baseIndex
+-- unchanged when no tier applies.
+function data.resolveTimeLostRadiusIndex(baseIndex, upgradePct)
+	if not baseIndex or not upgradePct or upgradePct <= 0 then
+		return baseIndex
+	end
+	local bestPct
+	for pct, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+		if pct <= upgradePct and map[baseIndex] and (not bestPct or pct > bestPct) then
+			bestPct = pct
+		end
+	end
+	if bestPct then
+		return data.nonUniqueTimeLostJewelRadiusUpgrades[bestPct][baseIndex]
+	end
+	return baseIndex
+end
 
 data.jewelRadius = data.setJewelRadiiGlobally(latestTreeVersion)
 

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -605,8 +605,41 @@ data.jewelRadii = {
 		{ inner = 1400, outer = 1700, col = "^xFFCC00", label = "Variable" },
 		{ inner = 1650, outer = 1950, col = "^xFF6600", label = "Variable" },
 		{ inner = 1800, outer = 2100, col = "^x0099FF", label = "Variable" },
+
+		-- Baryanic Leylines (Disciple of Varashta): non-unique Time-Lost radius +40%
+		{ inner = 0, outer = 1400, col = "^xBB6600", label = "Small" },
+		{ inner = 0, outer = 1610, col = "^x66FFCC", label = "Medium" },
+		{ inner = 0, outer = 1820, col = "^x2222CC", label = "Large" },
+		{ inner = 0, outer = 2100, col = "^xC100FF", label = "Very Large" },
 	}
 }
+
+-- Maps a base Time-Lost Jewel radius index to the upgraded index granted by
+-- "Non-Unique Time-Lost Jewels have X% increased radius" effects. Keyed by
+-- percentage so additional tiers can be added later.
+data.nonUniqueTimeLostJewelRadiusUpgrades = {
+	[40] = { [1] = 13, [2] = 14, [3] = 15, [4] = 16 },
+}
+
+-- Returns the radius index that should be used for a non-unique Time-Lost Jewel
+-- given the base index and the total "% increased radius" value in effect.
+-- Picks the largest supported tier at or below upgradePct; returns baseIndex
+-- unchanged when no tier applies.
+function data.resolveTimeLostRadiusIndex(baseIndex, upgradePct)
+	if not baseIndex or not upgradePct or upgradePct <= 0 then
+		return baseIndex
+	end
+	local bestPct
+	for pct, map in pairs(data.nonUniqueTimeLostJewelRadiusUpgrades) do
+		if pct <= upgradePct and map[baseIndex] and (not bestPct or pct > bestPct) then
+			bestPct = pct
+		end
+	end
+	if bestPct then
+		return data.nonUniqueTimeLostJewelRadiusUpgrades[bestPct][baseIndex]
+	end
+	return baseIndex
+end
 
 data.jewelRadius = data.setJewelRadiiGlobally(latestTreeVersion)
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5512,6 +5512,7 @@ local specialModList = {
 	["only affects passives in massive ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 12 }) },
 	["upgrades radius to medium"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 2 })},
 	["upgrades radius to large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 3 })},
+	["upgrades radius to very large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 4 })},
 	["non%-unique time%-lost jewels have (%d+)%% increased radius"] = function(num) return { mod("NonUniqueTimeLostJewelRadius", "INC", num) } end,
 	["primordial"] = { mod("Multiplier:PrimordialItem", "BASE", 1) },
 	["spectres have a base duration of (%d+) seconds"] = { mod("SkillData", "LIST", { key = "duration", value = 6 }, { type = "SkillName", skillName = "Raise Spectre", includeTransfigured = true }) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5512,7 +5512,7 @@ local specialModList = {
 	["only affects passives in massive ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 12 }) },
 	["upgrades radius to medium"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 2 })},
 	["upgrades radius to large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 3 })},
-	["upgrades radius to very large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 4 })},
+	["non%-unique time%-lost jewels have (%d+)%% increased radius"] = function(num) return { mod("NonUniqueTimeLostJewelRadius", "INC", num) } end,
 	["primordial"] = { mod("Multiplier:PrimordialItem", "BASE", 1) },
 	["spectres have a base duration of (%d+) seconds"] = { mod("SkillData", "LIST", { key = "duration", value = 6 }, { type = "SkillName", skillName = "Raise Spectre", includeTransfigured = true }) },
 	["flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("FlaskEffect", "INC", num, { type = "ActorCondition", actor = "player"}) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5348,6 +5348,7 @@ local specialModList = {
 	["only affects passives in massive ring"] = { mod("JewelData", "LIST", { key = "radiusIndex", value = 12 }) },
 	["upgrades radius to medium"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 2 })},
 	["upgrades radius to large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 3 })},
+	["non%-unique time%-lost jewels have (%d+)%% increased radius"] = function(num) return { mod("NonUniqueTimeLostJewelRadius", "INC", num) } end,
 	["primordial"] = { mod("Multiplier:PrimordialItem", "BASE", 1) },
 	["spectres have a base duration of (%d+) seconds"] = { mod("SkillData", "LIST", { key = "duration", value = 6 }, { type = "SkillName", skillName = "Raise Spectre", includeTransfigured = true }) },
 	["flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("FlaskEffect", "INC", num, { type = "ActorCondition", actor = "player"}) } end,


### PR DESCRIPTION
### Description of the problem being solved:

Adds support for Baryanic Leylines (Disciple of Varashta). The tree entry for "Non-Unique Time-Lost Jewels have 40% increased radius" existed but had no parser, so allocating the notable did nothing.

- `ModParser.lua` parses the stat into a `NonUniqueTimeLostJewelRadius` INC mod.
- `Data.lua` adds four precomputed +40% radius tiers plus a `resolveTimeLostRadiusIndex` helper keyed by percent.
- `CalcSetup.lua` and `PassiveTreeView.lua` call the helper so in-radius calcs, the socket ring, and node tooltips all use the upgraded radius on non-unique Time-Lost jewels.
- `ModCache.lua` regenerated; new spec added.

### Steps taken to verify a working solution:
- Launched PoB from the `dev` branch plus this change, picked a Sorceress, allocated Disciple of Varashta → Baryanic Leylines.
- With Alt held over the notable, confirmed the stat line parses as `NonUniqueTimeLostJewelRadius INC 40`
- Socketed a non-unique Time-Lost Ruby with an explicit `Small Passives in Radius also grant X%` roll into an allocated jewel socket; recorded which passives it affected before allocating Baryanic Leylines.
- Allocated Baryanic Leylines and confirmed via Alt-hover on individual passives that a node previously outside the base radius now receives the jewel's bonus (e.g. "+3% increased Armour from the Time-Lost Jewel"), and that the ring drawn on the tree for the socket visibly expands.
- De-allocated Baryanic Leylines and confirmed both the affected-passive list and the drawn ring return to baseline.
- Confirmed Against the Darkness (unique Time-Lost Diamond) is unaffected — its radius stays the same with Baryanic Leylines allocated, per the "Non-Unique" qualifier.
- Added `TestBaryanicLeylines_spec.lua` 

### Link to a build that showcases this PR:
<!-- Generate a share code from the Import/Export tab after allocating the notable + socketing a Time-Lost Jewel, and paste the link here. -->

### Before screenshot:
(without Baryonic Leylines)
<img width="1925" height="2116" alt="image" src="https://github.com/user-attachments/assets/79d9c58a-01a7-43d6-80d8-94bdf7bbd7c2" />
(with Baryonic Leylines)
<img width="1919" height="2103" alt="image" src="https://github.com/user-attachments/assets/1fc17b72-a4c2-4abd-90da-152961620c50" />
(and a before shot of a passive outside the ring)
<img width="1921" height="2119" alt="image" src="https://github.com/user-attachments/assets/6a599e47-9a02-4e26-848a-1e1852d80011" />


### After screenshot:
Showing that the Baryanic Leylines node shows that it is supported and the effects it will have on the build.
<img width="2294" height="2098" alt="image" src="https://github.com/user-attachments/assets/0974b429-c9e0-4726-8b95-44f91eae4f74" />
Same build/view on this branch, ring now visibly expanded and a previously-unaffected passive showing the jewel's inherited stats in its tooltip.
<img width="1913" height="2108" alt="image" src="https://github.com/user-attachments/assets/20cbb970-c022-40a0-8097-1d21a2ce847c" />
