### PR TITLE
Fix Item granted skills not showing up as Implicits when pasting

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -107,6 +107,41 @@ describe("TestItemParse", function()
 		assert.are.equals("+12 to Dexterity", item.explicitModLines[1].line)
 	end)
 
+	it("Pasted separated base granted skills stay implicit", function()
+		local item = new("Item", [[
+			Item Class: Spears
+			Rarity: Rare
+			Brood Edge
+			Jagged Spear
+			--------
+			Physical Damage: 33-61
+			Elemental Damage: 39-62 (fire), 9-14 (cold)
+			Critical Hit Chance: 8.70% (augmented)
+			Attacks per Second: 1.74 (augmented)
+			--------
+			Requires: Level 59, 33 Str, 81 (unmet) Dex
+			--------
+			Item Level: 76
+			--------
+			Bleeding you inflict deals Damage 11% faster (implicit)
+			--------
+			Grants Skill: Spear Throw
+			--------
+			Adds 39 to 62 Fire Damage
+			Adds 9 to 14 Cold Damage
+			+2.7% to Critical Hit Chance
+			16% increased Attack Speed
+			+22 to Dexterity
+		]])
+
+		assert.are.equals(2, #item.implicitModLines)
+		assert.are.equals("Bleeding you inflict deals Damage 11% faster", item.implicitModLines[1].line)
+		assert.are.equals("Grants Skill: Spear Throw", item.implicitModLines[2].line)
+		assert.are.equals(1, #item.grantedSkills)
+		assert.are.equals("SpearThrowPlayer", item.grantedSkills[1].skillId)
+		assert.are.equals("Adds 39 to 62 Fire Damage", item.explicitModLines[1].line)
+	end)
+
 	--TODO: POB2 Leagues?
 	--it("League", function()
 	--end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -62,6 +62,18 @@ local lineFlags = {
 	["custom"] = true, ["fractured"] = true, ["desecrated"] = true, ["mutated"] = true, ["enchant"] = true, ["implicit"] = true, ["rune"] = true,
 }
 
+local function baseHasImplicitLine(base, line)
+	if not base or not base.implicit then
+		return false
+	end
+	for implicitLine in base.implicit:gmatch("[^\n]+") do
+		if implicitLine == line then
+			return true
+		end
+	end
+	return false
+end
+
 -- Special function to store unique instances of modifier on specific item slots
 -- that require special handling for ItemConditions. Only called if line #224 is
 -- uncommented
@@ -395,10 +407,11 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		elseif line == "Requirements:" then
 			-- nothing to do
 		else
+			local lineIsBaseImplicit = mode == "GAME" and baseHasImplicitLine(self.base, line)
 			if self.checkSection then
 				if gameModeStage == "IMPLICIT" then
-					if foundImplicit then
-						-- There were definitely implicits, so any following modifiers must be explicits
+					if foundImplicit and not lineIsBaseImplicit then
+						-- There were definitely implicits, so any following non-base-implicit modifiers must be explicits
 						gameModeStage = "EXPLICIT"
 						foundExplicit = true
 					else
@@ -595,7 +608,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					   specName == "Armour" or specName == "Energy Shield" or specName == "Evasion" or specName == "Requires" then
 					self.hidden_specs = true
 				-- Anything else is an explicit with a colon in it (Fortress Covenant, Pure Talent, etc) unless it's part of the custom name
-				elseif not (self.name:match(specName) and self.name:match(specVal)) then
+				elseif not lineIsBaseImplicit and not (self.name:match(specName) and self.name:match(specVal)) then
 					foundExplicit = true
 					gameModeStage = "EXPLICIT"
 				end
@@ -644,6 +657,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					modLine.enchant = true
 				end
 				if modLine.enchant then
+					modLine.implicit = true
+				end
+				if lineIsBaseImplicit then
 					modLine.implicit = true
 				end
 				if modLine.desecrated then


### PR DESCRIPTION
﻿Summary
- Keep pasted base-granted skill lines implicit when they appear after an implicit separator.
- Add a regression using the reported spear paste text.

Root Cause
- Imported items already know that some base implicits grant skills.
- Pasted item parsing could leave the implicit section after a separator and then treat `Grants Skill: ...` as a normal explicit/unknown line.
- For spear bases, that meant `Grants Skill: Spear Throw` could be misclassified instead of detected as the base-granted skill.

Fix
- Add a small base-implicit line helper for raw item parsing.
- When parsing pasted game text, preserve a line as implicit if it exactly matches an implicit line on the resolved item base.
- Do not force such base-implicit lines into explicit mod handling.
- Preserve the following explicit mods normally.

Validation
- PASS: `git diff --check`
  - Output only included line-ending warnings from the Windows checkout.
- PASS: Lua syntax check for the touched files using `lupa`.
- PASS: targeted Busted spec after installing the repo's LuaJIT/Busted dependencies locally:
  - Command: `busted --lua=luajit ../spec/System/TestItemParse_spec.lua`
  - Output: `25 successes / 0 failures / 0 errors / 0 pending : 0.329 seconds`
- Not run locally: `docker-compose up`
  - Docker/docker-compose are not available in this local environment.
- ModCache regeneration: not applicable; this PR does not change mod parsing.

Risk / Rollback
- Low risk: the special handling only applies when a pasted line exactly matches the resolved base implicit.
- Explicit mods following the granted skill remain explicit and are covered by the regression.
- Rollback is the parser helper/branch plus the test.

Fixes #1728
