### PR TITLE
Fix increased Enemy damage taken mods doubling their affect in Ailment calcs

### DIFF
--- a/spec/System/TestAilments_spec.lua
+++ b/spec/System/TestAilments_spec.lua
@@ -14,4 +14,18 @@ describe("TestAilments", function()
 	--TODO: Shock not supported currently
 	--it("bleed is buffed by bleed chance", function()
 	--end)
+
+	it("does not double count chaos damage taken for chaos poison", function()
+		build.skillsTab:PasteSocketGroup("Chaos Bolt 1/0  1\nPoison I 1/0  1\n")
+		runCallback("OnFrame")
+
+		local baseEffMult = build.calcsTab.mainOutput.PoisonEffMult
+		assert.True(baseEffMult and baseEffMult > 0)
+
+		build.configTab.input.customMods = "Nearby enemies take 10% increased Chaos Damage"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(1.1, build.calcsTab.mainOutput.PoisonEffMult)
+	end)
 end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4838,8 +4838,9 @@ function calcs.offence(env, actor, activeSkill)
 						end
 					else
 						local resist = calcResistForType(ailmentDamageType, dotCfg)
-						local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime") + (ailmentDamageType ~= ailmentTypeMod and enemyDB:Sum("INC", dotCfg, ailmentTypeMod .. "DamageTaken") or 0)
-						local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime") * (ailmentDamageType ~= ailmentTypeMod and enemyDB:More("INC", dotCfg, ailmentTypeMod .. "DamageTaken") or 1)
+						local elementalDamageTaken = isElemental[ailmentDamageType] and "ElementalDamageTaken" or nil
+						local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime", elementalDamageTaken)
+						local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime", elementalDamageTaken)
 						effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
 						globalOutput[ailment .. "EffMult"] = effMult
 						if breakdown and effMult ~= 1 then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4838,8 +4838,8 @@ function calcs.offence(env, actor, activeSkill)
 						end
 					else
 						local resist = calcResistForType(ailmentDamageType, dotCfg)
-						local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime", ailmentTypeMod .. "DamageTaken")
-						local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime", ailmentTypeMod .. "DamageTaken")
+						local takenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime") + (ailmentDamageType ~= ailmentTypeMod and enemyDB:Sum("INC", dotCfg, ailmentTypeMod .. "DamageTaken") or 0)
+						local takenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", ailmentDamageType .. "DamageTaken", ailmentDamageType .. "DamageTakenOverTime") * (ailmentDamageType ~= ailmentTypeMod and enemyDB:More("INC", dotCfg, ailmentTypeMod .. "DamageTaken") or 1)
 						effMult = (1 - resist / 100) * (1 + takenInc / 100) * takenMore
 						globalOutput[ailment .. "EffMult"] = effMult
 						if breakdown and effMult ~= 1 then


### PR DESCRIPTION
Fixes bug with no outstanding issue.

### Description of the problem being solved:

Increases/more damage taken on enemies is double counted for physical/chaos ailments (bleed and poison). E.g., Nearby enemies take 10% increased chaos damage results in a 20% increase in the calculations.

### Steps taken to verify a working solution:

Confirmed physical/chaos work properly for bleed/poison respectively, while elemental still works for ignite.

### Link to a build that showcases this PR:

https://pobb.in/UCOPSE85Cyoz

### Before screenshot:

<img width="637" height="315" alt="image" src="https://github.com/user-attachments/assets/cd003cf0-46d4-4b35-937a-962412e1e84d" />

### After screenshot:

<img width="515" height="260" alt="image" src="https://github.com/user-attachments/assets/d10bdc3e-b5a1-4ce0-9c43-bc4759c3ad89" />