### PR TITLE
Map Potent Exposure exposure effect

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -6,6 +6,18 @@ describe("TestSkills", function()
 	teardown(function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
+
+	it("maps Potent Exposure to exposure effect modifiers", function()
+		local statMap = build.data.skills["SupportPotentExposurePlayer"].statSets[1].statMap["exposure_effect_+%"]
+		local mappedMods = { }
+		for _, mod in ipairs(statMap) do
+			mappedMods[mod.name] = mod.type
+		end
+
+		assert.are.equals("INC", mappedMods.FireExposureEffect)
+		assert.are.equals("INC", mappedMods.ColdExposureEffect)
+		assert.are.equals("INC", mappedMods.LightningExposureEffect)
+	end)
 	
 	it("Test blasphemy reserving Spirit", function()
 		build.skillsTab:PasteSocketGroup("Blasphemy 20/0  1\nDespair 20/0  1\n")

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1652,6 +1652,11 @@ return {
 	mod("LightningExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }),
 	mult = -1,
 },
+["exposure_effect_+%"] = {
+	mod("FireExposureEffect", "INC", nil),
+	mod("ColdExposureEffect", "INC", nil),
+	mod("LightningExposureEffect", "INC", nil),
+},
 ["offering_spells_effect_+%"] = {
 	mod("BuffEffect", "INC", nil),
 },


### PR DESCRIPTION
﻿Fixes #819

## Summary
- Map the `exposure_effect_+%` support stat used by Potent Exposure / old Strip Away data.
- Add a regression that verifies the support stat resolves to Fire, Cold, and Lightning exposure effect modifiers.

## Root Cause
Potent Exposure already carried the exported stat `exposure_effect_+%`, but that stat had no shared skill-stat mapping. As a result the support line remained unsupported and did not contribute to exposure effect calculations, which explained the lower Lightning Exposure value reported in the issue.

## Fix
Add a shared `SkillStatMap` entry for `exposure_effect_+%` that applies increased Fire, Cold, and Lightning Exposure Effect. This keeps the fix data-driven and applies to any skill/support using the same official stat.

## Validation
- `git diff --check` - pass, exit code 0.
- Targeted regression added in `spec/System/TestSkills_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Low risk: the mapping affects only official skill/support stats named `exposure_effect_+%`. Rollback removes the mapping and returns Potent Exposure to unsupported/no-effect behavior.
