### PR TITLE
Gate Barrage incorrectly granting damage to some skills

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -245,4 +245,40 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.calcsOutput.Cooldown == 10)
 	end)
+
+	it("Test Barrage only repeats Barrageable skills", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Warmonger Bow
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Spiral Volley 20/0  1")
+		runCallback("OnFrame")
+		local spiralVolleyDPS = build.calcsTab.mainOutput.TotalDPS
+
+		build.skillsTab:PasteSocketGroup("Barrage 20/0  1")
+		runCallback("OnFrame")
+		assert.are.equals(spiralVolleyDPS, build.calcsTab.mainOutput.TotalDPS)
+
+		newBuild()
+
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Warmonger Bow
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Ice Shot 20/0  1")
+		runCallback("OnFrame")
+		local iceShotDPS = build.calcsTab.mainOutput.TotalDPS
+
+		build.skillsTab:PasteSocketGroup("Barrage 20/0  1")
+		runCallback("OnFrame")
+		assert.True(build.calcsTab.mainOutput.TotalDPS > iceShotDPS)
+	end)
 end)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -924,7 +924,12 @@ function calcs.offence(env, actor, activeSkill)
 			skillModList:NewMod("AreaOfEffect", "INC", mod.value, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 		end
 	end
-	if skillModList:Flag(nil, "SequentialProjectiles") and not skillModList:Flag(nil, "OneShotProj") and not skillModList:Flag(nil,"NoAdditionalProjectiles") and not skillModList:Flag(nil, "TriggeredBySnipe") then
+	local canBarrageRepeat = skillModList:Flag(nil, "SequentialProjectiles")
+		and activeSkill.skillTypes[SkillType.Barrageable]
+		and not skillModList:Flag(nil, "OneShotProj")
+		and not skillModList:Flag(nil, "NoAdditionalProjectiles")
+		and not skillModList:Flag(nil, "TriggeredBySnipe")
+	if canBarrageRepeat then
 		-- Applies DPS multiplier based on projectile count
 		if skillModList:Sum("BASE", skillCfg, "BarrageRepeats") > 0 then
 			local dpsMulti = (1 + skillModList:Sum("BASE", skillCfg, "BarrageRepeats")) * (calcLib.mod(skillModList, skillCfg, "BarrageRepeatDamage"))

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -924,12 +924,7 @@ function calcs.offence(env, actor, activeSkill)
 			skillModList:NewMod("AreaOfEffect", "INC", mod.value, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 		end
 	end
-	local canBarrageRepeat = skillModList:Flag(nil, "SequentialProjectiles")
-		and activeSkill.skillTypes[SkillType.Barrageable]
-		and not skillModList:Flag(nil, "OneShotProj")
-		and not skillModList:Flag(nil, "NoAdditionalProjectiles")
-		and not skillModList:Flag(nil, "TriggeredBySnipe")
-	if canBarrageRepeat then
+	if activeSkill.skillTypes[SkillType.Barrageable] and skillModList:Flag(nil, "SequentialProjectiles") and not skillModList:Flag(nil, "OneShotProj") and not skillModList:Flag(nil, "NoAdditionalProjectiles") and not skillModList:Flag(nil, "TriggeredBySnipe") then
 		-- Applies DPS multiplier based on projectile count
 		if skillModList:Sum("BASE", skillCfg, "BarrageRepeats") > 0 then
 			local dpsMulti = (1 + skillModList:Sum("BASE", skillCfg, "BarrageRepeats")) * (calcLib.mod(skillModList, skillCfg, "BarrageRepeatDamage"))


### PR DESCRIPTION
Fixes #547

## Summary

Barrage repeat DPS now applies only to skills tagged `SkillType.Barrageable`.

## Root Cause

The Barrage buff adds `SequentialProjectiles`/`BarrageRepeats` globally, and the offence calculation used those flags to apply the Barrage repeat DPS path to the active skill.

That path did not check whether the active skill itself is Barrageable. `Spiral Volley` is a bow projectile skill, but it is not tagged `SkillType.Barrageable`, so it should not consume/apply Barrage in-game.

## Fix

Introduce a local `canBarrageRepeat` gate that keeps the existing `SequentialProjectiles`, `OneShotProj`, `NoAdditionalProjectiles`, and `TriggeredBySnipe` checks, and also requires:

```lua
activeSkill.skillTypes[SkillType.Barrageable]
```

This fixes the rule boundary rather than adding a one-off Spiral Volley exception.

## Validation

- Added a regression test for Spiral Volley: adding Barrage does not change its TotalDPS.
- Added a positive control for Ice Shot: adding Barrage still increases TotalDPS for a Barrageable skill.
- Ran `git diff --check` before commit: pass.
- Ran `git diff --cached --check` before commit: pass.
- Ran `git show --check --stat --oneline HEAD`: pass.

I did not run `docker-compose up` locally to avoid launching Docker/extra windows on this machine; the targeted Busted spec should run in CI.

## Risk / Rollback

Risk is low: this narrows Barrage repeat handling to skills already marked Barrageable in exported skill data. The positive-control test protects the intended Barrage path.

Rollback is the single commit if a valid Barrage-consuming skill is missing the Barrageable tag in data; that would be a data issue to correct explicitly.