### PR TITLE
Fix matchURL for BuildSites

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -18,25 +18,25 @@ buildSites = { }
 -- linkURL: The URL pattern to link to the provided build code (Unused currently)
 buildSites.websiteList = {
 	{
-		label = "Maxroll", id = "Maxroll", matchURL = "^https:/maxroll%.gg/poe2/pob/.*", regexURL = "maxroll%.gg/poe2/pob/(.+)%s*$", downloadURL = "maxroll%.gg/poe2/api/pob/%1",
+		label = "Maxroll", id = "Maxroll", matchURL = "^https://maxroll%.gg/poe2/pob/.*", regexURL = "maxroll%.gg/poe2/pob/(.+)%s*$", downloadURL = "maxroll%.gg/poe2/api/pob/%1",
 		codeOut = "https://maxroll.gg/poe2/pob/", postUrl = "https://maxroll.gg/poe2/api/pob", postFields = "pobCode=", linkURL = "maxroll%.gg/poe2/pob/%1"
 	},
 	{
-		label = "pobb.in", id = "POBBin", matchURL = "^https:/pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
+		label = "pobb.in", id = "POBBin", matchURL = "^https://pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = "", linkURL = "pobb.in/%1"
 	},
 	{
-		label = "poe.ninja", id = "PoeNinja", matchURL = "^https:/poe2?%.ninja/?p?o?e?2?/pob/.+", regexURL = "poe2?%.ninja/?p?o?e?2?/pob/(.+)%s*$", downloadURL = "poe.ninja/poe2/pob/raw/%1",
+		label = "poe.ninja", id = "PoeNinja", matchURL = "^https://poe2?%.ninja/?p?o?e?2?/pob/.+", regexURL = "poe2?%.ninja/?p?o?e?2?/pob/(.+)%s*$", downloadURL = "poe.ninja/poe2/pob/raw/%1",
 		codeOut = "", postUrl = "https://poe.ninja/poe2/pob/api/upload", postFields = "code=", linkURL="poe.ninja/poe2/pob/%1"
 	},
 	{ 
-		label = "poe2db.tw", id = "PoE2DB", matchURL = "^https:/poe2db%.tw/pob/.+", regexURL = "poe2db%.tw/pob/(.+)%s*$", downloadURL = "poe2db.tw/pob/%1/raw", 
+		label = "poe2db.tw", id = "PoE2DB", matchURL = "^https://poe2db%.tw/pob/.+", regexURL = "poe2db%.tw/pob/(.+)%s*$", downloadURL = "poe2db.tw/pob/%1/raw",
 		codeOut = "", postUrl = "https://poe2db.tw/pob/api/gen", postFields = "", linkURL = "poe2db.tw/pob/%1" 
 	},
 	{
-		label = "Pastebin.com", id = "pastebin", matchURL = "^https:/pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1", linkURL = "pastebin.com/%1"
+		label = "Pastebin.com", id = "pastebin", matchURL = "^https://pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1", linkURL = "pastebin.com/%1"
 	},
-	{ label = "PastebinP.com", id = "pastebinProxy", matchURL = "^https:/pastebinp%.com/%w+", regexURL = "pastebinp%.com/(%w+)%s*$", downloadURL = "pastebinp.com/raw/%1", linkURL = "pastebin.com/%1" },
+	{ label = "PastebinP.com", id = "pastebinProxy", matchURL = "^https://pastebinp%.com/%w+", regexURL = "pastebinp%.com/(%w+)%s*$", downloadURL = "pastebinp.com/raw/%1", linkURL = "pastebin.com/%1" },
 	{ label = "Rentry.co", id = "rentry", matchURL = "rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw", linkURL = "rentry.co/%1" },
 }
 


### PR DESCRIPTION
### Description of the problem being solved:
When we ported over the URL spoofing PR, the matchURLs were set to "https:/" instead of "https://" This is not an issue in PoB1

### Before screenshot:
<img width="458" height="113" alt="image" src="https://github.com/user-attachments/assets/43a74032-723c-409a-8093-ffc4aa753a4d" />

### After screenshot:
<img width="507" height="115" alt="image" src="https://github.com/user-attachments/assets/827d6a1c-ffec-4a1f-81ba-05e332be8dcd" />
