### PR TITLE
Add support for Temporal Chains

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -20949,6 +20949,14 @@ skills["TemporalChainsPlayer"] = {
 			baseEffectiveness = 0,
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "temporal_chains",
+			statMap = {
+				["base_skill_debuff_action_speed_+%_final_to_inflict"] = {
+					mod("TemporalChainsActionSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" })
+				},
+				["base_temporal_chains_other_buff_time_passed_+%_to_apply"] = {
+					mod("BuffExpireFaster", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+				},
+			},
 			baseFlags = {
 				area = true,
 				duration = true,

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -3795,6 +3795,9 @@ skills["ContagionPlayer"] = {
 				duration = true,
 				spell = true,
 			},
+			baseMods = {
+				skill("debuff", true),
+			},
 			constantStats = {
 				{ "base_skill_effect_duration", 5000 },
 				{ "active_skill_base_area_of_effect_radius", 17 },
@@ -12082,6 +12085,10 @@ skills["VileDisruptionPlayer"] = {
 			baseFlags = {
 				spell = true,
 				area = true,
+				duration = true,
+			},
+			baseMods = {
+				skill("debuff", true),
 			},
 			constantStats = {
 				{ "active_skill_base_area_of_effect_radius", 40 },

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -4095,6 +4095,12 @@ skills["InevitableAgonyPlayer"] = {
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "inevitable_agony",
 			baseFlags = {
+				area = true,
+				duration = true,
+				curse = true,
+			},
+			baseMods = {
+				skill("debuff", true),
 			},
 			constantStats = {
 				{ "curse_delay_duration_ms", 1500 },
@@ -5987,6 +5993,9 @@ skills["ParryPlayer"] = {
 				melee = true,
 				duration = true,
 				shieldAttack = true,
+			},
+			baseMods = {
+				skill("debuff", true),
 			},
 			constantStats = {
 				{ "movement_speed_+%_final_while_performing_action", -50 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1371,6 +1371,14 @@ statMap = {
 #skill TemporalChainsPlayer
 #set TemporalChainsPlayer
 #flags area duration
+statMap = {
+	["base_skill_debuff_action_speed_+%_final_to_inflict"] = {
+		mod("TemporalChainsActionSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" })
+	},
+	["base_temporal_chains_other_buff_time_passed_+%_to_apply"] = {
+		mod("BuffExpireFaster", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -276,6 +276,7 @@ statMap = {
 #skill ContagionPlayer
 #set ContagionPlayer
 #flags area duration spell
+#baseMod skill("debuff", true)
 #mods
 #skillEnd
 
@@ -811,7 +812,8 @@ statMap = {
 #from item
 #skill VileDisruptionPlayer
 #set VileDisruptionPlayer
-#flags spell area
+#flags spell area duration
+#baseMod skill("debuff", true)
 #mods
 #skillEnd
 

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -291,7 +291,8 @@ statMap = {
 #from tree
 #skill InevitableAgonyPlayer
 #set InevitableAgonyPlayer
-#flags
+#flags area duration curse
+#baseMod skill("debuff", true)
 #mods
 #skillEnd
 
@@ -426,6 +427,7 @@ statMap = {
 		mod("DamageTaken", "MORE", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Parry" }, { type = "Condition", var = "ParryActive" }),
 	},
 },
+#baseMod skill("debuff", true)
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Add support for Temp Chains slow and expire slower mods. Also fixing up or adding the debuff tag to a few skills that have Debuffs that I'm pretty sure should be scaled by temporal chains:
- Contagion
- Parry
- His Vile Intrusion
- Inevitable Agony

### Steps taken to verify a working solution:
- Verify ailment duration increased
- Verify enemy slowed attack time
- Verify updated skills debuff time

### Link to a build that showcases this PR:
<pre>eNrNHGtz2kjyc_wrVFRd1V0dMUhIPFz2XmHANru2w4IT396X1CANoGSQiGZkm1zdf7_uGUkIkECyk6rsBweJfk13T79m2PN_vSyZ9kQD7vreRUU_rVc06tm-43rzi8rHh6v37cq_fjs5HxGx-DC7DF2G3xi_nbw7lw-avSABsQUNbukTZd1Q-He-Qy8qIghpRRMkmFPxKSZf_6xXNJsRzu_JEoAmfmDTgHJe0Z5c-qwwh3ejD-OHirYkrjfx7a9UXAd-uLqoWBWNIZOLitGuaITb1HN6G2K9ReB7_pJ4QLICAr47HzGypsFEEKFx-HNR6cJCyZz2yRL-Ak_CQkCsV2oHwS_DgIuiOJMVpU4Cpp820v_lIY0COpjNqC3cJ9oLXNFb4CoSKlYeXlnYu5AJd8VcUFAMb-TB3-yR1uu5q37wBWH90eS4fhSkL4pDFiLbCxkDxywEO6acBk9EgEsWo-0vp65Hne7T_DjwHfFIz-eiGOSIwgbwRCmECbV9cPyyPEpi3rozWhyy1DoihLLSvG4dg0lRuNKEXyfQGMJIMciJH7KCkGKzoXXLyHf8b1uQem6w6NOXBKyVBzT0RIrrAabbgK18pk8-bsoCoSFwp6GgBWPI4GaUQLbr9dNOp2Ea7Van2c4PyIs1d23C7siLuwyXEAsfyFe6kazdMvNddb4QHsSiPFwrXwNXbkBfgdbzmfMatAXxee4KG7lK_TCb3RDP6dp2CKl_vUkl9Vyl9Enw1VN5vlBwpk5xDIwNG7EN60Bmts8QeOjZx9MlAn70gkiaIvQRYwyBAIuGKaNFUTZMonhSJN8qXnPqRQzXxdR0S6m9uIa6CliBxYvlj408bf2gbhE4rduDVDN0e4D-NkYJRSFitqJap8YhpNKqmqzcwC0kk4LMUkBxnBIqGHg0mK8nC5eyNKsi4LHSemRVAFM6QRq9kDNs8yvl0mnU0vbCPFyW3xPh6fzUOqwJBV1MCU_Eobvldq57UkZpKYxR4H_B7oKVQ4NlMFYe45Xc-nTGEM33xlCbewVq7Qhjh0F-Oxcs_XBT_pj64XCmwAuZLy4XVJM4pk5obxUyzXau4eO275JBq7uzEqN5FE0qPAs3XwtCEPtr33fmtCiKZFIKY1u-SbhaYZcPKilKACshKAXcVPX73ioA_QF2cjpa1Q_VTMUZbKALM0jqwOJcdlCKrwULuR02RYALM0jMeQeRcgl5R0457vxNPoGqOjcabiE9LiAufOSwyMlXl7EUAbNtHZiPcAp-MyaOG_I7KuB5s49zvSJkxWYSErDgoGHkP4PSFjjX4uWgodJOEHIbj6uAet_XhelvgRdiMPAcqNpBl4V57GJksbkMZzOu2f5ySsQteNZFpaJN4V38GToFTtXDiATBuqo90OXKDwjTgKrr8YjOg7uE5MZ5nwiiOVE_-IkELvGEjrlj96UhX3I5JrxymaBBH7igtLgijVMS2ItYis3TFWFsCmEQ3iLj85ocZuKnoaBLroWcqp7-kZKV700o4M8I4xC5iNwICCbfIveF_4z66ruwTQL0Ux7NP-WaEFRzHQTF53djkFysz7Rxdzw4UUlGUzXMyQN5XvjE0x7QbeKXCuRMg3x10gvITFDnTEPyJ7AtZu7LmfZfMM-cntVPrf_d-17m-1sf0hPksoASDtVjdr5SeTcqLa0sMgkF7CbaJxMwMUJIrvkPf4aEySUb9RM5Jh7Tb2dau34yXK6Ya7uCn2n6SYrNNXwUXJMR4kyTKNrf9fdG_R_amLicxqppmX_T3FgkTSnq5J-6XteEry1VZ6uhqKj3c4hXY2QRGUOT_DDyRHFnB8I4CtHYhzivobkTu4OLxNzyXUpRnjAfYAFn6EjX9eRQewwG0UAS_GI0_Ti-jTz2MEKjBALu6qWml8YoI9QVI_xrKQylJE3XJs-YoEpyKrOaWzovBd8tqa1oJUbZlXRL6lhZpYzlLykTJRVVRqDuMmQ0h4GM10MHXm59HWH-Tp9hwxt6p23CK9-hSFc9FnKaEkLeULakBbSg75qzjJ59Z63FzUdhrGsGZRMvxcYXvGykyNKVimEQoFRKDqCHm8jM-UixQOUqY8pEiZ96hNlcRTxvFYqIOsfY_dkLl1M8bFL_XlTiPigNuXS5_RmLBTz-g2wqAnn2OLi6GvQehp8GEcpE9YYynMrEMKHY_EFt4TNGVpAAkhTNwylX0BeVTy59luB9KojLeAa1Gzc53TtMS9LZQO9TegQtBS5a7TChwQsNMNUm8Puk5BFZAXGULDjAwNopS1fqQPIwKdUU9ggXUANkUenJ2dZhIgiTtRTI8oQdVW4ElWPsh_WKYo3FCylFADSHHt6dubbCyrR63Iwe0U08596ncckK6FYB7SOPfJfjjOAwdgSVodW554rjWlVQGf5FbbI-hq2A9pGTYdsxAgmg7-FQbp_SgNGuy7A7PGpZKCWls8O-SVD2Cd5BNFHt6lGCH8SCBjHsPiXYE-qYiRfYPTFkhq7k8cQRNSFMxlrk9P0wqoTJ2vVugR0bQWWYZWtmfCSYpWH3ScVzicNEFFSmGaLEecQECipjJfHM9sgiIrCMjSIDbPfJd50i0WIX_M0E5XDvB8iF47sfQCYZ0mbQksX30d0SQRVCV7eI0tgfhYu95NuI4H57GwXcdm-jIOv1LOzxbiWyjzvOLj-Skc5RxvPMUFUMP5kHvZqCmlq9Gl0O1XJCP_inHMAUiv0J8NtoTUTo9UElObsil9T-yqRUh2JHaVoqUR5YqNr_0dl_kdCmQN9OCNL4TXa9WIJSMpi-oYSJxcj32dsI7l6HKE4sY5dS2w9XxHNiah_yq_Qy2oM2D4jKiWUfDzD5m6SE9L1cp-ic1-KG7vzeh5IGSePb-OG853szdx7NQdVDNAmVUiRv4sGXcAWjMnOQkIlo2pVuAClKMOSXPt72iNs_HBzG_euIEZsufObQIO4Zk4uM8dBVdJdLH8-BnE23qecT6C2wg8SmhxeC3zB8dHFjUUci9_zQE9CIzlJErHwqcqXpS5sx0jEcXFjcoyaMOkeQ4kn4BsWoH5MND4d2GbXzkRy69L0rP1juqfIAp8kCKpoSupeSRW1sDN6qH1tKUvglizcOKGxi-4G9KCsUHguWNktc0CYILbOUo1_DH-LQ4r6unEGN-iESyPl1WpNHMOX4PaXG9jH4-BSzjGZS-wtnIuuPEK0gfsJy2brQIrk7d9mHmawNwIyyiiiqm-3jkBKmxK2MiI-UyMtqu_5zaL9tVoz1g1dyuQn7XZmTa3u1JBCroC6f8ONDQClOxaLjsIkALDL3PWD83feX_76ovG80zdN6u201G4Z6eavu3XcOHXZJwL_wWqneODUaVkNvdNQVq_MhnvUJjb7gPyMSiHWc2WqxRFE-wZsXSSrBh_Q9_6E6lcGJMDAF8TpVq90wOlXDbBtW1TJNs1U161anqtf1hl6VI-Oq1WxaerVpNFutasPUG82q3jSbdYBptI2q2WoBvNWsm1bV1OtAzGxalllt6B2rXjXNdkuvmo2W2ayaRgtwG23dbFSb9WbbqjYMJKzrnSYQMHQEqTdAjlbdqFp14C5fVM1OHdANy7JaVR0kAMHMJkhqGDr87ZhACeRpmFWjY7ZAxQINtPnJhIkHl3hwRIJ1d1sZnsui31MMPUEDjzB824rfwecm_o6Cw3fraNCBU3alUkgN6zRa8mMMI8rRH8e38sO7hRArflarPT8_n66IWPgz-uIyemr7y9oKGIHd3st573sUvdaF_y7nf_WG6yvL7LD5-z8_T3-37j-Z9_pt5_7x6nFweffHsNn80gmEP3jUDe_7h6BOv5nfps9s9Fn0_1x_bz1_ny7_-PP71dfp4I-Xy-DJ-s8X_WH85a-BzfrT0cRe28Dl4kIKWosljQ4WeLRtsN4KXEfVMPCczGniLzTXE_fKm2TlEX1O-8Gel0XOgF6mPEL5mvIL5QbKyJHHbXxEOZ9yHekjyg-lj6S9QDmK9E7lKJEDoXdEniq9Ew_DX2LxoyXXttZ8XsMtJPc_7jH8IHefRlYr8ICkvARw4XokGqXgrQzI0c9d5wnLhwcoqvnWfpUzVg5YsqK7psvogFcducMWh1f8ct0fTeLQsAGNIokHNUNyvXoH6QonSZufXchrGTLshKuVgsNpMIjUvb2Nz-OjE4FNGRq_SJ-8q5capM8p2xTDrmez0KFDL7ovkmiFkSmKqn6J1N2wkfWxLG13vkgYvTsHIXf5PKkbC7jV4ssP0d0H7VtKfwrrmvlTwowYN_7dE-oXgi-sa-iB8aMIkEbRkxofJdpnpq53bJOJFiRpzdUp0R0VxCGCqGOeGtqmJteI2t-R3sYiODkiUxE883oH-iPS-LWMMbTpvf9EfrIVIi4_QP2JvFl6hy81-e0vrPABl5e5-oE8QPipWk-z-gGq35Y8S_8RhKZAlDpA84ql5Cb5anO84UIdlZSz5XTVKqNb6mjLa3Wz5Ne0KhSYUHbLjuunmjTh8wPsmZI5y5ibr3_h3STv0xXXuf4KlUsWr1Z3ou1I0ixNq6_erGUOjTXe_EPeZ_rZ1uW6qpZ1u66IZTjzRfrix2stpTiq85xD9opd5vUGS3F6u9m2xM4yXvpK3q-8Uz5Bz9J3eRCuxM8PU9vMfkCs2pU-yxI3LtcQToO-Lgj5D4lc8Z7CBuJMNrg_tRjz6JMr8NuuGkn81H2yw-3te6Wb6qx3FpJZrSVAmoLas1b0MZ7iqM7rt5Pz2t7_kOH_nBNLWA==</pre>

### Before screenshot:
<img width="650" height="404" alt="image" src="https://github.com/user-attachments/assets/2e4306a8-4d02-4f3e-a562-cb514cbb1fda" />
<img width="342" height="84" alt="image" src="https://github.com/user-attachments/assets/26ec9713-8708-4b1d-afdd-9a439b9a01a9" />

### After screenshot:
<img width="553" height="438" alt="image" src="https://github.com/user-attachments/assets/bb1c9ef4-9dc2-4013-b63b-d9ea9c50b93c" />
---
<img width="584" height="191" alt="image" src="https://github.com/user-attachments/assets/ff4fbb72-fd6d-496c-add4-b2f8728b7b6f" />
---
<img width="440" height="143" alt="image" src="https://github.com/user-attachments/assets/5f92a1a7-ac22-4b31-815f-712ffcbe57f7" />
0.7 / 0.41 = ~1.71

---

e.g. Contagion
<img width="632" height="514" alt="image" src="https://github.com/user-attachments/assets/bfc604cc-e61a-42eb-a39a-a9fefc71691f" />
