### PR TITLE
Fix exporter loading of old GGPK data

### DIFF
--- a/src/Export/Classes/GGPKData.lua
+++ b/src/Export/Classes/GGPKData.lua
@@ -29,6 +29,16 @@ local function scanDir(directory, extension)
 	return t
 end
 
+local function getDatFilePathCandidates(fname)
+	if fname:match("^Data/Balance/") then
+		return {
+			fname,
+			fname:gsub("^Data/Balance/", "Data/"),
+		}
+	end
+	return { fname }
+end
+
 -- Path can be in any format recognized by the extractor at oozPath, ie,
 -- a .ggpk file or a Steam Path of Exile directory
 local GGPKClass = newClass("GGPKData", function(self, path, datPath, reExport)
@@ -132,7 +142,13 @@ function GGPKClass:AddDat64Files()
 	for _, fname in ipairs(datFiles) do
 		local record = { }
 		record.name = fname:match("([^/\\]+)$") .. "c64"
-		local rawFile = io.open(self.oozPath .. fname:gsub("/", "\\") .. "c64", 'rb')
+		local rawFile
+		for _, fileName in ipairs(getDatFilePathCandidates(fname)) do
+			rawFile = io.open(self.oozPath .. fileName:gsub("/", "\\") .. "c64", 'rb')
+			if rawFile then
+				break
+			end
+		end
 		if rawFile then
 			record.data = rawFile:read("*all")
 			rawFile:close()

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -75,6 +75,9 @@ function main:Init()
 	self.datFileByName = { }
 
 	self:LoadSettings()
+	if self.datSource and self.datSource.spec then
+		self.datSpecs = LoadModule(self.datSource.spec)
+	end
 	self.reExportGGPKData = false
 	if IsKeyDown("CTRL") then
 		self.reExportGGPKData = true
@@ -373,15 +376,30 @@ function main:CanExit()
 	return true
 end
 
+local function getDatSpecPath(datSource)
+	if not datSource or not datSource.spec then
+		return
+	end
+	return datSource.spec..(datSource.spec:match("%.lua$") and "" or ".lua")
+end
+
+function main:SaveDatSpec(datSource)
+	local specPath = getDatSpecPath(datSource)
+	if not specPath or not self.datSpecs then
+		return
+	end
+	local out = io.open(specPath, "w")
+	out:write('return ')
+	writeLuaTable(out, self.datSpecs, 1)
+	out:close()
+end
+
 function main:LoadDatSource(value)
 	self.leagueLabel = nil
 	local reExportState = self.reExportGGPKData
 	self.reExportGGPKData = true
+	self:SaveDatSpec(self.datSource)
 	self.datSource = value
-	local out = io.open(self.datSource.spec..(self.datSource.spec:match("%.lua$") and "" or ".lua"), "w")
-	out:write('return ')
-	writeLuaTable(out, self.datSpecs, 1)
-	out:close()
 	self.datSpecs = LoadModule(self.datSource.spec)
 	self:InitGGPK()
 	if USE_DAT64 then
@@ -405,12 +423,7 @@ function main:OpenPathPopup()
 end
 
 function main:Shutdown()
-	if self.datSource and self.datSource.spec then
-		local out = io.open(self.datSource.spec, "w")
-		out:write('return ')
-		writeLuaTable(out, self.datSpecs, 1)
-		out:close()
-	end
+	self:SaveDatSpec(self.datSource)
 
 	self:SaveSettings()
 end


### PR DESCRIPTION
﻿Fixes #1556

## Summary
- Let cached DAT loading find both current `Data/Balance/...` files and older pre-0.4.0 `Data/...` files.
- Save the currently selected DAT spec before switching sources, rather than writing the current spec into the newly selected source before loading it.
- Reuse one `SaveDatSpec` helper for source switching and shutdown.

## Root Cause
Two exporter paths were brittle for older GGPK data:
1. `AddDat64Files` only looked for cached files under the newer `Data/Balance` layout, so older extracted data under `Data` was reported missing.
2. `LoadDatSource` assigned `self.datSource = value` before saving, then wrote the previously loaded `self.datSpecs` to the newly selected source's spec path. That could overwrite the spec the user was trying to load.

## Fix
DAT lookup now tries the exact requested path first, then the legacy `Data/` path for `Data/Balance/` entries. Source switching now saves the previous source's spec before assigning and loading the new source.

## Validation
- `git diff --check` — pass, exit code 0.
- No exporter UI/GGPK extraction run locally in this pass because this machine was explicitly kept free of local app/test windows.

## Risk/Rollback
Low exporter-only risk. Current cached data remains preferred because the new path is tried first; the legacy path is only a fallback. Rollback is isolated to exporter source/spec loading and cached DAT lookup.
