### PR TITLE
Fix generic Minion damage mods applying to Inspiring Ally

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -193,6 +193,31 @@ describe("TestSkills", function()
 		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
 	end)
 
+	it("Inspiring Ally only mirrors companion damage, not generic minion damage", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Fanatic Greathammer
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
+		runCallback("OnFrame")
+
+		local baseLeapSlamHit = build.calcsTab.mainOutput.AverageDamage
+
+		build.configTab.input.customMods = "Increases and Reductions to Companion Damage also apply to you\nMinions deal 20% increased Damage"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(baseLeapSlamHit, build.calcsTab.mainOutput.AverageDamage)
+
+		build.configTab.input.customMods = "Increases and Reductions to Companion Damage also apply to you\nCompanions deal 12% increased Damage"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
+	end)
+
 	it("Test stacking persistent buff supports of same category", function()
 		build.skillsTab:PasteSocketGroup("Arctic Armour 20/0  1\nClarity I 1/0  1")
 		build.skillsTab:PasteSocketGroup("Time of Need 20/0  1\nClarity II 1/0  1")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -698,13 +698,31 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	local function modHasSkillType(mod, skillType)
+		for _, tag in ipairs(mod) do
+			if tag.type == "SkillType" then
+				if tag.skillType == skillType then
+					return true
+				end
+				if tag.skillTypeList then
+					for _, listedSkillType in ipairs(tag.skillTypeList) do
+						if listedSkillType == skillType then
+							return true
+						end
+					end
+				end
+			end
+		end
+		return false
+	end
+
 	if skillModList:Flag(nil, "CompanionDamageAppliesToPlayer") then
 		-- Companion Damage conversion from Inspiring Ally
 		local tempCfg = copyTable(skillCfg, true)
 		tempCfg.skillTypes[SkillType.CreatesCompanion] = true -- Add companion skill tag to cfg so it doesn't fail
-		for _, value in ipairs(skillModList:List(tempCfg, "MinionModifier")) do
-			if value.mod.name == "Damage" and value.mod.type == "INC" then
-				local mod = value.mod
+		for _, value in ipairs(skillModList:Tabulate("LIST", tempCfg, "MinionModifier")) do
+			local mod = value.value and value.value.mod
+			if modHasSkillType(value.mod, SkillType.CreatesCompanion) and mod and mod.name == "Damage" and mod.type == "INC" then
 				skillModList:NewMod("Damage", "INC", mod.value, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 			end
 		end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -538,6 +538,24 @@ function calcs.offence(env, actor, activeSkill)
 			func(activeSkill, output, breakdown)
 		end
 	end
+	
+	local function modHasSkillType(mod, skillType)
+		for _, tag in ipairs(mod) do
+			if tag.type == "SkillType" then
+				if tag.skillType == skillType then
+					return true
+				end
+				if tag.skillTypeList then
+					for _, listedSkillType in ipairs(tag.skillTypeList) do
+						if listedSkillType == skillType then
+							return true
+						end
+					end
+				end
+			end
+		end
+		return false
+	end
 
 	runSkillFunc("initialFunc")
 
@@ -698,24 +716,6 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
-	local function modHasSkillType(mod, skillType)
-		for _, tag in ipairs(mod) do
-			if tag.type == "SkillType" then
-				if tag.skillType == skillType then
-					return true
-				end
-				if tag.skillTypeList then
-					for _, listedSkillType in ipairs(tag.skillTypeList) do
-						if listedSkillType == skillType then
-							return true
-						end
-					end
-				end
-			end
-		end
-		return false
-	end
-
 	if skillModList:Flag(nil, "CompanionDamageAppliesToPlayer") then
 		-- Companion Damage conversion from Inspiring Ally
 		local tempCfg = copyTable(skillCfg, true)


### PR DESCRIPTION
﻿Fixes #1441

## Summary
- Restrict Inspiring Ally's damage mirroring to `MinionModifier` entries that are explicitly scoped to companion skills.
- Preserve generic minion-damage conversion for the separate Minion Damage applies-to-player mechanics.
- Add a regression proving generic minion damage does not increase player damage through Inspiring Ally, while companion damage still does.

## Root Cause
The Inspiring Ally path forced `SkillType.CreatesCompanion` into a copied skill config, then read every matching `MinionModifier` through `List`. That made generic minion damage look like companion damage, because generic `MinionModifier` entries have no companion-specific requirement and therefore also passed the temporary config.

## Fix
The companion path now uses `Tabulate` so it can inspect the original outer `MinionModifier` tags. It mirrors only entries whose outer modifier explicitly has `SkillType.CreatesCompanion`, then applies the evaluated inner damage mod to the player.

## Validation
- `git diff --check` — pass, exit code 0.
- Targeted regression added in `spec/System/TestSkills_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Low calculation risk: the patch only changes the Inspiring Ally conversion branch. Companion-scoped damage still converts; generic minion damage remains handled by the existing `MinionDamageAppliesToPlayer` path. Rollback is one localized CalcOffence hunk plus the test.
