### PR TITLE
Support opening builds from builds folder via command line argu…

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -152,17 +152,17 @@ function main:Init()
 
 	-- Open a build by name from the builds folder (passed via command line)
 	if pendingBuildName and self.buildPath then
-		-- Ensure it ends with .xml and resolve relative to buildPath
-		local fileName = pendingBuildName:match("([^/]+)$")
-		if fileName then
-			local buildFile = self.buildPath .. fileName
-			if not buildFile:lower():match("%.xml$") then
-				buildFile = buildFile .. ".xml"
+		-- Reject path traversal attempts
+		if not pendingBuildName:match("%.%.") then
+			local relativePath = pendingBuildName
+			if not relativePath:lower():match("%.xml$") then
+				relativePath = relativePath .. ".xml"
 			end
+			local buildFile = self.buildPath .. relativePath
 			local file = io.open(buildFile, "r")
 			if file then
 				file:close()
-				local buildName = fileName:gsub("%.xml$", "")
+				local buildName = relativePath:match("([^/]+)%.xml$") or relativePath
 				self:SetMode("BUILD", buildFile, buildName)
 			end
 		end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -60,19 +60,26 @@ function main:Init()
 	self.gameAccounts = { }
 
 	local ignoreBuild
+	local pendingBuildName
 	if arg[1] then
-		local importLink = buildSites.ParseImportLinkFromURI(arg[1])
-		buildSites.DownloadBuild(arg[1], nil, function(isSuccess, data, importLink)
-			if not isSuccess then
-				self:SetMode("BUILD", false, data)
-			else
-				local xmlText = Inflate(common.base64.decode(data:gsub("-","+"):gsub("_","/")))
-				self:SetMode("BUILD", false, "Imported Build", xmlText, false, importLink)
-				self.newModeChangeToTree = true
-			end
-		end)
+		if arg[1]:lower():match("%.xml$") then
+			-- Build name passed as argument, resolved against buildPath after settings load
+			pendingBuildName = arg[1]:gsub("\\", "/")
+			ignoreBuild = true
+		else
+			local importLink = buildSites.ParseImportLinkFromURI(arg[1])
+			buildSites.DownloadBuild(arg[1], nil, function(isSuccess, data, importLink)
+				if not isSuccess then
+					self:SetMode("BUILD", false, data)
+				else
+					local xmlText = Inflate(common.base64.decode(data:gsub("-","+"):gsub("_","/")))
+					self:SetMode("BUILD", false, "Imported Build", xmlText, false, importLink)
+					self.newModeChangeToTree = true
+				end
+			end)
+			ignoreBuild = true
+		end
 		arg[1] = nil -- Protect against downloading again this session.
-		ignoreBuild = true
 	end
 
 	if not ignoreBuild then
@@ -141,6 +148,24 @@ function main:Init()
 
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
+	end
+
+	-- Open a build by name from the builds folder (passed via command line)
+	if pendingBuildName and self.buildPath then
+		-- Ensure it ends with .xml and resolve relative to buildPath
+		local fileName = pendingBuildName:match("([^/]+)$")
+		if fileName then
+			local buildFile = self.buildPath .. fileName
+			if not buildFile:lower():match("%.xml$") then
+				buildFile = buildFile .. ".xml"
+			end
+			local file = io.open(buildFile, "r")
+			if file then
+				file:close()
+				local buildName = fileName:gsub("%.xml$", "")
+				self:SetMode("BUILD", buildFile, buildName)
+			end
+		end
 	end
 
 	self.uniqueDB = { list = { }, loading = true }

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -163,11 +163,7 @@ function main:Init()
 			file:close()
 			local buildName = pendingBuildFile:match("([^/]+)%.xml$") or pendingBuildFile
 			self:SetMode("BUILD", buildFile, buildName)
-		else
-			self:SetMode("BUILD", false, "Unnamed build")
 		end
-	elseif pendingBuildFile then
-		self:SetMode("BUILD", false, "Unnamed build")
 	end
 
 	self.uniqueDB = { list = { }, loading = true }

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -60,11 +60,10 @@ function main:Init()
 	self.gameAccounts = { }
 
 	local ignoreBuild
-	local pendingBuildName
+	local pendingBuildFile
 	if arg[1] then
 		if arg[1]:lower():match("%.xml$") then
-			-- Build name passed as argument, resolved against buildPath after settings load
-			pendingBuildName = arg[1]:gsub("\\", "/")
+			pendingBuildFile = arg[1]:gsub("\\", "/")
 			ignoreBuild = true
 		else
 			local importLink = buildSites.ParseImportLinkFromURI(arg[1])
@@ -150,21 +149,14 @@ function main:Init()
 		self:ChangeUserPath(self.userPath, ignoreBuild)
 	end
 
-	-- Open a build by name from the builds folder (passed via command line)
-	if pendingBuildName and self.buildPath then
-		-- Reject path traversal attempts
-		if not pendingBuildName:match("%.%.") then
-			local relativePath = pendingBuildName
-			if not relativePath:lower():match("%.xml$") then
-				relativePath = relativePath .. ".xml"
-			end
-			local buildFile = self.buildPath .. relativePath
-			local file = io.open(buildFile, "r")
-			if file then
-				file:close()
-				local buildName = relativePath:match("([^/]+)%.xml$") or relativePath
-				self:SetMode("BUILD", buildFile, buildName)
-			end
+	-- Open a build file from the builds folder (passed via command line)
+	if pendingBuildFile and self.buildPath and not pendingBuildFile:match("%.%.") then
+		local buildFile = self.buildPath .. pendingBuildFile
+		local file = io.open(buildFile, "r")
+		if file then
+			file:close()
+			local buildName = pendingBuildFile:match("([^/]+)%.xml$") or pendingBuildFile
+			self:SetMode("BUILD", buildFile, buildName)
 		end
 	end
 

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -150,14 +150,24 @@ function main:Init()
 	end
 
 	-- Open a build file from the builds folder (passed via command line)
-	if pendingBuildFile and self.buildPath and not pendingBuildFile:match("%.%.") then
-		local buildFile = self.buildPath .. pendingBuildFile
-		local file = io.open(buildFile, "r")
+	if pendingBuildFile and not pendingBuildFile:match("%.%.") then
+		local buildFile
+		-- Check if it's an absolute path (drive letter on Windows or / on Unix)
+		if pendingBuildFile:match("^%a:/") or pendingBuildFile:match("^/") then
+			buildFile = pendingBuildFile
+		elseif self.buildPath then
+			buildFile = self.buildPath .. pendingBuildFile
+		end
+		local file = buildFile and io.open(buildFile, "r")
 		if file then
 			file:close()
 			local buildName = pendingBuildFile:match("([^/]+)%.xml$") or pendingBuildFile
 			self:SetMode("BUILD", buildFile, buildName)
+		else
+			self:SetMode("BUILD", false, "Unnamed build")
 		end
+	elseif pendingBuildFile then
+		self:SetMode("BUILD", false, "Unnamed build")
 	end
 
 	self.uniqueDB = { list = { }, loading = true }


### PR DESCRIPTION
# Add Command-Line Support for Opening Local Builds

## Overview

This change adds support for opening existing local `.xml` builds via command-line arguments.

Previously, Path of Building only supported opening builds through the `pob2://` protocol, which is limited to importing builds from external sources. There was no way for external tools to open a build that already exists in the local builds folder.

## Usage

```bash
PathOfBuilding.exe "<path>/Path of Building (PoE2)/Builds/MyBuild.xml"
```

## Benefits

- Enables integration with external tools such as **PoeLurker**
- Enables **desktop shortcuts** to open specific builds directly

## Compatibility

- Existing `pob2://` protocol behavior is unchanged
- Launching without arguments behaves as before
- Invalid or missing files are handled gracefully (no crash)

## Testing

- ✅ Launch with valid `.xml` filename → build opens correctly  
- ✅ Launch with no arguments → default behavior unchanged  
- ✅ Launch with `pob2://` URI → protocol handler still works  
- ✅ Launch with invalid `.xml` filename → no crash, fails gracefully  
