### PR TITLE
Fix Ascendancy and Loadout Dropdowns visibility on smaller screens

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -106,9 +106,29 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			self:CloseBuild()
 		end
 	end)
-	self.controls.buildName = new("Control", {"LEFT",self.controls.back,"RIGHT"}, {8, 0, 0, 20})
+	self.controls.save = new("ButtonControl", {"LEFT",self.controls.back,"RIGHT"}, {8, 0, 50, 20}, "Save", function()
+		self:SaveDBFile()
+	end)
+	self.controls.save.enabled = function()
+		return not self.dbFileName or self.unsaved
+	end
+	self.controls.saveAs = new("ButtonControl", {"LEFT",self.controls.save,"RIGHT"}, {8, 0, 70, 20}, "Save As", function()
+		self:OpenSaveAsPopup()
+	end)
+	self.controls.saveAs.enabled = function()
+		return self.dbFileName
+	end
+
+	-- conditional for smaller screens to move "Current build" to the side bar
+	local function buildNameConditional()
+		return self.anchorTopBarRight:GetPos() < 900
+	end
+	self.controls.buildName = new("Control", {"LEFT",self.controls.saveAs,"RIGHT"}, {4, 36, 0, 20})
 	self.controls.buildName.width = function(control)
-		local limit = self.anchorTopBarRight:GetPos() - 98 - 40 - self.controls.back:GetSize() - self.controls.save:GetSize() - self.controls.saveAs:GetSize()
+		local limit = buildNameConditional() and 203 or
+			(self.anchorTopBarRight:GetPos() - 98 - 58
+			- self.controls.pointDisplay:GetSize() - self.controls.levelScalingButton:GetSize() - self.controls.characterLevel:GetSize()
+			- self.controls.back:GetSize() - self.controls.save:GetSize() - self.controls.saveAs:GetSize())
 		local bnw = DrawStringWidth(16, "VAR", self.buildName)
 		self.strWidth = m_min(bnw, limit)
 		self.strLimited = bnw > limit
@@ -137,30 +157,20 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			SetDrawLayer(nil, 0)
 		end
 	end
-	self.controls.save = new("ButtonControl", {"LEFT",self.controls.buildName,"RIGHT"}, {8, 0, 50, 20}, "Save", function()
-		self:SaveDBFile()
-	end)
-	self.controls.save.enabled = function()
-		return not self.dbFileName or self.unsaved
+	self.controls.buildName.x = function()
+		return buildNameConditional() and -196 or 8
 	end
-	self.controls.saveAs = new("ButtonControl", {"LEFT",self.controls.save,"RIGHT"}, {8, 0, 70, 20}, "Save As", function()
-		self:OpenSaveAsPopup()
-	end)
-	self.controls.saveAs.enabled = function()
-		return self.dbFileName
+	self.controls.buildName.y = function()
+		return buildNameConditional() and 32 or 0
 	end
 
 	-- Controls: top bar, right side
-	self.anchorTopBarRight = new("Control", nil, {function() return main.screenW / 2 + 6 end, 4, 0, 20})
-	self.controls.pointDisplay = new("Control", {"LEFT",self.anchorTopBarRight,"RIGHT"}, {-12, 0, 0, 20})
-	self.controls.pointDisplay.x = function(control)
-		local width, height = control:GetSize()
-		if self.controls.saveAs:GetPos() + self.controls.saveAs:GetSize() < self.anchorTopBarRight:GetPos() - width - 16 then
-			return -12 - width
-		else
-			return 0
-		end
+	self.anchorTopBarRight = new("Control", nil, {function() return main.screenW / 2 + self.controls.characterLevel.width + 11 end, 4, 0, 20})
+
+	local function getPointDisplayX() -- I had it hardcoded to -323 before switching to the control sizing
+		return - (23 + self.controls.pointDisplay:GetSize() + self.controls.levelScalingButton:GetSize() + self.controls.characterLevel:GetSize())
 	end
+	self.controls.pointDisplay = new("Control", {"LEFT",self.anchorTopBarRight,"RIGHT"}, {function() return getPointDisplayX() end, 0, 0, 20})
 	self.controls.pointDisplay.width = function(control)
 		control.str, control.req = self:EstimatePlayerProgress()
 		return DrawStringWidth(16, "FIXED", control.str) + 8
@@ -182,7 +192,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			SetDrawLayer(nil, 0)
 		end
 	end
-	self.controls.levelScalingButton = new("ButtonControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, {12, 0, 50, 20}, self.characterLevelAutoMode and "Auto" or "Manual", function()
+	self.controls.levelScalingButton = new("ButtonControl", {"LEFT",self.controls.pointDisplay,"RIGHT"}, {8, 0, 50, 20}, self.characterLevelAutoMode and "Auto" or "Manual", function()
 		self.characterLevelAutoMode = not self.characterLevelAutoMode
 		self.controls.levelScalingButton.label = self.characterLevelAutoMode and "Auto" or "Manual"
 		self.configTab:BuildModList()
@@ -226,7 +236,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			end
 		end
 	end
-	self.controls.classDrop = new("DropDownControl", {"LEFT",self.controls.characterLevel,"RIGHT"}, {8, 0, 100, 20}, nil, function(index, value)
+	self.controls.classDrop = new("DropDownControl", {"LEFT",self.controls.characterLevel,"RIGHT"}, {8, 0, 90, 20}, nil, function(index, value)
 		if value.classId ~= self.spec.curClassId then
 			if self.spec:CountAllocNodes() == 0 or self.spec:IsClassConnected(value.classId) then
 				self.spec:SelectClass(value.classId)
@@ -253,19 +263,12 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 			end
 		end
 	end)
-	self.controls.ascendDrop = new("DropDownControl", {"LEFT",self.controls.classDrop,"RIGHT"}, {8, 0, 150, 20}, nil, function(index, value)
+	self.controls.ascendDrop = new("DropDownControl", {"LEFT",self.controls.classDrop,"RIGHT"}, {8, 0, 120, 20}, nil, function(index, value)
 		self.spec:SelectAscendClass(value.ascendClassId)
 		self.spec:AddUndoState()
 		self.spec:SetWindowTitleWithBuildClass()
 		self.buildFlag = true
 	end)
-	-- // hiding away until we learn more, this dropdown and the Loadout dropdown conflict for UI space, will need to address if secondaryAscendancies come back
-	--self.controls.secondaryAscendDrop = new("DropDownControl", {"LEFT",self.controls.ascendDrop,"RIGHT"}, {8, 0, 120, 20}, nil, function(index, value)
-	--	self.spec:SelectSecondaryAscendClass(value.ascendClassId)
-	--	self.spec:AddUndoState()
-	--	self.spec:SetWindowTitleWithBuildClass()
-	--	self.buildFlag = true
-	--end)
 	self.controls.buildLoadouts = new("DropDownControl", {"LEFT",self.controls.ascendDrop,"RIGHT"}, {8, 0, 190, 20}, {}, function(index, value)
 		if value == "^7^7Loadouts:" or value == "^7^7-----" then
 			self.controls.buildLoadouts:SetSel(1)
@@ -381,15 +384,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 
 		self.controls.buildLoadouts:SelByValue(value)
 	end)
-
-	--self.controls.similarBuilds = new("ButtonControl", {"LEFT",self.controls.buildLoadouts,"RIGHT"}, {8, 0, 100, 20}, "Similar Builds", function()
-	--	self:OpenSimilarPopup()
-	--end)
-	--self.controls.similarBuilds.tooltipFunc = function(tooltip)
-	--	tooltip:Clear()
-	--	tooltip:AddLine(16, "Search for builds similar to your current character.")
-	--	tooltip:AddLine(16, "For best results, make sure to select your main item set, tree, and skills before opening the popup.")
-	--end
 	
 	if buildName == "~~temp~~" then
 		-- Remove temporary build file
@@ -404,7 +398,11 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 	self.displayStats, self.minionDisplayStats, self.extraSaveStats = LoadModule("Modules/BuildDisplayStats")
 
 	-- Controls: Side bar
-	self.anchorSideBar = new("Control", nil, {4, 36, 0, 0})
+	self.anchorSideBar = new("Control", nil, {4, 60, 0, 0})
+	self.anchorSideBar.y = function()
+		return buildNameConditional() and 60 or 36
+	end
+
 	self.controls.modeImport = new("ButtonControl", {"TOPLEFT",self.anchorSideBar,"TOPLEFT"}, {0, 0, 134, 20}, "Import/Export Build", function()
 		self.viewMode = "IMPORT"
 	end)
@@ -1137,6 +1135,7 @@ function buildMode:OnFrame(inputEvents)
 	self.controls.classDrop:SelByValue(self.spec.curClassId, "classId")
 	self.controls.ascendDrop.list = self.controls.classDrop:GetSelValueByKey("ascendancies")
 	self.controls.ascendDrop:SelByValue(self.spec.curAscendClassId, "ascendClassId")
+	self.controls.ascendDrop:CheckDroppedWidth(true)
 	-- // secondaryAscend dropdown hidden away until we learn more
 	--self.controls.secondaryAscendDrop.list = {{label = "None", ascendClassId = 0}, {label = "Warden", ascendClassId = 1}, {label = "Warlock", ascendClassId = 2}, {label = "Primalist", ascendClassId = 3}}
 	--self.controls.secondaryAscendDrop:SelByValue(self.spec.curSecondaryAscendClassId, "ascendClassId")

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -165,7 +165,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 	end
 
 	-- Controls: top bar, right side
-	self.anchorTopBarRight = new("Control", nil, {function() return main.screenW / 2 + self.controls.characterLevel.width + 11 end, 4, 0, 20})
+	self.anchorTopBarRight = new("Control", nil, {function() return main.screenW / 2 + self.controls.characterLevel.width + 10 end, 4, 0, 20})
 
 	local function getPointDisplayX() -- I had it hardcoded to -323 before switching to the control sizing
 		return - (23 + self.controls.pointDisplay:GetSize() + self.controls.levelScalingButton:GetSize() + self.controls.characterLevel:GetSize())
@@ -199,7 +199,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 		self.modFlag = true
 		self.buildFlag = true
 	end)
-	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.levelScalingButton,"RIGHT"}, {8, 0, 106, 20}, "", "Level", "%D", 3, function(buf)
+	self.controls.characterLevel = new("EditControl", {"LEFT",self.controls.levelScalingButton,"RIGHT"}, {10, 0, 106, 20}, "", "Level", "%D", 3, function(buf)
 		self.characterLevel = m_min(m_max(tonumber(buf) or 1, 1), 100)
 		self.configTab:BuildModList()
 		self.modFlag = true


### PR DESCRIPTION
### Description of the problem being solved:
A UI fix for smaller screens/portrait mode enjoyers. Ascendancy and Loadouts dropdowns in the top bar are cut off when widths get under a certain point. This PR moves some elements around and dynamically moves the Current Build to the sidebar to give us some much needed breathing room.

### Steps taken to verify a working solution:
- Resize all the things

### Before screenshot:
<img width="1089" height="197" alt="image" src="https://github.com/user-attachments/assets/e16ab2fa-e8a8-4391-875c-90c302672caf" />

### After screenshot:
<img width="1091" height="227" alt="image" src="https://github.com/user-attachments/assets/a8d74118-f968-4e8b-8e9f-02243b430b5f" />

---

<img width="1919" height="203" alt="image" src="https://github.com/user-attachments/assets/42e3b150-faf2-493c-9a6d-1fd89a4a8377" />
