### PR TITLE
Fix Mortar Cannon grenade cooldown speed

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -245,4 +245,42 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.calcsOutput.Cooldown == 10)
 	end)
+
+	it("does not use grenade cooldown recovery as Mortar Cannon attack rate", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Sturdy Crossbow
+			Physical Damage: 5-10
+			Attacks per Second: 1.50
+		]])
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Mortar Cannon 20/0  1\nExplosive Grenade 20/0  1\n")
+		runCallback("OnFrame")
+
+		local socketGroup = build.skillsTab.socketGroupList[1]
+		local foundGrenadeSkill = false
+		for index, activeSkill in ipairs(socketGroup.displaySkillList) do
+			if activeSkill.activeEffect.grantedEffect.id == "ExplosiveGrenadePlayer" then
+				socketGroup.mainActiveSkill = index
+				foundGrenadeSkill = true
+				break
+			end
+		end
+		assert.True(foundGrenadeSkill)
+		build.buildFlag = true
+		runCallback("OnFrame")
+
+		local baseSpeed = build.calcsTab.mainOutput.Speed
+		local baseTime = build.calcsTab.mainOutput.Time
+		local baseCooldown = build.calcsTab.mainOutput.Cooldown
+		assert.True(baseCooldown > 0)
+
+		build.configTab.input.customMods = "100% increased Cooldown Recovery Rate for Grenade Skills"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.True(build.calcsTab.mainOutput.Cooldown < baseCooldown)
+		assert.are.equals(baseSpeed, build.calcsTab.mainOutput.Speed)
+		assert.are.equals(baseTime, build.calcsTab.mainOutput.Time)
+	end)
 end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -344,6 +344,12 @@ function calcSkillCooldown(skillModList, skillCfg, skillData)
 	end
 end
 
+local function isMortarCannonSupportedGrenade(activeSkill, skillData)
+	local totemBase = skillData.totemBase
+	return activeSkill.skillTypes[SkillType.Grenade] and activeSkill.skillTypes[SkillType.UsedByTotem] and
+		totemBase and totemBase.grantedEffect and totemBase.grantedEffect.id == "SupportMortarCannonPlayer"
+end
+
 local function calcWarcryCastTime(skillModList, skillCfg, skillData, actor)
 	local baseSpeed = 1 / skillModList:Sum("BASE", skillCfg, "WarcryCastTime")
 	local warcryCastTime = baseSpeed * calcLib.mod(skillModList, skillCfg, "WarcrySpeed") * calcs.actionSpeedMod(actor)
@@ -2739,9 +2745,12 @@ function calcs.offence(env, actor, activeSkill)
 				output.Speed = output.Speed * totemActionSpeed
 				output.CastRate = output.Speed
 			end
+			local cooldownCapsUseRate = not isMortarCannonSupportedGrenade(activeSkill, skillData)
 			if globalOutput.Cooldown then
 				output.Cooldown = globalOutput.Cooldown
-				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
+				if cooldownCapsUseRate then
+					output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
+				end
 			end
 			if output.Cooldown and skillFlags.selfCast or skillData.maxHitRatePerEnemy or skillData.hitTimeOverride then
 				skillFlags.notAverage = true
@@ -2844,7 +2853,7 @@ function calcs.offence(env, actor, activeSkill)
 					t_insert(breakdown.Speed, s_format("= %.2f ^8(eff. attack rate)", output.Speed))
 				end
 				-- Cooldown:
-				if output.Cooldown and (1 / output.Cooldown) < output.CastRate then
+				if cooldownCapsUseRate and output.Cooldown and (1 / output.Cooldown) < output.CastRate then
 					t_insert(breakdown.Speed, s_format("\n"))
 					t_insert(breakdown.Speed, s_format("1 / %.2f ^8(skill cooldown)", output.Cooldown))
 					if output.Repeats > 1 then


### PR DESCRIPTION
﻿Fixes #1417

## Summary
- Keep calculating grenade cooldown for Mortar Cannon-supported grenades, but stop using that cooldown as the mortar attack-rate cap.
- Suppress the cooldown-cap speed breakdown for this Mortar Cannon case so the explanation matches the calculation.
- Add a regression asserting grenade cooldown recovery changes cooldown without changing Mortar Cannon grenade attack time/rate.

## Root Cause
Grenade cooldown recovery correctly modifies the supported grenade cooldown, including Mortar Cannon's hidden `grenade_skill_cooldown_speed_+%` support stat. Later, the generic offence speed path treated any `globalOutput.Cooldown` as a direct cap on casts/attacks per second. That is valid for ordinary cooldown skills, but not for Mortar Cannon's totem firing cadence: cooldown governs charge recovery once the mortar has exhausted charges, not the attack time between loaded grenades.

## Fix
Detect Mortar Cannon-supported grenade active skills via the totem base support id (`SupportMortarCannonPlayer`). For that specific invariant, retain `output.Cooldown` but skip the direct `output.Speed = min(speed, repeats / cooldown)` cap and matching breakdown line.

## Validation
- `git diff --check` - pass, exit code 0.
- Targeted regression added in `spec/System/TestSkills_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Moderate-low risk: the special case is narrowly scoped to grenade skills totemified by Mortar Cannon's hidden support. Rollback restores the generic cooldown cap and reintroduces the reported incorrect attack-rate change.
