### PR TITLE
Fix penetration minimum DPS breakdown

### DIFF
--- a/spec/System/TestCalcBreakdown_spec.lua
+++ b/spec/System/TestCalcBreakdown_spec.lua
@@ -1,0 +1,20 @@
+describe("TestCalcBreakdown", function()
+	local calcBreakdown = LoadModule("Modules/CalcBreakdown", {}, {}, {})
+
+	it("shows penetration minimum in effective DPS breakdown", function()
+		local out = calcBreakdown.effMult("Lightning", 50, 100, 0, 1.5, 1, nil, true, nil, -50)
+		local text = table.concat(out, "\n")
+
+		assert.True(text:match("= %-50%%") ~= nil)
+		assert.True(text:match("1%.50 %^8%(resistance%)") ~= nil)
+		assert.True(text:match("= 1%.500") ~= nil)
+	end)
+
+	it("shows negative resistance in effective DPS breakdown without penetration", function()
+		local out = calcBreakdown.effMult("Cold", -20, 0, 0, 1.2, 1, nil, true)
+		local text = table.concat(out, "\n")
+
+		assert.True(text:match("1%.20 %^8%(resistance%)") ~= nil)
+		assert.True(text:match("= 1%.200") ~= nil)
+	end)
+end)

--- a/src/Modules/CalcBreakdown.lua
+++ b/src/Modules/CalcBreakdown.lua
@@ -112,6 +112,8 @@ end
 
 function breakdown.effMult(damageType, resist, pen, taken, mult, takenMore, sourceRes, useRes, invertChance, minPen)
 	local out = { }
+	minPen = minPen or 0
+	local effectiveResist = resist > minPen and m_max(resist - pen, minPen) or resist
 	local resistForm = (damageType == "Physical") and "physical damage reduction" or "resistance"
 	local resistLabel = resistForm
 
@@ -145,7 +147,7 @@ function breakdown.effMult(damageType, resist, pen, taken, mult, takenMore, sour
 	if useRes then
 		breakdown.multiChain(out, {
 			label = "Effective DPS modifier:",
-			{ "%.2f ^8(%s)", 1 - (math.max(resist - pen,0)) / 100, resistForm },
+			{ "%.2f ^8(%s)", 1 - effectiveResist / 100, resistForm },
 			{ "%.2f ^8(increased/reduced damage taken)", 1 + taken / 100 },
 			{ "%.2f ^8(more/less damage taken)", takenMore },
 			total = s_format("= %.3f", mult),


### PR DESCRIPTION
## Summary
Refs #983

Make the Calcs breakdown use the same penetration floor as the hit calculation when showing the Effective DPS modifier.

## Root Cause
The main hit calculation already supports `ElementalPenetrationMinimum`, including Leopold's Applause allowing elemental penetration down to `-50%`. The breakdown generator still displayed the resistance multiplier with a hard `0%` floor:

```lua
math.max(resist - pen, 0)
```

That made the Calcs explanation show a `1.00` resistance component even when the actual calculation used negative effective resistance.

## Fix
- Default `minPen` to `0` in `breakdown.effMult` for existing callers.
- Compute the displayed effective resistance with the same rule used by the offence calculation:
  - if resistance is already below the penetration floor, leave it alone;
  - otherwise clamp penetration at `minPen`.
- Use that value in the Effective DPS modifier breakdown.
- Add direct breakdown regressions for Leopold-style `-50%` penetration floor and normal negative resistance without penetration.

## Validation
- `git diff --check` passed.
- `git diff --cached --check` passed.

Not run locally:
- `docker-compose up` / full Busted suite. The repository test runner is Docker-based; I avoided local container/window activity and left the focused regression for CI.

## Risk / Rollback
Low risk. This changes only explanatory breakdown output, not the damage calculation itself. Rollback is the single commit on this branch.