### PR TITLE
Fix crash when importing some builds to party tab

### DIFF
--- a/spec/System/TestPartyTab_spec.lua
+++ b/spec/System/TestPartyTab_spec.lua
@@ -1,0 +1,35 @@
+describe("PartyTab", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	it("parses decimal tagged party member stats without treating the value as a nested key", function()
+		local partyTab = build.partyTab
+
+		local ok, err = pcall(function()
+			partyTab:ParseBuffs(
+				partyTab.actor["modDB"],
+				"MovementSpeedMod|percent|max=129.6",
+				"PartyMemberStats",
+				partyTab.actor["output"]
+			)
+		end)
+
+		assert.True(ok, err)
+		assert.True(math.abs(1.296 - partyTab.actor["output"].MovementSpeedMod) < 0.000001)
+	end)
+
+	it("preserves existing nested party member stats when parsing another stat for the same output table", function()
+		local partyTab = build.partyTab
+
+		partyTab:ParseBuffs(
+			partyTab.actor["modDB"],
+			"MainHand.CritChance=4.5\nMainHand.Speed=1.2",
+			"PartyMemberStats",
+			partyTab.actor["output"]
+		)
+
+		assert.are.equals(4.5, partyTab.actor["output"].MainHand.CritChance)
+		assert.are.equals(1.2, partyTab.actor["output"].MainHand.Speed)
+	end)
+end)

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -759,9 +759,12 @@ function PartyTabClass:ParseBuffs(list, buf, buffType, label)
 			for line in buf:gmatch("([^\n]*)\n?") do
 				if line:find("=") then
 					-- label is output for this type, as a special case
-					if line:match("%.") then
-						local k1, k2, v = line:match("([%w ]-%w+)%.([%w ]-%w+)=(.+)")
-						label[k1] = {[k2] = tonumber(v)}
+					local k1, k2, v = line:match("^([%w ]-%w+)%.([%w ]-%w+)=(.+)$")
+					if k1 then
+						if type(label[k1]) ~= "table" then
+							label[k1] = { }
+						end
+						label[k1][k2] = tonumber(v)
 					elseif line:match("|") then
 						local k, tags, v = line:match("([%w ]-%w+)|(.+)=(.+)")
 						v = tonumber(v)


### PR DESCRIPTION
﻿Summary
- Fix party member stat exports that contain decimal metadata values such as `MovementSpeedMod|percent|max=129.6`.
- Add regression coverage for decimal stat metadata and multi-key nested stat exports.

Root Cause
- `PartyTab.ParseBuffs` treated any stat export line containing `.` as a nested `key.subkey=value` line.
- Decimal values also contain `.`, so `max=129.6` was sent through the nested-stat path.
- That path then attempted to index a nil nested label table and crashed during party import.

Fix
- Replace the broad dot check with an anchored nested-stat matcher: `key.subkey=value`.
- Only use the nested path when the whole line matches that shape.
- Ensure the nested table exists before assigning subkeys.
- Decimal metadata now stays on the normal stat-value parsing path.

Validation
- PASS: `git diff --check`
  - Output only included line-ending warnings from the Windows checkout.
- PASS: focused Lua reproduction of the root cause/fix:
  - old broad dot path crashes on `MovementSpeedMod|percent|max=129.6`
  - anchored nested-stat path parses decimal metadata and preserves nested stats
- PASS: targeted Busted spec after installing the repo's LuaJIT/Busted dependencies locally:
  - Command: `busted --lua=luajit ../spec/System/TestPartyTab_spec.lua`
  - Output: `2 successes / 0 failures / 0 errors / 0 pending : 4.297 seconds`
- Not run locally: `docker-compose up`
  - Docker/docker-compose are not available in this local environment.

Risk / Rollback
- Low risk: this narrows an overly broad parser branch to the nested-stat syntax it was meant to handle.
- Valid nested exports remain covered by the regression test.
- Rollback is the single parser change plus the test file.

Fixes #1689
