### PR TITLE
Exclude node-granted skills from gem group count

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -245,4 +245,32 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.calcsOutput.Cooldown == 10)
 	end)
+
+	it("Test node-granted skills do not consume gem groups", function()
+		for _ = 1, 9 do
+			build.skillsTab:PasteSocketGroup("Arc 20/0  1")
+		end
+
+		local grantedGroup = {
+			label = "Loyal Hellhound",
+			enabled = true,
+			source = "Loyal Hellhound",
+			sourceNode = { name = "Loyal Hellhound" },
+			gemList = {
+				{
+					skillId = "SummonInfernalHoundPlayer",
+					nameSpec = "Summon Infernal Hound",
+					quality = 0,
+					level = 1,
+					enabled = true,
+					fromNode = true,
+				},
+			},
+		}
+		build.skillsTab:ProcessSocketGroup(grantedGroup)
+		table.insert(build.skillsTab.socketGroupList, grantedGroup)
+		build.skillsTab:UpdateGlobalGemCountAssignments()
+
+		assert.are.equals(9, GlobalGemAssignments["GemGroupCount"])
+	end)
 end)

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1317,7 +1317,9 @@ function SkillsTabClass:UpdateGlobalGemCountAssignments()
 		local countGroup = true
 		if socketGroup.enabled then
 			for _, gemInstance in ipairs(socketGroup.gemList) do
-				if gemInstance.fromItem or (gemInstance.gemData and gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.fromTree) then
+				local grantedByNonGemSource = gemInstance.fromItem or gemInstance.fromNode or socketGroup.sourceNode
+				local grantedFromTree = gemInstance.gemData and gemInstance.gemData.grantedEffect and gemInstance.gemData.grantedEffect.fromTree
+				if grantedByNonGemSource or grantedFromTree then
 					countGroup = false
 				end
 				if gemInstance.gemData and gemInstance.enabled then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1403,6 +1403,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					enabled = true,
 				}
 				activeGemInstance.fromItem = grantedSkill.sourceItem ~= nil
+				activeGemInstance.fromNode = grantedSkill.sourceNode ~= nil
 				activeGemInstance.level = grantedSkill.level
 				activeGemInstance.gemId = data.gemForSkill[data.skills[grantedSkill.skillId]]
 				activeGemInstance.enableGlobal1 = true


### PR DESCRIPTION
Fixes #394

## Summary

Skills granted by passive tree nodes no longer consume one of the build's gem group slots.

## Root Cause

Skills granted by items already carry `fromItem`, and tree-origin granted effects can be excluded via `grantedEffect.fromTree`. But node-granted skills created from `env.grantedSkillsNodes` did not propagate their node origin onto the generated active gem instance.

As a result, a node-granted skill such as `Summon Infernal Hound` was placed into a skill group and counted by `UpdateGlobalGemCountAssignments`, producing the too-many-gem-groups warning even though the skill is not a socketed skill gem in-game.

## Fix

- Propagate `grantedSkill.sourceNode` to `activeGemInstance.fromNode` when generated skill groups are refreshed.
- Treat `fromNode` / `sourceNode` groups as non-gem granted groups when counting global gem groups.
- Leave the generated skill group itself intact so the granted skill can still be displayed and calculated.

## Validation

- Added a regression test with 9 normal gem groups plus a node-granted `Summon Infernal Hound` group.
- The test asserts `GlobalGemAssignments["GemGroupCount"]` remains 9.
- Ran `git diff --check` before commit: pass.
- Ran `git diff --cached --check` before commit: pass.
- Ran `git show --check --stat --oneline HEAD`: pass.

I did not run `docker-compose up` locally to avoid launching Docker/extra windows on this machine; the targeted Busted spec should run in CI.

## Risk / Rollback

Risk is low: this only changes gem-group counting metadata for non-gem granted skills. It does not remove the granted skill group or alter skill calculations.

Rollback is the single commit if maintainers prefer a different source marker for generated node skills.