### PR TITLE
Add support for Ritualistic Curse's More Delay

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -6812,6 +6812,11 @@ skills["SupportRitualisticCursePlayer"] = {
 			label = "Ritualistic Curse",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_ritual_curse_curse_delay_+%_final"] = {
+					mod("CurseDelay", "MORE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -1291,6 +1291,11 @@ statMap = {
 
 #skill SupportRitualisticCursePlayer
 #set SupportRitualisticCursePlayer
+statMap = {
+	["support_ritual_curse_curse_delay_+%_final"] = {
+		mod("CurseDelay", "MORE", nil),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
Add statMap for Ritualistic Curse Support's "30% more delay" mod.

### Steps taken to verify a working solution:
- Validate Curse Delay
- Validate with Whispers of Doom

### After screenshot:
<img width="499" height="302" alt="image" src="https://github.com/user-attachments/assets/28ace491-9bde-4779-be9a-3e81caf3d306" />

<img width="752" height="423" alt="image" src="https://github.com/user-attachments/assets/15c98fd7-e6a4-4659-b2fb-2b601069a340" />
<img width="463" height="169" alt="image" src="https://github.com/user-attachments/assets/252fc228-7c0e-4cc4-ae79-39513c0ce20f" />
