### PR TITLE
Fix crash on loading build due to some minion skills

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -10,13 +10,14 @@ describe("TestSkills", function()
 
 	it("uses granted effect minion list when active skill minion list is missing", function()
 		local srcInstance = { statSet = { }, skillPart = { }, nameSpec = "Spectre: Test" }
+		local minionId = "RaisedSkeletonSniper"
 		local activeEffect = {
 			srcInstance = srcInstance,
 			grantedEffect = {
 				id = "TestSpectreSkill",
 				name = "Spectre: Test",
 				statSets = { { label = "Default" } },
-				minionList = { "Metadata/Monsters/Skeletons/Skeleton" },
+				minionList = { minionId },
 			},
 			statSet = { skillFlags = { } },
 		}
@@ -25,7 +26,6 @@ describe("TestSkills", function()
 			skillData = { },
 			-- activeSkill.minionList intentionally absent; this reproduces #1677.
 		}
-		build.data.minions["Metadata/Monsters/Skeletons/Skeleton"] = { name = "Test Skeleton" }
 		build.skillsTab.socketGroupList[1] = {
 			displaySkillList = { activeSkill },
 			mainActiveSkill = 1,
@@ -33,8 +33,8 @@ describe("TestSkills", function()
 
 		build:RefreshSkillSelectControls(build.controls, 1, "")
 
-		assert.are.equals("Test Skeleton", build.controls.mainSkillMinion.list[1].label)
-		assert.are.equals("Metadata/Monsters/Skeletons/Skeleton", build.controls.mainSkillMinion.list[1].minionId)
+		assert.are.equals("Skeletal Sniper", build.controls.mainSkillMinion.list[1].label)
+		assert.are.equals(minionId, build.controls.mainSkillMinion.list[1].minionId)
 	end)
 
 	it("Test blasphemy reserving Spirit", function()

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -7,6 +7,36 @@ describe("TestSkills", function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
 	
+
+	it("uses granted effect minion list when active skill minion list is missing", function()
+		local srcInstance = { statSet = { }, skillPart = { }, nameSpec = "Spectre: Test" }
+		local activeEffect = {
+			srcInstance = srcInstance,
+			grantedEffect = {
+				id = "TestSpectreSkill",
+				name = "Spectre: Test",
+				statSets = { { label = "Default" } },
+				minionList = { "Metadata/Monsters/Skeletons/Skeleton" },
+			},
+			statSet = { skillFlags = { } },
+		}
+		local activeSkill = {
+			activeEffect = activeEffect,
+			skillData = { },
+			-- activeSkill.minionList intentionally absent; this reproduces #1677.
+		}
+		build.data.minions["Metadata/Monsters/Skeletons/Skeleton"] = { name = "Test Skeleton" }
+		build.skillsTab.socketGroupList[1] = {
+			displaySkillList = { activeSkill },
+			mainActiveSkill = 1,
+		}
+
+		build:RefreshSkillSelectControls(build.controls, 1, "")
+
+		assert.are.equals("Test Skeleton", build.controls.mainSkillMinion.list[1].label)
+		assert.are.equals("Metadata/Monsters/Skeletons/Skeleton", build.controls.mainSkillMinion.list[1].minionId)
+	end)
+
 	it("Test blasphemy reserving Spirit", function()
 		build.skillsTab:PasteSocketGroup("Blasphemy 20/0  1\nDespair 20/0  1\n")
 		runCallback("OnFrame")

--- a/src/Classes/CompareEntry.lua
+++ b/src/Classes/CompareEntry.lua
@@ -379,12 +379,14 @@ function CompareEntryClass:RefreshSkillSelectControls(controls, mainGroup, suffi
 
 	-- Minion controls
 	local disabled = activeSkill.activeEffect and activeSkill.activeEffect.statSet and activeSkill.activeEffect.statSet.skillFlags.disable
-	if not disabled and activeSkill.minion and (activeEffect.grantedEffect.minionList or (activeSkill.minionList and activeSkill.minionList[1])) then
-		self:RefreshMinionControls(controls, activeSkill, activeEffect, suffix)
+	local minionList = activeSkill.minionList or activeEffect.grantedEffect.minionList
+	if not disabled and activeSkill.minion and (activeEffect.grantedEffect.minionList or (minionList and minionList[1])) then
+		self:RefreshMinionControls(controls, activeSkill, activeEffect, suffix, minionList)
 	end
 end
 
-function CompareEntryClass:RefreshMinionControls(controls, activeSkill, activeEffect, suffix)
+function CompareEntryClass:RefreshMinionControls(controls, activeSkill, activeEffect, suffix, minionList)
+	minionList = minionList or activeSkill.minionList or activeEffect.grantedEffect.minionList or { }
 	wipeTable(controls.mainSkillMinion.list)
 	if activeEffect.grantedEffect.minionHasItemSet then
 		for _, itemSetId in ipairs(self.itemsTab.itemSetOrderList) do
@@ -396,11 +398,14 @@ function CompareEntryClass:RefreshMinionControls(controls, activeSkill, activeEf
 		end
 		controls.mainSkillMinion:SelByValue(activeEffect.srcInstance["skillMinionItemSet" .. suffix] or 1, "itemSetId")
 	else
-		for _, minionId in ipairs(activeSkill.minionList) do
-			t_insert(controls.mainSkillMinion.list, {
-				label = self.data.minions[minionId].name,
-				minionId = minionId,
-			})
+		for _, minionId in ipairs(minionList) do
+			local minion = self.data.minions[minionId]
+			if minion then
+				t_insert(controls.mainSkillMinion.list, {
+					label = minion.name,
+					minionId = minionId,
+				})
+			end
 		end
 		controls.mainSkillMinion:SelByValue(
 		activeEffect.srcInstance["skillMinion" .. suffix] or controls.mainSkillMinion.list[1], "minionId")

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1818,7 +1818,8 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 					controls.mainSkillStageCount.shown = true
 					controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeSkill.skillData.stagesMin or 1)
 				end
-				if not activeSkill.activeEffect.statSet.skillFlags.disable and (activeEffect.grantedEffect.minionList or (activeSkill.minionList and activeSkill.minionList[1])) then
+				local minionList = activeSkill.minionList or activeEffect.grantedEffect.minionList
+				if not activeSkill.activeEffect.statSet.skillFlags.disable and (activeEffect.grantedEffect.minionList or (minionList and minionList[1])) then
 					wipeTable(controls.mainSkillMinion.list)
 					if activeEffect.grantedEffect.minionHasItemSet then
 						for _, itemSetId in ipairs(self.itemsTab.itemSetOrderList) do
@@ -1842,11 +1843,14 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 							and activeSkill.activeEffect.grantedEffect.name:match("^Companion:")
 							and not (controls.showMinion and controls.showMinion.state == true)
 						)
-						for _, minionId in ipairs(activeSkill.minionList) do
-							t_insert(controls.mainSkillMinion.list, {
-								label = self.data.minions[minionId].name,
-								minionId = minionId,
-							})
+						for _, minionId in ipairs(minionList or { }) do
+							local minion = self.data.minions[minionId]
+							if minion then
+								t_insert(controls.mainSkillMinion.list, {
+									label = minion.name,
+									minionId = minionId,
+								})
+							end
 						end
 						controls.mainSkillMinion:SelByValue(activeEffect.srcInstance["skillMinion"..suffix] or controls.mainSkillMinion.list[1], "minionId")
 					end


### PR DESCRIPTION
## Summary
Fixes #1677

- uses the granted effect's minion list when `activeSkill.minionList` is unavailable during main-skill selector refresh
- mirrors the same fallback in CompareEntry minion controls
- skips stale/unknown minion ids rather than crashing while building the selector list
- adds a regression fixture for the `ipairs(nil)` crash shape

## Root Cause
`RefreshSkillSelectControls` entered the minion-control branch when `activeEffect.grantedEffect.minionList` existed, but then iterated `activeSkill.minionList` directly. Some loaded/imported builds can have granted-effect minion metadata before `activeSkill.minionList` is populated, so opening the build could crash on `ipairs(nil)` and leave the user stuck in a startup crash loop.

## Fix
The selector now normalizes to `activeSkill.minionList or activeEffect.grantedEffect.minionList` before iteration. CompareEntry had the same assumption and now uses the same fallback. Unknown minion ids are ignored while building display rows, preserving a usable UI for partially stale data.

## Validation
- `busted --lua=luajit ../spec/System/TestSkills_spec.lua`
  - PASS: `11 successes / 0 failures / 0 errors / 0 pending : 63.531 seconds`
- `git diff --check`
  - PASS

## Risk/Rollback
Risk is limited to minion selector population for skills with granted minion metadata. Normal active skills with populated `activeSkill.minionList` keep the same path. Rollback is this commit only.