### PR TITLE
Guard settings path popup against nil details

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -809,6 +809,8 @@ function main:SaveSettings()
 end
 
 function main:OpenPathPopup(invalidPath, errMsg, ignoreBuild)
+	invalidPath = invalidPath or ""
+	errMsg = errMsg or "Unknown error"
 	local controls = { }
 	local defaultLabelPlacementX = 8
 


### PR DESCRIPTION
﻿Fixes #1533

## Summary
- Make `OpenPathPopup` tolerate missing path/error details by normalising nil values at the boundary.
- Preserve the existing recovery popup flow instead of crashing while attempting to explain the settings-path failure.

## Root Cause
`OpenPathPopup` concatenated `errMsg` and called `invalidPath:gsub(...)` unconditionally. If startup reached this recovery path without one of those details, the recovery UI itself raised a Lua error, preventing first-run users from choosing a working settings path.

## Fix
Default `invalidPath` to an empty string and `errMsg` to `"Unknown error"` at the start of `OpenPathPopup` before constructing controls or label text.

## Validation
- `git diff --check` — pass, exit code 0.
- No GUI/runtime launch was run locally in this pass because this machine was explicitly kept free of local app/test windows.

## Risk/Rollback
Very low risk: this only changes the nil-input path for an existing recovery popup. Normal calls with explicit path/error values keep their current text.
