### PR TITLE
Fix pasted items not selecting correct runes

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -263,6 +263,48 @@ describe("TestItemParse", function()
 		
 	end)
 
+
+	it("infers pasted multi-value rune lines as whole runes", function()
+		local item = new("Item", [[
+			Rarity: Rare
+			Onslaught Relic
+			Warmonger Bow
+			--------
+			Quality: +20% (augmented)
+			Physical Damage: 91-161 (augmented)
+			Elemental Damage: 57-98 (fire), 58-98 (cold)
+			Critical Hit Chance: 11.00%
+			Attacks per Second: 1.50 (augmented)
+			--------
+			Requires: Level 67, 86 Str, 65 Int
+			--------
+			Sockets: S S S
+			--------
+			Item Level: 81
+			--------
+			Adds 9 to 15 Cold Damage (rune)
+			Leeches 3% of Physical Damage as Life (rune)
+			Bonded: 5% increased maximum Life (rune)
+			Bonded: 30% increased Freeze Buildup (rune)
+			--------
+			Adds 16 to 35 Physical Damage
+			Adds 49 to 83 Cold Damage
+			20% increased Attack Speed
+			+31 to Strength
+			Adds 57 to 98 Fire Damage (desecrated)
+			--------
+			Corrupted
+		]])
+
+		assert.are.equals(3, item.itemSocketCount)
+		assert.are.same({ "Greater Glacial Rune", "Greater Body Rune" }, item.runes)
+		assert.are.equals(1, item.runeModLines[1].runeCount)
+		assert.are.equals(1, item.runeModLines[2].runeCount)
+		for _, rune in ipairs(item.runes) do
+			assert.are_not.equals("Lesser Glacial Rune", rune)
+		end
+	end)
+
 	it("multi-line rune mod", function()
 		-- Thruldana is Bow-only as well
 		local item = new("Item", [[

--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -300,6 +300,8 @@ describe("TestItemParse", function()
 		assert.are.same({ "Greater Glacial Rune", "Greater Body Rune" }, item.runes)
 		assert.are.equals(1, item.runeModLines[1].runeCount)
 		assert.are.equals(1, item.runeModLines[2].runeCount)
+		assert.is_nil(item.runeModLines[3].runeCount)
+		assert.is_nil(item.runeModLines[4].runeCount)
 		for _, rune in ipairs(item.runes) do
 			assert.are_not.equals("Lesser Glacial Rune", rune)
 		end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -839,8 +839,90 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		if self.base.weapon or self.base.armour or self.base.tags.wand or self.base.tags.staff or self.base.tags.sceptre then
 			local shouldFixRunesOnItem = #self.runes == 0
 
+			local function getRuneLineParts(modLine)
+				local values = { }
+				local strippedModLine = modLine:gsub("(%d%.?%d*)", function(val)
+					t_insert(values, tonumber(val))
+					return "#"
+				end)
+				if #values == 0 then
+					t_insert(values, 1)
+				end
+				return strippedModLine, values
+			end
+
+			local function compareRuneValueSets(a, b)
+				for i = 1, math.max(#a, #b) do
+					local aVal = a[i] or 0
+					local bVal = b[i] or 0
+					if aVal ~= bVal then
+						return aVal > bVal
+					end
+				end
+				return false
+			end
+
+			local function runeValueSetsEqual(a, b)
+				for i = 1, math.max(#a, #b) do
+					if math.abs((a[i] or 0) - (b[i] or 0)) > 1e-9 then
+						return false
+					end
+				end
+				return true
+			end
+
+			local function addRuneValueSets(a, b)
+				local out = { }
+				for i = 1, math.max(#a, #b) do
+					out[i] = (a[i] or 0) + (b[i] or 0)
+				end
+				return out
+			end
+
+			local function runeValueSetExceeds(valueSet, target)
+				for i = 1, math.max(#valueSet, #target) do
+					if (valueSet[i] or 0) > (target[i] or 0) + 1e-9 then
+						return true
+					end
+				end
+				return false
+			end
+
+			local function findRuneCombination(groupedRunes, targetValues, maxRunes)
+				local best = { }
+				local counts = { }
+
+				local function search(startIndex, count, sum)
+					if runeValueSetsEqual(sum, targetValues) then
+						if not best.count or count < best.count then
+							best.count = count
+							best.counts = { }
+							for index, value in pairs(counts) do
+								best.counts[index] = value
+							end
+						end
+						return
+					end
+					if count >= maxRunes or (best.count and count >= best.count) then
+						return
+					end
+
+					for index = startIndex, #groupedRunes do
+						local nextSum = addRuneValueSets(sum, groupedRunes[index].values)
+						if not runeValueSetExceeds(nextSum, targetValues) then
+							counts[index] = (counts[index] or 0) + 1
+							search(index, count + 1, nextSum)
+							counts[index] = counts[index] - 1
+						end
+					end
+				end
+
+				search(1, 0, { })
+				return best.counts, best.count
+			end
+
 			-- Form a key value table with the following format
-			-- { [strippedModLine] = { { runeName1, runeValue1 }, etc, }, etc}
+			-- { [strippedModLine] = { { name = runeName1, values = { low, high } }, etc, }, etc}
 			-- This will be used to more easily grab the relevant runes that combinations will need to be of.
 			-- This could be refactored to only needs to be called once.
 			local statGroupedRunes = { }
@@ -848,15 +930,11 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			local specificItemType = self.base.type:lower()
 			for runeName, runeMods in pairs(data.itemMods.Runes) do
 				local addModToGroupedRunes = function (modLine)
-					local runeValue = 1
-					local runeStrippedModLine = modLine:gsub("(%d%.?%d*)", function(val)
-						runeValue = val
-						return "#"
-					end)
+					local runeStrippedModLine, runeValues = getRuneLineParts(modLine)
 					if statGroupedRunes[runeStrippedModLine] == nil then
 						statGroupedRunes[runeStrippedModLine] = { }
 					end
-					t_insert(statGroupedRunes[runeStrippedModLine], { runeName, runeValue });
+					t_insert(statGroupedRunes[runeStrippedModLine], { name = runeName, values = runeValues })
 				end
 				for slotType, slotMod in pairs(runeMods) do
 					if slotType == broadItemType or slotType == specificItemType then
@@ -869,129 +947,27 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 
 			-- Sort table to ensure first entries are always largest.
 			for _, runes in pairs(statGroupedRunes) do
-				table.sort(runes,  function(a, b) return a[2] > b[2] end)
+				table.sort(runes,  function(a, b) return compareRuneValueSets(a.values, b.values) end)
 			end
 
 			local remainingRunes = self.itemSocketCount
 			for i, modLine in ipairs(self.runeModLines) do
-				local value = 1
-				local strippedModLine = modLine.line:gsub("(%d%.?%d*)", function(val)
-					value = val
-					return "#"
-				end)
+				local strippedModLine, targetValues = getRuneLineParts(modLine.line)
 				local groupedRunes = statGroupedRunes[strippedModLine]
-				if groupedRunes then -- found the rune category with the relevant stat.
-					-- First a greedy base is found using the runes in the groupedRunes. If this matches the target value then that set of runes is applied.
-					-- If the greedy base isn't a solution we search all the possible combinations that could lead to a valid combination.
-					-- This done by recursing through all combinations that could lead to a valid value and pruning values that exceed the number
-					-- of runes and solutions that it would be impossible to reach the target value from. Visited combinations are recorded and are used such 
-					-- that candidates are only searched once. This makes for a fairly efficient algorithm that doesn't search unneeded values very much.
-					local function getNumberOfRunesOfEachType(values, target)
-						local function adjustCombination(values, target, result, best, visited, sum, count)
-							-- This is used to avoid unnecessary checks on decrement.
-							local function checkAndAdjustCombination(values, target, result, best, visited, sum, count)
-								-- If it's a valid solution, update best
-								if math.abs(sum-target) <  1e-9 then
-									if not best.count or count < best.count then
-										best.count = count
-										-- Copy solution to avoid side effects from continued searching.
-										local solution = {}
-										for k, v in pairs(result) do
-											solution[k] = v
-										end
-										best.solution = solution
-									end
-									return
-								end
-
-								-- Prune if we already used more runes than the best found
-								if best.count and count >= best.count then return end
-
-								return adjustCombination(values, target, result, best, visited, sum, count)
-							end
-
-							for _, v in ipairs(values) do
-								local function checkUnique(result)
-									-- Generate a unique key from the result table this prevents duplicates combinations being searched
-									local key = ""
-									for value, count in pairs(result) do
-										if count > 0 then
-											key = key .. value .. "x" .. count .. " "
-										end
-									end
-									if visited[key] then 
-										return false 
-									else
-										visited[key] = true
-										return true
-									end
-								end
-								
-								-- Incrementing is done first as to reach the target you will need to add a count as such it should be more efficient.
-								-- Try increasing (if it doesn't overshoot or exceed maximum number of remaining runes)
-								if sum + tonumber(v) <= target + 1e-9 and count < remainingRunes then
-									result[v] = (result[v] or 0) + 1
-									if checkUnique(result) then
-										checkAndAdjustCombination(values, target, result, best, visited, sum + v, count + 1)
-									end
-									result[v] = result[v] - 1
-								end
-
-								-- Try decreasing (if possible and only if target is still reachable).
-								if (result[v] or 0) > 0 and (not best.count or target - 1e-9 < sum - tonumber(v) + values[1] * (best.count - count + 1)) then
-									result[v] = result[v] - 1
-									if checkUnique(result) then
-										adjustCombination(values, target, result, best, visited, sum - v, count - 1)
-									end
-									result[v] = result[v] + 1
-								end
-							end
-						end
-						
-						-- Step 1: Perform greedy search and tests if a single rune is used as these are the most common use case.
-						local greedySolution = {}
-						local leftover = target
-
-						for _, v in ipairs(values) do
-							local count = math.floor(leftover / v)
-							greedySolution[v] = count
-							leftover = leftover - count * v
-						end
-
-						local greedyCount = 0
-						for v, c in pairs(greedySolution) do
-							greedyCount = greedyCount + c
-						end
-						if math.abs(leftover) <= 1e-9 then -- Greedy search found a solution
-							return greedySolution, greedyCount
-						end
-
-						-- Step 2. Perform search starting from the greedy base
-						local best = {count = nil, solution = nil}
-						local visited = {}
-
-						adjustCombination(values, target, greedySolution, best, visited, target - leftover, greedyCount)
-
-						return best.solution, best.count
-					end
-
-					local values = { }
-					for i, runes in ipairs(groupedRunes) do
-						t_insert(values, runes[2])
-					end
-					local result, numRunes = getNumberOfRunesOfEachType(values, tonumber(value))
+				if groupedRunes and not (shouldFixRunesOnItem and modLine.bonded) then -- found the rune category with the relevant stat.
+					local result, numRunes = findRuneCombination(groupedRunes, targetValues, remainingRunes)
 
 					if result then -- we have found a valid combo for that rune category
 						remainingRunes = remainingRunes - numRunes
 						-- this code should probably be refactored to based off stored self.runes rather than the recomputed amounts off the runeModLines this 
 						-- is too avoid having to run the relatively expensive recomputation every time the item is parsed even if we know the runes on the item already.
-						modLine.soulCore = groupedRunes[1][1]:match("Soul Core") ~= nil
+						modLine.soulCore = groupedRunes[1].name:match("Soul Core") ~= nil
 						modLine.runeCount = numRunes
 
 						if shouldFixRunesOnItem then
-							for i, rune in ipairs(groupedRunes) do
-								for _ = 1, tonumber(result[rune[2]]) do
-									t_insert(self.runes, groupedRunes[i][1])
+							for index, rune in ipairs(groupedRunes) do
+								for _ = 1, result[index] or 0 do
+									t_insert(self.runes, rune.name)
 								end
 							end
 						end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -954,7 +954,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			for i, modLine in ipairs(self.runeModLines) do
 				local strippedModLine, targetValues = getRuneLineParts(modLine.line)
 				local groupedRunes = statGroupedRunes[strippedModLine]
-				if groupedRunes and not (shouldFixRunesOnItem and modLine.bonded) then -- found the rune category with the relevant stat.
+				if groupedRunes and not modLine.bonded then -- found the rune category with the relevant stat.
 					local result, numRunes = findRuneCombination(groupedRunes, targetValues, remainingRunes)
 
 					if result then -- we have found a valid combo for that rune category


### PR DESCRIPTION
## Summary
Fixes #1675

- reconstruct pasted rune sockets from the full numeric tuple in a rune mod line instead of only the final number
- avoids using `Bonded:` secondary rune lines to add extra socketed runes during paste reconstruction
- adds a regression fixture for a pasted item with `Adds 9 to 15 Cold Damage (rune)` plus a life-leech rune and an empty socket

## Root Cause
Pasted items without explicit `Rune:` metadata rebuild `item.runes` from the visible rune mod lines. The matcher grouped rune stats by replacing numbers with `#`, but retained only the last number in each line. For a range such as `Adds 9 to 15 Cold Damage`, the target became `15`, so the solver could reconstruct three Lesser Glacial Runes (`3 to 5`) instead of one Greater Glacial Rune (`9 to 15`). After fixing the range match, `Bonded:` secondary lines also needed to be excluded from adding additional inferred runes, otherwise a secondary line could consume the remaining empty socket.

## Fix
Rune inference now stores and compares all numeric values in a mod line as a vector. The combination search sums vectors, so a range must match both low and high values. During paste reconstruction, `Bonded:` lines are not used to add extra socketed rune names; the primary rune lines remain the source of truth for rebuilding `item.runes`.

## Validation
- `busted --lua=luajit ../spec/System/TestItemParse_spec.lua`
  - PASS: `25 successes / 0 failures / 0 errors / 0 pending : 0.421 seconds`
- `git diff --check`
  - PASS

## Risk/Rollback
Risk is limited to rune reconstruction for pasted items that lack explicit `Rune:` metadata. Existing parsed rune mod lines still remain intact. Rollback is this commit only.