### PR TITLE
Fix applyRange plus sign at zero

### DIFF
--- a/spec/System/TestItemTools_spec.lua
+++ b/spec/System/TestItemTools_spec.lua
@@ -36,6 +36,9 @@ local applyRangeTests = {
 	[{ "+(-25-50)% to Fire Resistance", 1.0, 1.5 }] = "+75% to Fire Resistance",
 	[{ "+(-25-50)% to Fire Resistance", 0.0, 1.0 }] = "-25% to Fire Resistance",
 	[{ "+(-25-50)% to Fire Resistance", 0.0, 1.5 }] = "-37% to Fire Resistance",
+
+	-- Range with plus sign that resolves exactly to zero
+	[{ "+(-1-1) to Maximum Power Charges", 0.5, 1.0 }] = "0 to Maximum Power Charges",
 }
 
 describe("TestItemTools", function()

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -76,7 +76,7 @@ function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 	local strippedLine = line:gsub("([%+-]?)%((%-?%d+%.?%d*)%-(%-?%d+%.?%d*)%)", function(sign, min, max)
 		local value = min + range * (tonumber(max) - min)
 		if sign == "-" then value = value * -1 end
-		return (sign == "+" and value >= 0 ) and sign..tostring(value) or tostring(value)
+		return (sign == "+" and value > 0) and sign..tostring(value) or tostring(value)
 	end)
 	:gsub("%-(%d+%.?%d*%%) (%a+)", antonymFunc)
 	:gsub("(%-?%d+%.?%d*)", function(value)


### PR DESCRIPTION
﻿Fixes #1412

## Summary
- Stop preserving a leading `+` when ranged item text resolves exactly to zero.
- Add an `applyRange` regression for a signed range centered on zero.

## Root Cause
`itemLib.applyRange` preserved the original plus sign when the interpolated range value was `>= 0`. That produced `+0 ...` for ranges that land exactly on zero, even though the rest of item text formatting uses plain `0`.

## Fix
Preserve `+` only for strictly positive interpolated values. Negative values already drop the plus sign, and now zero does too.

## Validation
- `git diff --check` - pass, exit code 0.
- Targeted regression added in `spec/System/TestItemTools_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Very low risk: the change is limited to signed range formatting when an originally plus-prefixed range resolves to exactly zero.
