### PR TITLE
Default From Nothing imports to small radius

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -58,6 +58,26 @@ describe("TestItemParse", function()
 	--it("Sockets", function()
 	--end)
 
+
+	it("defaults trade-site From Nothing jewels to small radius", function()
+		local item = new("Item", [[
+			Rarity: Unique
+			From Nothing
+			Diamond
+			Item Level: 84
+			--------
+			Passives in Radius of Walker of the Wilds can be Allocated
+			without being connected to your tree
+			--------
+			Corrupted
+		]])
+
+		assert.are.equals("Small", item.jewelRadiusLabel)
+		assert.are.equals(1, item.jewelRadiusIndex)
+		assert.are.equals("walker of the wilds", item.jewelData.fromNothingKeystone)
+		assert.truthy(item.jewelData.fromNothingKeystones["walker of the wilds"])
+	end)
+
 	--TODO: impl jewels for POB2
 	--it("Jewel", function()
 	--end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1098,6 +1098,15 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 	if deferJewelRadiusIndexAssignment then
 		self.jewelRadiusIndex = self.jewelData.radiusIndex
 	end
+	if self.jewelData and self.jewelData.fromNothingKeystone and not self.jewelRadiusIndex then
+		for index, radiusData in pairs(data.jewelRadius) do
+			if radiusData.label == "Small" then
+				self.jewelRadiusIndex = index
+				self.jewelRadiusLabel = radiusData.label
+				break
+			end
+		end
+	end
 	if self.jewelData and self.jewelData.timeLostJewelRadiusOverride then
 		self.jewelRadiusIndex = self.jewelData.timeLostJewelRadiusOverride
 	end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -2340,9 +2340,13 @@ function PassiveSpecClass:NodeAdditionOrReplacementFromString(node,sd,replacemen
 end
 
 function PassiveSpecClass:NodeInKeystoneRadius(keystoneNames, nodeId, radiusIndex)
+	if not radiusIndex then
+		return false
+	end
 	for _, node in pairs(self.nodes) do
 		if node.name and node.type == "Keystone" and keystoneNames[node.name:lower()] then
-			if (node.nodesInRadius[radiusIndex][nodeId]) then
+			local nodesInRadius = node.nodesInRadius and node.nodesInRadius[radiusIndex]
+			if nodesInRadius and nodesInRadius[nodeId] then
 				return true
 			end
 		end


### PR DESCRIPTION
## Summary
Fixes #1457

- defaults trade-site `From Nothing` jewel imports to the unique's known `Small` radius when the pasted text omits the `Radius: Small` property
- hardens `NodeInKeystoneRadius` so a missing or unavailable radius map returns false instead of indexing nil
- adds a regression fixture using the trade-site copied text from the issue

## Root Cause
Trade-site item text for `From Nothing` can omit the `Radius: Small` line that is present in the in-game copy. The parser only set `jewelRadiusIndex` from an explicit radius property, so the imported jewel kept its From Nothing keystone data but had no radius. Passive tree code later used that missing radius while checking keystone-radius allocation support, which could crash on nil indexing.

## Fix
After parsing jewel mods, `From Nothing` imports with no parsed radius now receive the generated unique's known `Small` radius. The keystone-radius helper also validates the radius before indexing tree radius maps, so malformed future jewel data fails closed rather than crashing.

## Validation
- `busted --lua=luajit ../spec/System/TestItemParse_spec.lua`
  - PASS: `25 successes / 0 failures / 0 errors / 0 pending : 0.281 seconds`
- `git diff --check`
  - PASS

## Risk/Rollback
Risk is limited to `From Nothing` jewel imports missing radius metadata and to safer nil handling in one passive tree radius helper. Rollback is this commit only.