### PR TITLE
Fix Show All Configurations hiding some options

### DIFF
--- a/spec/System/TestConfigTab_spec.lua
+++ b/spec/System/TestConfigTab_spec.lua
@@ -1,0 +1,32 @@
+describe("TestConfigTab", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	teardown(function()
+		-- newBuild() takes care of resetting everything in setup()
+	end)
+
+	it("Show All Configurations reveals skill-gated inactive options", function()
+		runCallback("OnFrame")
+
+		local control = build.configTab.varControls.arcaneCloakUsedRecentlyCheck
+		assert.True(control ~= nil)
+		assert.False(control.shown())
+
+		build.configTab.toggleConfigs = true
+
+		assert.True(control.shown())
+	end)
+
+	it("Show All Configurations keeps parent-gated child options hidden", function()
+		runCallback("OnFrame")
+
+		local control = build.configTab.varControls.overridePowerCharges
+		assert.True(control ~= nil)
+
+		build.configTab.toggleConfigs = true
+
+		assert.False(control.shown())
+	end)
+end)

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -73,21 +73,16 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 		return true
 	end
 
-	-- blacklist for Show All Configurations
+	-- Show build-gated options when the user explicitly asks for all configurations.
+	-- Parent-gated and legacy options are intentionally still hidden: parent-gated
+	-- controls are not independently actionable, and legacy controls are not for
+	-- normal editing.
 	local function isShowAllConfig(varData)
-		local labelMatch = varData.label:lower()
-		local excludeKeywords = { "recently", "in the last", "in the past", "in last", "in past", "pvp" }
-
 		if not self.toggleConfigs then
 			return false
 		end
-		if varData.ifOption or varData.ifSkill or varData.ifSkillData or varData.ifSkillFlag or varData.ifGemFamily or varData.legacy then
+		if varData.ifOption or varData.legacy then
 			return false
-		end
-		for _, keyword in pairs(excludeKeywords) do
-			if labelMatch:find(keyword) then
-				return false
-			end
 		end
 		return true
 	end


### PR DESCRIPTION
﻿Fixes #1752

## Summary
- Make `Show All Configurations` reveal build-gated inactive configuration controls such as skill, condition, stat, flag, and gem-family gated options.
- Keep parent-gated child controls and legacy controls hidden because they are not independently actionable.
- Add regressions for both behaviours.

## Root Cause
`Show All Configurations` was still blocked by a hard blacklist for many gating types (`ifSkill`, `ifSkillData`, `ifSkillFlag`, `ifGemFamily`) and several label keywords such as `recently`. That made the shown inactive configuration set depend on the current build, despite the control saying it should show all configurations.

## Fix
Narrow the exclusion list to only gates that must remain hidden for correctness: `ifOption` child controls and legacy controls. Build-dependent gates are now eligible when the user explicitly toggles Show All Configurations.

## Validation
- `git diff --cached --check` - pass, exit code 0.
- Targeted regressions added in `spec/System/TestConfigTab_spec.lua`.
- Docker/Busted not run locally in this pass because this machine was explicitly kept free of local test/container windows; GitHub Actions should run the normal suite on the PR.

## Risk/Rollback
Low-medium risk: this affects visibility filtering in the Configuration tab only. Rollback restores the previous blacklist but reintroduces incomplete Show All behaviour.
