### PR TITLE
Fix Qimah quest reward import wording

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -7,6 +7,17 @@ describe("TetsItemMods", function()
 		-- newBuild() takes care of resetting everything in setup()
 	end)
 
+	it("Import keeps Qimah elemental resistance reward from API wording", function()
+		local qimahRewardVar = "questInterlude 2QimahSeven Pillars"
+
+		build.importTab:ImportQuestRewardConfig({ "+5% to Elemental Resistances" })
+		assert.are.equals("+5% to all Elemental Resistances", build.configTab.input[qimahRewardVar])
+
+		newBuild()
+		build.importTab:ImportQuestRewardConfig({ "+5% to all Elemental Resistances" })
+		assert.are.equals("+5% to all Elemental Resistances", build.configTab.input[qimahRewardVar])
+	end)
+
 	it("Both slots mod (evasion and es mastery)", function()
 
 		build.configTab.input.customMods = "\z

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -650,12 +650,35 @@ function ImportTabClass:ImportQuestRewardConfig(questStats)
 	end
 
 	-- Ensure all required lines exist, then remove them so they can't match again
-	local function matchQuest(requiredLines)
+	local function getImportAliases(importAliases, needed)
+		if not importAliases then
+			return nil
+		end
+		for canonicalLine, aliases in pairs(importAliases) do
+			if canonicalLine:lower() == needed then
+				return aliases
+			end
+		end
+	end
+
+	local function statLineMatches(line, needed, importAliases)
+		if line == needed then
+			return true
+		end
+		for _, alias in ipairs(getImportAliases(importAliases, needed) or {}) do
+			if line == escapeGGGString(alias):lower() then
+				return true
+			end
+		end
+		return false
+	end
+
+	local function matchQuest(requiredLines, importAliases)
 		local indices = {}
 		for _, needed in ipairs(requiredLines) do
 			local found
 			for idx, line in ipairs(statLines) do
-				if line == needed then
+				if statLineMatches(line, needed, importAliases) then
 					found = idx
 					break
 				end
@@ -677,7 +700,7 @@ function ImportTabClass:ImportQuestRewardConfig(questStats)
 		if quest.useConfig == true then
 			local var = "quest" .. quest.Description .. quest.Area .. quest.Info
 			if quest.Stat then
-				local matches = matchQuest(splitLine(quest.Stat))
+				local matches = matchQuest(splitLine(quest.Stat), quest.ImportStatAliases)
 				if configTab.input[var] ~= matches then
 					configTab.input[var] = matches
 					updated = true
@@ -685,7 +708,7 @@ function ImportTabClass:ImportQuestRewardConfig(questStats)
 			elseif quest.Options then
 				local selected = configTab.defaultState[var] or "None"
 				for _, option in ipairs(quest.Options) do
-					if matchQuest(splitLine(option)) then
+					if matchQuest(splitLine(option), quest.ImportStatAliases) then
 						selected = option
 						break
 					end

--- a/src/Data/QuestRewards.lua
+++ b/src/Data/QuestRewards.lua
@@ -258,6 +258,11 @@ return {
 			"+5 to all Attributes",
 			"5% increased Experience Gain\n\t-5% to Elemental Resistances\n\t3% reduced Movement Speed\n\t15% reduced Global Defences\n\t20% reduced Presence Area Of Effect\n\t12% reduced Cooldown Recovery Rate\n\t5% reduced Attributes",
 		},
+		["ImportStatAliases"] = {
+			["+5% to all Elemental Resistances"] = {
+				"+5% to Elemental Resistances",
+			},
+		},
 		["AreaLevel"] = 63,
 		["useConfig"] = true
 	},


### PR DESCRIPTION
﻿Fixes #1681

## Summary
- Accept the Path of Exile API wording for Qimah's elemental resistance quest reward.
- Keep the existing canonical config option text, `+5% to all Elemental Resistances`.
- Add a regression spec for both the API wording and the existing canonical wording.

## Root Cause
The quest reward importer matches imported quest stat lines by exact normalized text. The Qimah option is stored locally as `+5% to all Elemental Resistances`, while the imported character data can report `+5% to Elemental Resistances`. Because those strings did not compare equal, import fell through to the default `None` selection.

## Fix
Added a small data-driven import alias table on the Qimah quest reward and taught the existing matcher to accept those aliases while still selecting the canonical local option. This keeps matching strict for all other rewards and avoids broad fuzzy matching.

## Validation
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '1681 Qimah quest reward elemental resistances' --json number,title,headRefName,author,url --jq '.'` returned `[]`.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- `git show --check --stat --oneline HEAD` passed.
- Added `Import keeps Qimah elemental resistance reward from API wording` in `spec/System/TestItemMods_spec.lua`.

I did not run the containerized Busted suite locally; this machine is currently being kept free of extra containers/windows. The included spec exercises the exact import wording mismatch.

## Risk / Rollback
Low risk. The alias is scoped to the Qimah reward option and only affects import matching, not the stored config value or calculations. Rollback is the single commit on this branch.
