### PR TITLE
Guard minion skill tooltip state

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -7,6 +7,22 @@ describe("TestSkills", function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
 	
+
+	it("does not crash when minion tooltip state has no main skill", function()
+		local tooltip = {
+			AddLine = function() end,
+			AddSeparator = function() end,
+		}
+		local socketGroup = {
+			enabled = true,
+			slotEnabled = true,
+			displaySkillList = { { effectList = { }, minion = { } } },
+			gemList = { },
+		}
+
+		build.skillsTab:AddSocketGroupTooltip(tooltip, socketGroup)
+	end)
+
 	it("Test blasphemy reserving Spirit", function()
 		build.skillsTab:PasteSocketGroup("Blasphemy 20/0  1\nDespair 20/0  1\n")
 		runCallback("OnFrame")

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1165,17 +1165,20 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 			end
 		end
 		if activeSkill.minion then
-			tooltip:AddSeparator(10)
-			tooltip:AddLine(16, "^7Active Skill #" .. index .. "'s Main Minion Skill:")
-			local activeEffect = activeSkill.minion.mainSkill.effectList[1]
-			tooltip:AddLine(20, string.format("%s%s ^7%d/%d",
-				data.skillColorMap[activeEffect.grantedEffect.color] or colorCodes.NORMAL,
-				activeEffect.grantedEffect.name,
-				activeEffect.level,
-				activeEffect.quality
-			))
-			if activeEffect.srcInstance then
-				gemShown[activeEffect.srcInstance] = true
+			local mainSkill = activeSkill.minion.mainSkill
+			local activeEffect = mainSkill and mainSkill.effectList and mainSkill.effectList[1]
+			if activeEffect and activeEffect.grantedEffect then
+				tooltip:AddSeparator(10)
+				tooltip:AddLine(16, "^7Active Skill #" .. index .. "'s Main Minion Skill:")
+				tooltip:AddLine(20, string.format("%s%s ^7%d/%d",
+					data.skillColorMap[activeEffect.grantedEffect.color] or colorCodes.NORMAL,
+					activeEffect.grantedEffect.name,
+					activeEffect.level,
+					activeEffect.quality
+				))
+				if activeEffect.srcInstance then
+					gemShown[activeEffect.srcInstance] = true
+				end
 			end
 		end
 	end


### PR DESCRIPTION
## Summary
Fixes #1787

- stops the Skills tab tooltip from crashing when a displayed minion skill has not populated `minion.mainSkill`
- keeps the existing main-minion-skill tooltip for fully populated minion skill state
- adds a regression fixture that exercises the malformed tooltip state from the stack trace

## Root Cause
`SkillsTab:AddSocketGroupTooltip` treated `activeSkill.minion` as proof that `activeSkill.minion.mainSkill.effectList[1]` existed. The issue stack shows that hover/tooltips can observe a partially populated minion state where `minion` exists but `mainSkill` is nil, so the tooltip path could crash even though this is only presentation logic.

## Fix
The tooltip now validates the nested minion main-skill/effect state before rendering that optional subsection. Valid minion main-skill data is still rendered exactly as before; incomplete minion state is skipped rather than taking down the Skills tab.

## Validation
- `busted --lua=luajit ../spec/System/TestSkills_spec.lua`
  - PASS: `11 successes / 0 failures / 0 errors / 0 pending : 62.593 seconds`
- `git diff --check`
  - PASS

## Risk/Rollback
Risk is limited to the optional minion main-skill tooltip section. Fully populated minion tooltips retain the same output; incomplete state no longer crashes. Rollback is this commit only.