### PR TITLE
Fix active gem DPS sorting

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -245,4 +245,25 @@ describe("TestSkills", function()
 
 		assert.True(build.calcsTab.calcsOutput.Cooldown == 10)
 	end)
+
+	it("Test active gem DPS sorting estimates replacement skills", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Bombard Crossbow
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Oil Grenade 20/0  1")
+		runCallback("OnFrame")
+
+		build.skillsTab.sortGemsByDPS = true
+		build.skillsTab.sortGemsByDPSField = "CombinedDPS"
+		local activeGemSelect = build.skillsTab.gemSlots[1].nameSpec
+		activeGemSelect:UpdateSortCache()
+
+		local _, explosiveGrenade = build.skillsTab:FindSkillGem("Explosive Grenade")
+		assert.True(activeGemSelect.sortCache.dpsCalculated["Default:" .. explosiveGrenade.id])
+	end)
 end)

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -246,6 +246,7 @@ function GemSelectClass:UpdateSortCache()
 		canSupport = { },
 		dps = { },
 		dpsColor = { },
+		dpsCalculated = { },
 		sortType = self.skillsTab.sortGemsByDPSField
 	}
 	self.sortCache = sortCache
@@ -300,14 +301,19 @@ function GemSelectClass:UpdateSortCache()
 	local calcFunc, calcBase = self.skillsTab.build.calcsTab:GetMiscCalculator(self.build)
 	-- Check for nil because some fields may not be populated, default to 0
 	local baseDPS = (dpsField == "FullDPS" and calcBase[dpsField] ~= nil and calcBase[dpsField]) or (calcBase.Minion and calcBase.Minion.CombinedDPS) or (calcBase[dpsField] ~= nil and calcBase[dpsField]) or 0
+	sortCache.baseDPS = baseDPS
 
 	for gemId, gemData in pairs(self.gems) do
 		sortCache.dps[gemId] = baseDPS
-		-- Ignore gems that don't support the active skill
-		if sortCache.canSupport[gemId] or (gemData.grantedEffect.hasGlobalEffect and not gemData.grantedEffect.support) then
+		local canEstimateDPS = sortCache.canSupport[gemId]
+			or (gemData.grantedEffect.hasGlobalEffect and not gemData.grantedEffect.support)
+			or (self.index == 1 and not gemData.grantedEffect.support)
+		-- Ignore gems that cannot affect the active skill or replace the active gem
+		if canEstimateDPS then
 			local output = self:CalcOutputWithThisGem(calcFunc, gemData, useFullDPS, fastCalcOptions, calcBase)
 			-- Check for nil because some fields may not be populated, default to 0
 			sortCache.dps[gemId] = (dpsField == "FullDPS" and output[dpsField] ~= nil and output[dpsField]) or (output.Minion and output.Minion.CombinedDPS) or (output[dpsField] ~= nil and output[dpsField]) or 0
+			sortCache.dpsCalculated[gemId] = true
 		end
 		-- Color based on the DPS
 		if sortCache.dps[gemId] > baseDPS then
@@ -436,6 +442,9 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 					SetDrawColor(self.sortCache.dpsColor[gemId])
 					main:DrawCheckMark(width - 4 - height / 2 - (scrollBar.enabled and 18 or 0), y + (height - 4) / 2, (height - 4) * 0.8)
 				elseif gemData.grantedEffect.hasGlobalEffect then
+					SetDrawColor(self.sortCache.dpsColor[gemId])
+					DrawString(width - 4 - height / 2 - (scrollBar.enabled and 18 or 0), y - 2, "CENTER_X", height, "VAR", "+")
+				elseif self.sortCache.dpsCalculated[gemId] and self.sortCache.dps[gemId] ~= self.sortCache.baseDPS then
 					SetDrawColor(self.sortCache.dpsColor[gemId])
 					DrawString(width - 4 - height / 2 - (scrollBar.enabled and 18 or 0), y - 2, "CENTER_X", height, "VAR", "+")
 				end


### PR DESCRIPTION
﻿## Summary

Fixes #1633.

Includes active replacement gems in the existing DPS sort estimate so active gems that change the selected skill's DPS are ranked by their actual impact instead of being left at the base build DPS.

## Root Cause

`GemSelectControl:UpdateSortCache` only ran the DPS comparison for support gems that could support the displayed active skill, plus non-support gems with global effects. Ordinary active gems in the active-gem slot were still valid replacement candidates, but they were never sent through `CalcOutputWithThisGem`, so they kept the base DPS value and missed the impact marker.

## Fix

- Track which gem candidates actually receive a DPS estimate.
- Estimate DPS for non-support gems when the selector is editing the active gem slot.
- Show the existing `+` impact marker only for active replacement gems whose calculated DPS differs from the base DPS.
- Add a regression covering an Oil Grenade active slot where Explosive Grenade must receive a calculated DPS entry.

## Validation

- `git diff --check` — passed, CRLF conversion warnings only.
- `git diff --cached --check` — passed, CRLF conversion warnings only.
- `git show --check --stat --oneline HEAD` — passed.

I did not run Docker/Busted locally on this machine; the local test path for this repo is container-based and I avoided starting containers or external windows during this contribution pass.

## Risk / Rollback

Risk is limited to the gem selector DPS-sort cache. The change reuses the existing calculator path already used for support/global-effect gem comparisons, and only broadens it for active-gem replacements in the active slot. Rollback is the single commit if it causes selector-performance or sorting regressions.
