### PR TITLE
Handle trade responses without rate limit headers

### DIFF
--- a/spec/System/TestTradeQueryRateLimiter_spec.lua
+++ b/spec/System/TestTradeQueryRateLimiter_spec.lua
@@ -24,6 +24,12 @@ describe("TradeQueryRateLimiter", function()
 			assert.are.equal(policy.ip.state[10].request, 7)
 			assert.are.equal(policy.account.limits[5].request, 2)
 		end)
+
+		it("ignores responses without rate limit policy headers", function()
+			local limiter = new("TradeQueryRateLimiter")
+			local policies = limiter:ParsePolicy("HTTP/1.1 503 Service Unavailable\nContent-Type: text/html")
+			assert.are.same({}, policies)
+		end)
 	end)
 
 	describe("UpdateFromHeader", function()
@@ -34,6 +40,15 @@ describe("TradeQueryRateLimiter", function()
 			limiter.limitMargin = 1
 			local header = "X-Rate-Limit-Policy: test\nX-Rate-Limit-Rules: Ip\nX-Rate-Limit-Ip: 5:10:60\nX-Rate-Limit-Ip-State: 4:10:60"
 			limiter:UpdateFromHeader(header)
+			assert.are.equal(limiter.policies["test"].ip.limits[10].request, 4)
+		end)
+
+		it("leaves current limits intact when a response has no rate limit policy", function()
+			local limiter = new("TradeQueryRateLimiter")
+			limiter.limitMargin = 1
+			local header = "X-Rate-Limit-Policy: test\nX-Rate-Limit-Rules: Ip\nX-Rate-Limit-Ip: 5:10:60\nX-Rate-Limit-Ip-State: 4:10:60"
+			limiter:UpdateFromHeader(header)
+			limiter:UpdateFromHeader("HTTP/1.1 525 SSL Handshake Failed\nContent-Type: text/html")
 			assert.are.equal(limiter.policies["test"].ip.limits[10].request, 4)
 		end)
 	end)

--- a/src/Classes/TradeQueryRateLimiter.lua
+++ b/src/Classes/TradeQueryRateLimiter.lua
@@ -75,8 +75,11 @@ function TradeQueryRateLimiterClass:ParsePolicy(headerString)
 	local policies = {}
 	local headers = self:ParseHeader(headerString)
 	local policyName = headers["x-rate-limit-policy"]
+	if not policyName or policyName == "" then
+		return policies
+	end
 	policies[policyName] = {}
-	local retryAfter = headers["retry-after"]
+	local retryAfter = tonumber(headers["retry-after"])
 	if retryAfter then
 		policies[policyName].retryAfter = os.time() + retryAfter
 	end
@@ -96,13 +99,17 @@ function TradeQueryRateLimiterClass:ParsePolicy(headerString)
 		for key, headerKey in pairs(properties) do
 			policies[policyName][ruleName][key] = {}
 			local headerValue = headers[headerKey]
-			for bucket in headerValue:gmatch("[^,]+") do -- example 8:10:60,15:60:120,60:300:1800
-				local next = bucket:gmatch("[^:]+") -- example 8:10:60
-				local request, window, timeout = tonumber(next()), tonumber(next()), tonumber(next())
-				policies[policyName][ruleName][key][window] = {
-					["request"] = request,
-					["timeout"] = timeout
-				}
+			if headerValue then
+				for bucket in headerValue:gmatch("[^,]+") do -- example 8:10:60,15:60:120,60:300:1800
+					local next = bucket:gmatch("[^:]+") -- example 8:10:60
+					local request, window, timeout = tonumber(next()), tonumber(next()), tonumber(next())
+					if request and window and timeout then
+						policies[policyName][ruleName][key][window] = {
+							["request"] = request,
+							["timeout"] = timeout
+						}
+					end
+				end
 			end
 		end
 	end

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -31,8 +31,9 @@ function TradeQueryRequestsClass:ProcessQueue()
 					local requestId = self.rateLimiter:InsertRequest(policy)
 					local onComplete = function(response, errMsg)
 						self.rateLimiter:FinishRequest(policy, requestId)
-						self.rateLimiter:UpdateFromHeader(response.header)
-						if response.header:match("HTTP/[%d%.]+ (%d+)") == "429" then
+						local responseHeader = response and response.header or ""
+						self.rateLimiter:UpdateFromHeader(responseHeader)
+						if responseHeader:match("HTTP/[%d%.]+ (%d+)") == "429" then
 							request.attempts = (request.attempts or 0) + 1
 							local backoff = m_min(2 ^ request.attempts, 60)
 							request.retryTime = os.time() + backoff
@@ -40,15 +41,12 @@ function TradeQueryRequestsClass:ProcessQueue()
 							return
 						end
 						-- if limit rules don't return account then the POESESSID is invalid.
-						if response.header:match("[xX]%-[rR]ate%-[lL]imit%-[rR]ules: (.-)\n"):match("Account") == nil and main.POESESSID ~= "" then
+						local rateLimitRules = responseHeader:match("[xX]%-[rR]ate%-[lL]imit%-[rR]ules: (.-)\n")
+						if not errMsg and rateLimitRules and rateLimitRules:match("Account") == nil and main.POESESSID ~= "" then
 							main.POESESSID = ""
-							if errMsg then
-								errMsg = errMsg .. "\nPOESESSID is invalid. Please Re-Log and reset"
-							else
-								errMsg = "POESESSID is invalid. Please Re-Log and reset"
-							end
+							errMsg = "POESESSID is invalid. Please Re-Log and reset"
 						end
-						request.callback(response.body, errMsg, unpack(request.callbackParams or {}))
+						request.callback(response and response.body, errMsg, unpack(request.callbackParams or {}))
 					end
 					-- self:SendRequest(request.url , onComplete, {body = request.body, poesessid = main.POESESSID})
 					local header = "Content-Type: application/json"


### PR DESCRIPTION
﻿Fixes #506

## Summary
- Treat trade responses without `X-Rate-Limit-Policy` as non-policy responses instead of indexing nil.
- Preserve existing rate-limit state when Cloudflare/SSL/HTML error responses lack trade rate-limit headers.
- Avoid clearing `POESESSID` unless a real rate-limit rules header is present and lacks `Account`.
- Add regression coverage for missing policy headers and missing-policy updates.

## Root Cause
The trade callback assumed every response had Path of Exile trade rate-limit headers. SSL/Cloudflare/error responses can contain only an HTTP status and generic headers, so `ParsePolicy` attempted to index `policies[nil]`, and the request callback chained `:match(...):match(...)` through a nil match.

## Fix
`ParsePolicy` now returns an empty policy table when the policy header is absent, parses `Retry-After` numerically, and ignores malformed buckets. The request callback now normalises the response header to an empty string, updates rate limits only when parseable headers exist, and only performs the invalid-session check when the `X-Rate-Limit-Rules` header exists.

## Validation
- `git diff --check` — pass, exit code 0.
- Targeted regressions added in `spec/System/TestTradeQueryRateLimiter_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Low trade-request risk: valid policy headers still parse through the existing path. The changed behavior is limited to missing/malformed policy responses, where crashing or deleting session state was worse than preserving current limits and surfacing the original request error.
