### PR TITLE
Fix weapon set allocation issues + add colour to nodes

### DIFF
--- a/spec/System/TestPassiveSpec_spec.lua
+++ b/spec/System/TestPassiveSpec_spec.lua
@@ -1,0 +1,71 @@
+describe("TestPassiveSpec", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	local function pathContains(path, needle)
+		if not path then
+			return false
+		end
+		for _, node in ipairs(path) do
+			if node == needle then
+				return true
+			end
+		end
+		return false
+	end
+
+	local function isAllocatableNormalNode(node)
+		return node
+			and not node.alloc
+			and node.type == "Normal"
+			and not node.ascendancyName
+			and not node.isMultipleChoice
+			and not node.isMultipleChoiceOption
+			and #node.intuitiveLeapLikesAffecting == 0
+	end
+
+	local function findNormalPathNodeAfter(spec, throughNode)
+		for _, node in ipairs(throughNode.linked) do
+			if isAllocatableNormalNode(node) and (node.pathRoot == throughNode or pathContains(node.path, throughNode)) then
+				return node
+			end
+		end
+		for _, node in pairs(spec.nodes) do
+			if isAllocatableNormalNode(node) and (node.pathRoot == throughNode or pathContains(node.path, throughNode)) then
+				return node
+			end
+		end
+	end
+
+	it("normal passive allocation cannot continue through weapon-set-only branches", function()
+		local spec = build.spec
+		local startNode = spec.nodes[spec.curClass.startNodeId]
+		local firstNode = findNormalPathNodeAfter(spec, startNode)
+		assert.True(firstNode ~= nil)
+
+		spec.allocMode = 0
+		spec:AllocNode(firstNode)
+		assert.are.equals(0, firstNode.allocMode)
+
+		local weaponSetNode = findNormalPathNodeAfter(spec, firstNode)
+		assert.True(weaponSetNode ~= nil)
+
+		spec.allocMode = 1
+		spec:AllocNode(weaponSetNode)
+		assert.are.equals(1, weaponSetNode.allocMode)
+
+		local blockedNode = findNormalPathNodeAfter(spec, weaponSetNode)
+		assert.True(blockedNode ~= nil)
+		assert.True(blockedNode.pathRoot == weaponSetNode or pathContains(blockedNode.path, weaponSetNode))
+
+		spec.allocMode = 0
+		spec:AllocNode(blockedNode)
+		assert.are_not.equals(true, blockedNode.alloc)
+
+		spec.allocMode = 1
+		spec:AllocNode(blockedNode)
+		assert.True(blockedNode.alloc)
+		assert.are.equals(1, blockedNode.allocMode)
+	end)
+end)

--- a/spec/System/TestPassiveSpec_spec.lua
+++ b/spec/System/TestPassiveSpec_spec.lua
@@ -3,69 +3,85 @@ describe("TestPassiveSpec", function()
 		newBuild()
 	end)
 
-	local function pathContains(path, needle)
-		if not path then
-			return false
-		end
-		for _, node in ipairs(path) do
-			if node == needle then
-				return true
-			end
-		end
-		return false
-	end
-
-	local function isAllocatableNormalNode(node)
+	local function allocNode(spec, nodeId, allocMode)
+		local node = spec.nodes[nodeId]
+		spec.allocMode = allocMode
+		spec:AllocNode(node)
+		assert.are.equals(allocMode, node.allocMode)
 		return node
-			and not node.alloc
-			and node.type == "Normal"
-			and not node.ascendancyName
-			and not node.isMultipleChoice
-			and not node.isMultipleChoiceOption
-			and #node.intuitiveLeapLikesAffecting == 0
 	end
 
-	local function findNormalPathNodeAfter(spec, throughNode)
-		for _, node in ipairs(throughNode.linked) do
-			if isAllocatableNormalNode(node) and (node.pathRoot == throughNode or pathContains(node.path, throughNode)) then
-				return node
-			end
-		end
-		for _, node in pairs(spec.nodes) do
-			if isAllocatableNormalNode(node) and (node.pathRoot == throughNode or pathContains(node.path, throughNode)) then
-				return node
-			end
-		end
-	end
-
-	it("normal passive allocation cannot continue through weapon-set-only branches", function()
+	it("normal passive allocation promotes the shortest path instead of using a longer detour", function()
 		local spec = build.spec
-		local startNode = spec.nodes[spec.curClass.startNodeId]
-		local firstNode = findNormalPathNodeAfter(spec, startNode)
-		assert.True(firstNode ~= nil)
+		allocNode(spec, 56651, 0)
+		local weaponSetNode = allocNode(spec, 38143, 1)
+		assert.are.equals("Strength", weaponSetNode.dn)
+
+		local reachableNode = spec.nodes[43923]
+		assert.are.equals("Accuracy", reachableNode.dn)
 
 		spec.allocMode = 0
-		spec:AllocNode(firstNode)
-		assert.are.equals(0, firstNode.allocMode)
+		spec:AllocNode(reachableNode)
 
-		local weaponSetNode = findNormalPathNodeAfter(spec, firstNode)
-		assert.True(weaponSetNode ~= nil)
+		assert.True(reachableNode.alloc)
+		assert.are.equals(0, reachableNode.allocMode)
+		assert.are.equals(0, weaponSetNode.allocMode)
+	end)
 
-		spec.allocMode = 1
-		spec:AllocNode(weaponSetNode)
-		assert.are.equals(1, weaponSetNode.allocMode)
+	it("normal passive allocation promotes the weapon-set chain behind the path root", function()
+		local spec = build.spec
+		allocNode(spec, 56651, 0)
+		allocNode(spec, 35324, 0)
+		allocNode(spec, 35660, 1)
+		allocNode(spec, 18548, 1)
 
-		local blockedNode = findNormalPathNodeAfter(spec, weaponSetNode)
-		assert.True(blockedNode ~= nil)
-		assert.True(blockedNode.pathRoot == weaponSetNode or pathContains(blockedNode.path, weaponSetNode))
+		local promotedNode = spec.nodes[28992]
+		assert.are.equals("Honed Instincts", promotedNode.dn)
 
 		spec.allocMode = 0
-		spec:AllocNode(blockedNode)
-		assert.are_not.equals(true, blockedNode.alloc)
+		spec:AllocNode(promotedNode)
 
-		spec.allocMode = 1
-		spec:AllocNode(blockedNode)
-		assert.True(blockedNode.alloc)
-		assert.are.equals(1, blockedNode.allocMode)
+		assert.True(promotedNode.alloc)
+		assert.are.equals(0, promotedNode.allocMode)
+		assert.are.equals(0, spec.nodes[18548].allocMode)
+		assert.are.equals(0, spec.nodes[35660].allocMode)
+	end)
+
+	it("weapon-set allocation cannot originate from another weapon set path", function()
+		local spec = build.spec
+		allocNode(spec, 56651, 0)
+		allocNode(spec, 35324, 0)
+		allocNode(spec, 35660, 1)
+		allocNode(spec, 18548, 1)
+
+		local weaponSet2Node = spec.nodes[28992]
+		assert.are.equals("Honed Instincts", weaponSet2Node.dn)
+
+		spec.allocMode = 2
+		spec:AllocNode(weaponSet2Node)
+
+		assert.True(weaponSet2Node.alloc)
+		assert.are.equals(2, weaponSet2Node.allocMode)
+		assert.are.equals(1, spec.nodes[18548].allocMode)
+		assert.are.equals(1, spec.nodes[35660].allocMode)
+	end)
+
+	it("normal passives cannot stay connected through weapon-set-only paths", function()
+		local spec = build.spec
+		allocNode(spec, 56651, 0)
+		allocNode(spec, 35234, 0)
+		allocNode(spec, 6789, 0)
+		allocNode(spec, 4313, 0)
+		allocNode(spec, 28992, 0)
+		allocNode(spec, 35660, 1)
+		allocNode(spec, 18548, 1)
+
+		spec:DeallocNode(spec.nodes[4313])
+
+		assert.are_not.equals(true, spec.nodes[28992].alloc)
+		assert.True(spec.nodes[35660].alloc)
+		assert.True(spec.nodes[18548].alloc)
+		assert.are.equals(1, spec.nodes[35660].allocMode)
+		assert.are.equals(1, spec.nodes[18548].allocMode)
 	end)
 end)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -815,6 +815,20 @@ function PassiveSpecClass:AllocNode(node, altPath)
 		-- Node cannot be connected to the tree as there is no possible path
 		return
 	end
+	local path = altPath or node.path
+
+	if self.allocMode == 0 and #node.intuitiveLeapLikesAffecting == 0 then
+		if not altPath and node.pathRoot and node.pathRoot.alloc and node.pathRoot.allocMode and node.pathRoot.allocMode > 0 then
+			-- Normal passives cannot continue from weapon-set-only branches.
+			return
+		end
+		for _, pathNode in ipairs(path) do
+			if pathNode.alloc and pathNode.allocMode and pathNode.allocMode > 0 then
+				-- Normal passives cannot continue from weapon-set-only branches.
+				return
+			end
+		end
+	end
 
 	-- Allocate all nodes along the path
 	if #node.intuitiveLeapLikesAffecting > 0 then
@@ -822,7 +836,7 @@ function PassiveSpecClass:AllocNode(node, altPath)
 		node.allocMode = (node.ascendancyName or node.type == "Keystone" or node.type == "Socket" or node.containJewelSocket) and 0 or self.allocMode
 		self.allocNodes[node.id] = node
 	else
-		for _, pathNode in ipairs(altPath or node.path) do
+		for _, pathNode in ipairs(path) do
 			pathNode.alloc = true
 			pathNode.allocMode = (node.ascendancyName or pathNode.type == "Keystone" or pathNode.type == "Socket" or pathNode.containJewelSocket) and 0 or self.allocMode
 			-- set path attribute nodes to latest chosen attribute or default to Strength if allocating before choosing an attribute
@@ -952,6 +966,7 @@ end
 function PassiveSpecClass:BuildPathFromNode(root)
 	root.pathDist = 0
 	root.path = { }
+	root.pathRoot = root
 	local queue = { root }
 	local o, i = 1, 2 -- Out, in
 	while o < i do
@@ -999,6 +1014,7 @@ function PassiveSpecClass:BuildPathFromNode(root)
 					other.pathDist = other.pathDist + 1
 				end
 				other.path = wipeTable(other.path)
+				other.pathRoot = root
 				other.path[1] = other
 				for i, n in ipairs(node.path) do
 					other.path[i+1] = n
@@ -1668,6 +1684,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 	for id, node in pairs(self.nodes) do
 		node.pathDist = (node.alloc and #node.intuitiveLeapLikesAffecting == 0) and 0 or 1000
 		node.path = nil
+		node.pathRoot = nil
 		if node.isJewelSocket or node.expansionJewel then
 			node.distanceToClassStart = 0
 		end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -72,7 +72,7 @@ function PassiveSpecClass:Init(treeVersion, convert)
 	-- Keys are node IDs, values are nodes
 	self.allocNodes = { }
 
-	-- List of nodes allocated in subgraphs; used to maintain allocation when loading, and when rebuilding subgraphs
+	-- List of nodes allocated in subgraphs, used to maintain allocation when loading, and when rebuilding subgraphs
 	self.allocSubgraphNodes = { }
 
 	-- List of cluster nodes to allocate
@@ -810,24 +810,105 @@ end
 -- Allocate the given node, if possible, and all nodes along the path to the node
 -- An alternate path to the node may be provided, otherwise the default path will be used
 -- The path must always contain the given node, as will be the case for the default path
+function PassiveSpecClass:CanPathThroughAllocMode(allocMode, node)
+	-- Normal allocation can only use normal nodes, weapon set allocation can also use its own set.
+	local nodeMode = node.allocMode or 0
+	return nodeMode == 0 or allocMode > 0 and nodeMode == allocMode
+end
+
+function PassiveSpecClass:GetAllocationPath(target, allocMode, allocatedOnly, skipRoot)
+	-- Build a shortest path using only roots and allocated nodes that are valid for the requested alloc mode.
+	local visited = { }
+	local prev = { }
+	local queue = { }
+	local o = 1
+	for _, node in pairs(self.allocNodes) do
+		-- Start from every compatible allocated node so the first hit is the shortest valid route.
+		if node ~= skipRoot and self:CanPathThroughAllocMode(allocatedOnly and 0 or allocMode, node) then
+			visited[node] = true
+			queue[#queue + 1] = node
+		end
+	end
+	while queue[o] do
+		local node = queue[o]
+		o = o + 1
+		if node == target then
+			local path = { }
+			local current = target
+			-- Rebuild the path backwards from the target to the allocated root.
+			while current and prev[current] do
+				t_insert(path, current)
+				current = prev[current]
+			end
+			-- Keep the root outside the path list so hover rendering can preview the first connector.
+			path.root = current
+			return path
+		end
+		if node.unlockConstraint then
+			for _, nodeId in ipairs(node.unlockConstraint.nodes) do
+				if not self.nodes[nodeId].alloc then
+					goto continue
+				end
+			end
+		end
+		for _, other in ipairs(node.linked) do
+			local canPath = true
+			if other.unlockConstraint then
+				for _, nodeId in ipairs(other.unlockConstraint.nodes) do
+					if not self.nodes[nodeId].alloc then
+						canPath = false
+						break
+					end
+				end
+			end
+			local otherMode = other.allocMode or 0
+			local canVisit = allocatedOnly and other.alloc and self:CanPathThroughAllocMode(allocMode, other) and (otherMode > 0 or other.type ~= "ClassStart" and other.type ~= "AscendClassStart") or not allocatedOnly and (not other.alloc or self:CanPathThroughAllocMode(allocMode, other))
+			-- Keep the normal tree, weapon set 1, and weapon set 2 as separate pathing graphs.
+			if canPath and canVisit and not visited[other] and node.type ~= "Mastery" and other.type ~= "ClassStart" and other.type ~= "AscendClassStart" and (node.ascendancyName == other.ascendancyName or (not prev[node] and not other.ascendancyName)) then
+				visited[other] = true
+				prev[other] = node
+				queue[#queue + 1] = other
+			end
+		end
+		::continue::
+	end
+end
+
+function PassiveSpecClass:GetEffectiveAllocationPath(node, altPath)
+	local path = altPath or node.path
+	if altPath or #node.intuitiveLeapLikesAffecting > 0 then
+		return path
+	end
+	local pathRoot = node.pathRoot
+	local pathRootMode = pathRoot and pathRoot.allocMode or 0
+	if pathRootMode == 0 then
+		return path
+	end
+	if self.allocMode == 0 and pathRoot.alloc then
+		-- Normal allocation through a weapon-set branch promotes that branch back to normal pathing.
+		path = { unpack(path) }
+		local rootPath = self:GetAllocationPath(pathRoot, pathRootMode, true, pathRoot)
+		path.root = rootPath and rootPath.root
+		for _, pathNode in ipairs(rootPath or { pathRoot }) do
+			if not isValueInArray(path, pathNode) then
+				t_insert(path, pathNode)
+			end
+		end
+	elseif self.allocMode > 0 and pathRootMode ~= self.allocMode then
+		-- Weapon-set paths cannot start from the other weapon set, so recalculate from compatible roots.
+		path = self:GetAllocationPath(node, self.allocMode)
+	end
+	return path
+end
+
 function PassiveSpecClass:AllocNode(node, altPath)
 	if not node.path then
 		-- Node cannot be connected to the tree as there is no possible path
 		return
 	end
-	local path = altPath or node.path
-
-	if self.allocMode == 0 and #node.intuitiveLeapLikesAffecting == 0 then
-		if not altPath and node.pathRoot and node.pathRoot.alloc and node.pathRoot.allocMode and node.pathRoot.allocMode > 0 then
-			-- Normal passives cannot continue from weapon-set-only branches.
-			return
-		end
-		for _, pathNode in ipairs(path) do
-			if pathNode.alloc and pathNode.allocMode and pathNode.allocMode > 0 then
-				-- Normal passives cannot continue from weapon-set-only branches.
-				return
-			end
-		end
+	local path = self:GetEffectiveAllocationPath(node, altPath)
+	if not path then
+		return
 	end
 
 	-- Allocate all nodes along the path
@@ -924,7 +1005,8 @@ end
 
 -- Attempt to find a class start node starting from the given node
 -- Unless noAscent == true it will also look for an ascendancy class start node
-function PassiveSpecClass:FindStartFromNode(node, visited, noAscend)
+function PassiveSpecClass:FindStartFromNode(node, visited, noAscend, allocMode)
+	allocMode = allocMode or node.allocMode or 0
 	-- Mark the current node as visited so we don't go around in circles
 	node.visited = true
 	t_insert(visited, node)
@@ -934,9 +1016,9 @@ function PassiveSpecClass:FindStartFromNode(node, visited, noAscend)
 		--  - the other node is a start node, or
 		--  - there is a path to a start node through the other node which didn't pass through any nodes which have already been visited
 		local startIndex = #visited + 1
-		if other.alloc and
+		if other.alloc and self:CanPathThroughAllocMode(allocMode, other) and
 		  (other.type == "ClassStart" or other.type == "AscendClassStart" or
-		    (not other.visited and node.type ~= "Mastery" and self:FindStartFromNode(other, visited, noAscend))
+		    (not other.visited and node.type ~= "Mastery" and self:FindStartFromNode(other, visited, noAscend, allocMode))
 		  ) then
 			if node.ascendancyName and not other.ascendancyName then
 				-- Pathing out of Ascendant, un-visit the outside nodes
@@ -1007,7 +1089,7 @@ function PassiveSpecClass:BuildPathFromNode(root)
 			if not other.pathDist then
 				ConPrintTable(other, true)
 			end
-			if node.type ~= "Mastery" and other.type ~= "ClassStart" and other.type ~= "AscendClassStart" and other.pathDist > curDist and (node.ascendancyName == other.ascendancyName or (curDist == 0 and not other.ascendancyName)) and canPath then
+			if node.type ~= "Mastery" and other.type ~= "ClassStart" and other.type ~= "AscendClassStart" and (not other.alloc or self:CanPathThroughAllocMode(root.allocMode or 0, other)) and other.pathDist > curDist and (node.ascendancyName == other.ascendancyName or (curDist == 0 and not other.ascendancyName)) and canPath then
 				-- The shortest path to the other node is through the current node
 				other.pathDist = curDist
 				if not other.alloc then
@@ -1479,13 +1561,13 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		node.connectedToStart = false
 		local anyStartFound = (node.type == "ClassStart" or node.type == "AscendClassStart")
 		for _, other in ipairs(node.linked) do
-			if other.alloc and not isValueInArray(node.depends, other) then
+			if other.alloc and self:CanPathThroughAllocMode(node.allocMode or 0, other) and not isValueInArray(node.depends, other) then
 				-- The other node is allocated and isn't already dependent on this node, so try and find a path to a start node through it
 				if other.type == "ClassStart" or other.type == "AscendClassStart" then
 					-- Well that was easy!
 					anyStartFound = true
 					node.connectedToStart = true
-				elseif self:FindStartFromNode(other, visited) then
+				elseif self:FindStartFromNode(other, visited, nil, node.allocMode or 0) then
 					-- We found a path through the other node, therefore the other node cannot be dependent on this node
 					anyStartFound = true
 					node.connectedToStart = true
@@ -1507,13 +1589,13 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 							local otherPath = false
 							local allocatedLinkCount = 0
 							for _, linkedNode in ipairs(n.linked) do
-								if linkedNode.alloc then
+								if linkedNode.alloc and self:CanPathThroughAllocMode(n.allocMode or 0, linkedNode) then
 									allocatedLinkCount = allocatedLinkCount + 1
 								end
 							end
 							if allocatedLinkCount > 1 then
 								for _, linkedNode in ipairs(n.linked) do
-									if linkedNode.alloc and not depIds[linkedNode.id] then
+									if linkedNode.alloc and self:CanPathThroughAllocMode(n.allocMode or 0, linkedNode) and not depIds[linkedNode.id] then
 										otherPath = true
 									end
 								end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -328,8 +328,13 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		-- Use the node's own path and dependence list
 		hoverPath = { }
 		if #hoverNode.intuitiveLeapLikesAffecting == 0 then
-			for _, pathNode in pairs(hoverNode.path) do
+			-- Use the same effective path as allocation so weapon-set promotion previews match clicks.
+			local path = (hoverNode.alloc and hoverNode.path or spec:GetEffectiveAllocationPath(hoverNode)) or { }
+			for _, pathNode in ipairs(path) do
 				hoverPath[pathNode] = true
+			end
+			if path.root then
+				hoverPath[path.root] = true
 			end
 		end
 		hoverDep = { }
@@ -640,13 +645,33 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	local function setConnectorColor(r, g, b)
 		connectorColor[1], connectorColor[2], connectorColor[3] = r, g, b
 	end
+	local function nodeIsHoverPathEndpoint(node)
+		if node == hoverNode or hoverPath[node] then
+			return true
+		end
+		if node.alloc then
+			local mode = node.allocMode or 0
+			return mode == 0 or mode == spec.allocMode
+		end
+	end
+	local function nodeWillChangeAllocMode(node)
+		-- Hovering a normal allocation can preview weapon-set nodes being promoted back to normal.
+		return hoverNode and hoverPath and hoverPath[node] and not hoverNode.alloc and spec.allocMode == 0 and (node.allocMode or 0) > 0
+	end
+	local function nodeWillAllocateWithAllocMode(node)
+		-- Unallocated hover/trace path nodes should preview with the selected weapon-set tint.
+		return hoverPath and hoverPath[node] and (self.traceMode or hoverNode and not hoverNode.alloc) and not node.alloc and spec.allocMode > 0 and not node.ascendancyName and node.type ~= "Keystone" and node.type ~= "Socket" and not node.containJewelSocket
+	end
 	local function getState(n1, n2)
 		-- Determine the connector state
 		local state = "Normal"
-		if n1.alloc and n2.alloc then
+		local mode1, mode2 = n1.allocMode or 0, n2.allocMode or 0
+		if hoverPath and nodeIsHoverPathEndpoint(n1) and nodeIsHoverPathEndpoint(n2) and hoverPath[n1] and hoverPath[n2] and (nodeWillChangeAllocMode(n1) or nodeWillChangeAllocMode(n2)) then
+			state = "Intermediate"
+		elseif n1.alloc and n2.alloc and (mode1 == 0 or mode2 == 0 or mode1 == mode2) then
 			state = "Active"
 		elseif hoverPath then
-			if (n1.alloc or n1 == hoverNode or hoverPath[n1]) and (n2.alloc or n2 == hoverNode or hoverPath[n2]) then
+			if nodeIsHoverPathEndpoint(n1) and nodeIsHoverPathEndpoint(n2) and (not n1.alloc or not n2.alloc or hoverPath[n1] and hoverPath[n2]) then
 				state = "Intermediate"
 			end
 		end
@@ -831,6 +856,8 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 		local base, overlay, effect
 		local isAlloc = node.alloc or build.calcsTab.mainEnv.grantedPassives[nodeId] or (compareNode and compareNode.alloc)
+		local allocMode = nodeWillAllocateWithAllocMode(node) and spec.allocMode or node.allocMode
+		local allocModeColor = not self.showHeatMap and not launch.devModeAlt and not compareNode and allocMode and allocMode > 0 and not nodeWillChangeAllocMode(node)
 		SetDrawLayer(nil, 25)
 		if node.type == "ClassStart" then
 			overlay = nil
@@ -1000,6 +1027,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		end
 
 		if overlay then
+			if allocModeColor then
+				SetDrawColor(unpack(hexToRGB(colorCodes[allocMode == 1 and "NEGATIVE" or "POSITIVE"]:sub(3))))
+			end
 			-- Draw overlay
 			if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" then
 				if hoverNode and hoverNode ~= node then
@@ -1051,6 +1081,8 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			end
 			self:DrawAsset(overlayImage, scrX, scrY, scale)
 			if not self.showHeatMap and not launch.devModeAlt and not node.alloc and (node.type == "AscendClassStart" or node.type == "ClassStart") then
+				SetDrawColor(1, 1, 1)
+			elseif allocModeColor then
 				SetDrawColor(1, 1, 1)
 			end
 		end


### PR DESCRIPTION
﻿## Summary

Prevent normal passive allocation from continuing through weapon-set-only branches.

Fixes #1532

## Root Cause

Passive path construction treats every allocated node as a path root without remembering which root produced a candidate path. That means a node at the end of a weapon-set branch can become the closest root for the next unallocated passive. When allocation mode is switched back to normal, `AllocNode` only checks that a path exists, so it can allocate a normal passive from a weapon-set-only branch.

## Fix

- Track the allocated root that produced each passive path via `pathRoot`.
- Clear `pathRoot` whenever paths are rebuilt, alongside `path`/`pathDist`.
- In normal allocation mode, reject paths rooted in an allocated weapon-set node or explicitly passing through one.
- Leave weapon-set mode allocation unchanged.
- Added a focused passive-spec regression that:
  - allocates one normal node,
  - allocates the next node in weapon set 1,
  - proves normal mode cannot continue beyond that branch,
  - proves weapon set 1 still can.

## Validation

Local validation run:

```text
git diff --check
PASS (CRLF normalization warnings only)

git diff --cached --check
PASS (CRLF normalization warnings only)

git show --check --stat --oneline HEAD
PASS (CRLF normalization warnings only)
```

I did not run Docker/Busted locally because the available full test runner is container-based and I was avoiding external test containers/windows during this session.

## Risk / Rollback

Risk is localized to passive allocation/path bookkeeping. The guard applies only while normal allocation mode is selected; weapon-set mode continues to use the existing path behavior. Rollback is the single commit if an unexpected valid normal-path edge case appears.
