### PR TITLE
Add support for Zenith

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -414,7 +414,7 @@ return {
 	mod("Cost", "MORE", nil),
 	value = -100,
 },
-["base_mana_cost_efficiency_"] = {
+["base_mana_cost_efficiency_+%"] = {
 	mod("ManaCostEfficiency", "INC", nil),
 },
 ["base_life_cost_+%"] = {
@@ -2173,6 +2173,9 @@ return {
 },
 ["spell_maximum_added_chaos_damage"] = {
 	mod("ChaosMax", "BASE", nil, 0, KeywordFlag.Spell),
+},
+["support_spell_damage_+%_final_while_above_90%_maximum_mana"] = {
+	mod("Damage", "MORE", nil, 0, KeywordFlag.Spell, { type = "Condition", var = "FullMana"}),
 },
 
 --


### PR DESCRIPTION
### Description of the problem being solved:
Fixes the statMap for base mana cost efficiency and adds a statMap for more spell damage when above 90% max mana. I'm reusing the Full Mana config because I didn't think we really needed a separate checkbox for "aboveNinetyMana."

### Steps taken to verify a working solution:
- Validate mana cost efficiency
- Validate Full Mana config shows and applies 30% more spell damage

### Before screenshot:
<img width="884" height="285" alt="image" src="https://github.com/user-attachments/assets/32f26e3a-ac66-4da0-a872-7ba467e3af83" />

### After screenshot:
<img width="707" height="295" alt="image" src="https://github.com/user-attachments/assets/2384056d-cb92-4135-9f8c-d873ce65d8a5" />
<img width="726" height="130" alt="image" src="https://github.com/user-attachments/assets/b013713f-64ba-4b86-85fe-87c05b718fad" />
<img width="589" height="119" alt="image" src="https://github.com/user-attachments/assets/9d0327c0-5a9d-4a12-9e82-112ac0170b76" />
