### PR TITLE
Fix disconnected radius attribute passives granting stats

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -552,4 +552,38 @@ describe("TetsItemMods", function()
 		assert.are_not.equals(baseColdAvg, round(build.calcsTab.mainOutput.ColdStoredCombinedAvg))
 		assert.equals(0, round(build.calcsTab.mainOutput.FireStoredCombinedAvg))
 	end)
+
+	it("does not grant attributes from disconnected radius-allocated attribute passives", function()
+		local function makeAttributeNode(connectedToStart)
+			local node = {
+				id = 1,
+				type = "Normal",
+				isAttribute = true,
+				connectedToStart = connectedToStart,
+				intuitiveLeapLikesAffecting = { { id = 100 } },
+				modList = new("ModList"),
+				allocMode = 0,
+			}
+			node.modList:NewMod("Int", "BASE", 5, "Tree:1")
+			return node
+		end
+
+		local disconnectedNode = makeAttributeNode(false)
+		local env = {
+			mode = "MAIN",
+			radiusJewelList = { },
+			allocNodes = {
+				[disconnectedNode.id] = disconnectedNode,
+			},
+		}
+
+		assert.are.equals(0, build.calcsTab.calcs.buildModListForNode(env, disconnectedNode, 0):Sum("BASE", nil, "Int"))
+
+		local connectedNode = makeAttributeNode(true)
+		env.allocNodes = {
+			[connectedNode.id] = connectedNode,
+		}
+
+		assert.are.equals(5, build.calcsTab.calcs.buildModListForNode(env, connectedNode, 0):Sum("BASE", nil, "Int"))
+	end)
 end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -117,6 +117,10 @@ local function refreshJewelStatCache(env)
 	end
 end
 
+local function attributeNodeAllocatedByDisconnectedRadius(node)
+	return node.isAttribute and not node.connectedToStart and node.intuitiveLeapLikesAffecting and #node.intuitiveLeapLikesAffecting > 0
+end
+
 function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeystoneMods)
 	local localSmallIncEffect = 0
 	local localNotableIncEffect = 0
@@ -128,6 +132,9 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeyst
 		if node.keystoneMod then
 			modList:AddMod(node.keystoneMod)
 		end
+	elseif attributeNodeAllocatedByDisconnectedRadius(node) then
+		-- PoE2 currently does not grant the Str/Dex/Int from attribute passives
+		-- allocated only through "can be Allocated without being connected" radius effects.
 	else
 		modList:AddList(node.modList)
 	end


### PR DESCRIPTION
﻿## Summary
- Stop disconnected radius-allocated attribute passives from granting their Str/Dex/Int stats.
- Preserve normal connected attribute passives, even if they are also inside an Intuitive Leap / From Nothing style radius.
- Add a regression around the passive-node modifier path.

## Root Cause
Nodes affected by "can be Allocated without being connected" radius effects are marked through `intuitiveLeapLikesAffecting`, but `buildModListForNode` still always added the node's base `modList`. For attribute passives, that meant PoB granted Str/Dex/Int even when the node was allocated only through the disconnected-radius mechanic, which does not currently grant those attributes in-game.

## Fix
When a node is an attribute passive, is affected by a disconnected-allocation radius, and is not connected to the class start, its base attribute mod list is skipped. Connected attribute passives remain unchanged.

## Validation
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '241' --json number,title,headRefName,author,url --jq '.'` → `[]`
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '"From Nothing"' --json number,title,headRefName,author,url --jq '.'` → existing From Nothing/radius PRs, none for this attribute-stat behavior
- `git diff --check` → pass (CRLF warning only)
- `git diff --cached --check` → pass (CRLF warning only)
- `git show --check --stat --oneline HEAD` → pass

I did not run the containerized Busted suite locally; this machine is currently being kept free of extra containers/windows. The included spec exercises the changed passive-node modifier branch directly.

## Risk / Rollback
Risk is limited to attribute passives allocated only by disconnected-radius mechanics. If GGG fixes the in-game behavior later, this can be reverted cleanly.

Fixes #241
