### PR TITLE
Exclude hit-only mods from ailment source damage

### DIFF
--- a/spec/System/TestAilments_spec.lua
+++ b/spec/System/TestAilments_spec.lua
@@ -7,6 +7,27 @@ describe("TestAilments", function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
 
+	it("does not apply hit-only damage modifiers to ignite source damage", function()
+		build.skillsTab:PasteSocketGroup("Incinerate 20/0  1")
+		build.configTab.input.conditionEnemyBurning = true
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local baseIgniteDPS = build.calcsTab.mainOutput.IgniteDPS
+		local baseAverageDamage = build.calcsTab.mainOutput.AverageDamage
+		local baseFireStoredHitMin = build.calcsTab.mainOutput.FireStoredHitMin
+		local baseFireStoredHitMax = build.calcsTab.mainOutput.FireStoredHitMax
+
+		build.configTab.input.customMods = "35% increased Damage with Hits against Burning Enemies"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.True(build.calcsTab.mainOutput.AverageDamage > baseAverageDamage)
+		assert.True(math.abs(build.calcsTab.mainOutput.IgniteDPS - baseIgniteDPS) < 0.000000001)
+		assert.are.equals(baseFireStoredHitMin, build.calcsTab.mainOutput.FireStoredHitMin)
+		assert.are.equals(baseFireStoredHitMax, build.calcsTab.mainOutput.FireStoredHitMax)
+	end)
+
 	--TODO: Shock not supported currently
 	--it("maximum shock value", function()
 	--end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3672,6 +3672,19 @@ function calcs.offence(env, actor, activeSkill)
 			output[damageType.."StoredCombinedAvg"] = 0
 		end
 
+		local ailmentSourceCfg
+		local function getAilmentSourceCfg()
+			if not ailmentSourceCfg then
+				ailmentSourceCfg = { }
+				for key, value in pairs(cfg) do
+					ailmentSourceCfg[key] = value
+				end
+				ailmentSourceCfg.flags = band(ailmentSourceCfg.flags or 0, bnot(ModFlag.Hit))
+				ailmentSourceCfg.keywordFlags = band(ailmentSourceCfg.keywordFlags or 0, bnot(KeywordFlag.Hit))
+			end
+			return ailmentSourceCfg
+		end
+
 		-- Calculate hit damage for each damage type
 		local totalHitMin, totalHitMax, totalHitAvg = 0, 0, 0
 		local totalCritMin, totalCritMax, totalCritAvg = 0, 0, 0
@@ -3742,17 +3755,24 @@ function calcs.offence(env, actor, activeSkill)
 					damageTypeHitAvgLucky = (damageTypeHitMin / 3 + 2 * damageTypeHitMax / 3)
 					damageTypeHitAvg = damageTypeHitAvgNotLucky * (1 - damageTypeLuckyChance) + damageTypeHitAvgLucky * damageTypeLuckyChance
 
-					-- Store pre-resist/armour/penetration hit damage for ailment calculations
+					-- Store pre-resist/armour/penetration source damage for ailment calculations.
+					-- Hit-only modifiers, such as "Damage with Hits", must not become ailment source damage.
+					local ailmentSourceHitMin, ailmentSourceHitMax = calcDamage(activeSkill, output, getAilmentSourceCfg(), nil, damageType, 0)
+					ailmentSourceHitMin = ailmentSourceHitMin * allMult
+					ailmentSourceHitMax = ailmentSourceHitMax * allMult
+					local ailmentSourceHitAvgNotLucky = (ailmentSourceHitMin / 2 + ailmentSourceHitMax / 2)
+					local ailmentSourceHitAvgLucky = (ailmentSourceHitMin / 3 + 2 * ailmentSourceHitMax / 3)
+					local ailmentSourceHitAvg = ailmentSourceHitAvgNotLucky * (1 - damageTypeLuckyChance) + ailmentSourceHitAvgLucky * damageTypeLuckyChance
 					if pass == 1 then
-						output[damageType.."StoredCombinedAvg"] = output[damageType.."StoredCombinedAvg"] + damageTypeHitAvg * (output.CritChance / 100)
-						output[damageType.."StoredCritAvg"] = damageTypeHitAvg
-						output[damageType.."StoredCritMin"] = damageTypeHitMin
-						output[damageType.."StoredCritMax"] = damageTypeHitMax
+						output[damageType.."StoredCombinedAvg"] = output[damageType.."StoredCombinedAvg"] + ailmentSourceHitAvg * (output.CritChance / 100)
+						output[damageType.."StoredCritAvg"] = ailmentSourceHitAvg
+						output[damageType.."StoredCritMin"] = ailmentSourceHitMin
+						output[damageType.."StoredCritMax"] = ailmentSourceHitMax
 					else
-						output[damageType.."StoredCombinedAvg"] = output[damageType.."StoredCombinedAvg"] + damageTypeHitAvg * (1 - output.CritChance / 100)
-						output[damageType.."StoredHitAvg"] = damageTypeHitAvg
-						output[damageType.."StoredHitMin"] = damageTypeHitMin
-						output[damageType.."StoredHitMax"] = damageTypeHitMax
+						output[damageType.."StoredCombinedAvg"] = output[damageType.."StoredCombinedAvg"] + ailmentSourceHitAvg * (1 - output.CritChance / 100)
+						output[damageType.."StoredHitAvg"] = ailmentSourceHitAvg
+						output[damageType.."StoredHitMin"] = ailmentSourceHitMin
+						output[damageType.."StoredHitMax"] = ailmentSourceHitMax
 					end
 
 					if (damageTypeHitMin ~= 0 or damageTypeHitMax ~= 0) and env.mode_effective then


### PR DESCRIPTION
## Summary
Fixes #1068.

This keeps hit-only damage modifiers on the hit calculation, but prevents them from becoming ignite source damage through the stored hit values used by ailment calculations.

## Root Cause
The offence pass calculated normal hit damage first, including modifiers such as `Damage with Hits against Burning Enemies`, and then saved those hit-scaled values into `StoredHit*`/`StoredCrit*` fields for ailments.

The later DoT calculation strips hit-only flags from its config, but ignite had already inherited the inflated stored source damage. That made a hit-only modifier incorrectly raise ignite DPS.

## Fix
- Build a small ailment-source copy of the active calculation config with `ModFlag.Hit` and `KeywordFlag.Hit` removed.
- Use that config only when writing the stored source-damage fields consumed by ailments.
- Leave the normal hit damage path unchanged, so hit DPS still benefits from valid hit-only modifiers.
- Add a regression test proving a hit-only conditional modifier raises `AverageDamage` while leaving ignite DPS and stored fire source damage unchanged.

## Validation
Reproduced before the fix with a custom modifier:

```text
35% increased Damage with Hits against Burning Enemies
```

Before patch, this raised ignite DPS from `0.136266864304` to `0.24754717693` even though the modifier is hit-only.

Validated after patch:

```text
busted --lua=luajit ../spec/System/TestAilments_spec.lua
1 success / 0 failures / 0 errors / 0 pending : 3.906 seconds

busted --lua=luajit ../spec/System/TestAttacks_spec.lua
6 successes / 0 failures / 0 errors / 0 pending : 32.406 seconds

git diff --check
PASS
```

## Risk/Rollback
Risk is limited to stored ailment source damage for damaging ailments. The displayed hit damage path remains unchanged. Rollback is this single commit if downstream tests expose an unexpected ailment interaction.