### PR TITLE
Fix Uhtred supports counting Meta gems as supports

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -245,4 +245,21 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.calcsOutput.Cooldown == 10)
 	end)
+
+	it("Test hidden meta supports do not count as connected supports", function()
+		build.skillsTab:PasteSocketGroup("Cast on Critical 20/0  1\nArc 20/0  1\nUhtred's Omen 1/0  1\nRising Tempest 1/0  1")
+		runCallback("OnFrame")
+
+		local arcSkill = nil
+		for _, activeSkill in ipairs(build.calcsTab.calcsEnv.player.activeSkillList) do
+			if activeSkill.activeEffect.grantedEffect.name == "Arc" then
+				arcSkill = activeSkill
+				break
+			end
+		end
+
+		assert.is_not_nil(arcSkill)
+		assert.are.equals(2, arcSkill.skillModList:GetMultiplier("SupportCount", arcSkill.skillCfg))
+		assert.are.equals(3, arcSkill.skillModList:Sum("BASE", arcSkill.skillCfg, "GemSupportLevel"))
+	end)
 end)

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -634,7 +634,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 					activeSkill.triggeredBy = skillEffect
 				end
 			end
-			skillModList:NewMod("Multiplier:SupportCount", "BASE", 1, "Support Count")
+			if not skillEffect.grantedEffect.hidden then
+				skillModList:NewMod("Multiplier:SupportCount", "BASE", 1, "Support Count")
+			end
 			if level.PvPDamageMultiplier then
 				skillModList:NewMod("PvpDamageMultiplier", "MORE", level.PvPDamageMultiplier, skillEffect.grantedEffect.modSource)
 			end


### PR DESCRIPTION
Fixes #1734

## Summary

Hidden internal supports from meta gems no longer increment `Multiplier:SupportCount` for the supported active skill.

## Root Cause

`CalcActiveSkill` counted every supporting granted effect in `activeSkill.effectList` as a connected support. Meta gems such as Cast on Critical also inject hidden internal support effects like `SupportMetaCastOnCritPlayer`. Those hidden effects are real calculation helpers, but they are not player-connected support gems and should not satisfy or break support-count thresholds.

For Uhtred lineage supports, that extra hidden support changed the count from the in-game value of 2 to 3, preventing `Uhtred's Omen` from granting its level bonus in meta-gem setups.

## Fix

Keep merging hidden support effects as before, but exclude `grantedEffect.hidden` supports from `Multiplier:SupportCount`.

This preserves the hidden trigger support behavior while making support-count conditions reflect visible connected support gems.

## Validation

- Added a regression test for `Cast on Critical + Arc + Uhtred's Omen + Rising Tempest`:
  - Arc support count remains 2.
  - Uhtred's Omen grants `+3` gem support level.
- Ran `git diff --check` before commit: pass.
- Ran `git diff --cached --check` before commit: pass.
- Ran `git show --check --stat --oneline HEAD`: pass.

I did not run `docker-compose up` locally to avoid launching Docker/extra windows on this machine; the change is covered by the targeted Busted spec and should run in CI.

## Risk / Rollback

Risk is low: only the support-count multiplier excludes hidden support effects. Hidden supports are still merged and can still provide trigger behavior, mana/reservation modifiers, and other calculation data.

Rollback is the single commit if any hidden support is found that intentionally should count as a player-connected support.