### PR TITLE
Fix Ember Fusillade projectile DPS

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -238,6 +238,32 @@ describe("TestSkills", function()
 		assert.True(curseList:match("Flammability") ~= nil and curseList:match("Elemental Weakness") ~= nil)
 	end)
 
+	it("Ember Fusillade projectile count scales hit DPS and Full DPS", function()
+		build.skillsTab:PasteSocketGroup("Ember Fusillade 20/0  1\n")
+		build.skillsTab.socketGroupList[1].includeInFullDPS = true
+		build.buildFlag = true
+		runCallback("OnFrame")
+
+		local baseProjectileCount = build.calcsTab.mainOutput.ProjectileCount
+		local baseTotalDPS = build.calcsTab.mainOutput.TotalDPS
+		local baseFullDPS = build.calcsTab.mainOutput.FullDPS
+
+		assert.True(baseProjectileCount > 0)
+		assert.True(baseTotalDPS > 0)
+		assert.True(baseFullDPS > 0)
+
+		build.configTab.input.customMods = "Ember Fusillade fires 2 additional Projectiles"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local projectileCount = build.calcsTab.mainOutput.ProjectileCount
+		local expectedProjectileRatio = projectileCount / baseProjectileCount
+
+		assert.True(projectileCount > baseProjectileCount)
+		assert.True(build.calcsTab.mainOutput.TotalDPS > baseTotalDPS * expectedProjectileRatio * 0.95)
+		assert.True(build.calcsTab.mainOutput.FullDPS > baseFullDPS * expectedProjectileRatio * 0.95)
+	end)
+
 	-- skills that don't have a base CD and have more than one use need to use the added cooldown by whatever support allows the +1 limit to be supportable
 	it("Test Added Cooldown interaction with +1 Limit", function()
 		build.skillsTab:PasteSocketGroup("Thunderstorm 20/0  1\nHourglass 1/0 1\nOverabundance I 1/0 1\n")

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -5848,6 +5848,9 @@ skills["EmberFusilladePlayer"] = {
 		[39] = { critChance = 7, levelRequirement = 90, cost = { Mana = 206, }, },
 		[40] = { critChance = 7, levelRequirement = 90, cost = { Mana = 225, }, },
 	},
+			preDamageFunc = function(activeSkill, output)
+				activeSkill.skillData.dpsMultiplier = output.ProjectileCount or 1
+			end,
 	statSets = {
 		[1] = {
 			label = "Projectile",

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -405,6 +405,9 @@ statMap = {
 #skillEnd
 
 #skill EmberFusilladePlayer
+preDamageFunc = function(activeSkill, output)
+	activeSkill.skillData.dpsMultiplier = output.ProjectileCount or 1
+end,
 #set EmberFusilladePlayer
 #flags spell duration projectile
 #mods


### PR DESCRIPTION
﻿Summary
- Make Ember Fusillade's hit DPS scale with its calculated Projectile Count.
- Add a regression covering both Hit DPS and Full DPS when Ember Fusillade gains additional projectiles.
- Update the skill export template and the generated skill data together so future skill-data exports preserve the fix.

Root Cause
- Ember Fusillade already calculated and displayed Projectile Count correctly.
- The generic hit DPS path intentionally does not multiply every projectile skill by Projectile Count, because many projectile skills do not shotgun.
- Ember Fusillade is one of the skills where multiple embers from the same fusillade can hit, but the skill did not set a skill-local DPS multiplier.
- Full DPS then inherited the same undercount because it aggregates TotalDPS.

Fix
- Add an Ember Fusillade-local `preDamageFunc` that maps the already-calculated `output.ProjectileCount` into `skillData.dpsMultiplier`.
- Keep the multiplier skill-specific; no global projectile DPS behavior changed.
- Add a focused regression that verifies additional Ember Fusillade projectiles increase Projectile Count, TotalDPS, and FullDPS together.

Validation
- PASS: `git diff --check`
  - Output only included line-ending warnings from the Windows checkout.
- PASS: Lua syntax check for touched Lua files using `lupa`:
  - `src/Data/Skills/act_int.lua: syntax ok`
  - `spec/System/TestSkills_spec.lua: syntax ok`
- PASS: static reproduction of the calculation path:
  - before additional projectiles ratio=1
  - after additional projectiles ratio=3
- PASS: targeted Busted spec after installing the repo's LuaJIT/Busted dependencies locally:
  - Command: `busted --lua=luajit ../spec/System/TestSkills_spec.lua`
  - Output: `11 successes / 0 failures / 0 errors / 0 pending : 67.641 seconds`
- Not run locally: `docker-compose up`
  - Docker/docker-compose are not available in this local environment.
- ModCache regeneration: not applicable; this PR does not change mod parsing.

Generated data note
- `src/Export/Skills/act_int.txt` is the source template change.
- `src/Data/Skills/act_int.lua` is the matching generated data update included for review/runtime consistency.

Risk / Rollback
- Low risk: the DPS multiplier is scoped to Ember Fusillade only.
- The generic projectile calculation remains unchanged, avoiding accidental shotgun scaling for unrelated projectile skills.
- Rollback is the one Ember Fusillade skill-template/data change plus the regression test.

Fixes #1850
