### PR TITLE
Fix projectile spell block EHP

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -527,4 +527,26 @@ describe("TestDefence", function()
 		assert.are.equals(0, floor(poolsRemaining.Life))
 		assert.are.equals(0, floor(poolsRemaining.OverkillDamage))
 	end)
+
+	it("uses block chance against projectile spells", function()
+		build.configTab.input.enemyIsBoss = "None"
+		build.configTab.input.enemyDamageType = "SpellProjectile"
+		build.configTab.input.customMods = [[
+			20% chance to block
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(20, build.calcsTab.calcsOutput.EffectiveBlockChance)
+		assert.are.equals(20, build.calcsTab.calcsOutput.EffectiveProjectileBlockChance)
+		assert.are.equals(20, build.calcsTab.calcsOutput.EffectiveSpellProjectileBlockChance)
+		assert.are.equals(80, build.calcsTab.calcsOutput.ConfiguredDamageChance)
+
+		build.configTab.input.enemyDamageType = "Average"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(15, build.calcsTab.calcsOutput.EffectiveAverageBlockChance)
+		assert.are.equals(85, build.calcsTab.calcsOutput.ConfiguredDamageChance)
+	end)
 end)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1005,7 +1005,8 @@ function calcs.defence(env, actor)
 		local totalSpellBlockChance = modDB:Sum("BASE", nil, "SpellBlockChance") * calcLib.mod(modDB, nil, "SpellBlockChance")
 		output.SpellBlockChance = m_min(totalSpellBlockChance, output.SpellBlockChanceMax)
 		output.SpellBlockChanceOverCap = m_max(0, totalSpellBlockChance - output.SpellBlockChanceMax)
-		output.SpellProjectileBlockChance = m_max(m_min(output.SpellBlockChance + modDB:Sum("BASE", nil, "ProjectileSpellBlockChance") * calcLib.mod(modDB, nil, "SpellBlockChance"), output.SpellBlockChanceMax), 0)
+		local spellProjectileBlockChance = m_min(output.SpellBlockChance + modDB:Sum("BASE", nil, "ProjectileSpellBlockChance") * calcLib.mod(modDB, nil, "SpellBlockChance"), output.SpellBlockChanceMax)
+		output.SpellProjectileBlockChance = m_max(spellProjectileBlockChance, output.ProjectileBlockChance, 0)
 	end
 	if breakdown then
 		breakdown.BlockChance = {


### PR DESCRIPTION
﻿Summary
- Make projectile spell block inherit the regular projectile block path when no separate spell block path applies.
- Add a defence regression for 20% block against Projectile Spell EHP.
- Document the current Average EHP category result so the regression guards both the bug and the intended category split.

Root Cause
- Generic PoE2 block is represented in PoB as BlockChance and ProjectileBlockChance.
- The EHP code calculated SpellProjectileBlockChance only from SpellBlockChance plus ProjectileSpellBlockChance.
- As a result, 20% block correctly showed for normal projectiles, but projectile spells had 0% block unless a spell-block-specific source existed.
- That made the configured EHP block failure chance too high for projectile spell hits, and also pulled the Average category down.

Fix
- Preserve the existing spell-projectile block path, but clamp SpellProjectileBlockChance to at least ProjectileBlockChance.
- Keep the change local to the block category calculation; no global EHP rewrite or projectile/block refactor.

Validation
- PASS: `git diff --check`
  - Output only included line-ending warnings from the Windows checkout.
- PASS: Lua syntax check for touched files using `lupa`:
  - `src/Modules/CalcDefence.lua: syntax ok`
  - `spec/System/TestDefence_spec.lua: syntax ok`
- PASS: static reproduction of the issue math:
  - before SpellProjectile ConfiguredDamageChance=100%
  - after  SpellProjectile ConfiguredDamageChance=80%
  - before Average ConfiguredDamageChance=90%
  - after  Average ConfiguredDamageChance=85%
- PASS: targeted Busted spec after installing the repo's LuaJIT/Busted dependencies locally:
  - Command: `busted --lua=luajit ../spec/System/TestDefence_spec.lua`
  - Output: `6 successes / 0 failures / 0 errors / 0 pending : 40.234 seconds`
- Not run locally: `docker-compose up`
  - Docker/docker-compose are not available in this local environment.

Risk / Rollback
- Low risk: this only changes the SpellProjectileBlockChance category to respect already-calculated ProjectileBlockChance.
- Existing explicit spell-projectile block still wins when it is higher.
- Rollback is the single calculation-line change plus the regression test.

Refs #1788
