### PR TITLE
Mark Black Doubt sacrifice mod unscalable

### DIFF
--- a/spec/System/TestItemTools_spec.lua
+++ b/spec/System/TestItemTools_spec.lua
@@ -26,6 +26,8 @@ local applyRangeTests = {
 	[{ "(15-20)% increased Cold Damage per 1% Cold Resistance above 75%", 1.0, 1.5 }] = "30% increased Cold Damage per 1% Cold Resistance above 75%",
 	[{ "(15-20)% increased Cold Damage per 1% Cold Resistance above 75%", 0.5, 1.0 }] = "18% increased Cold Damage per 1% Cold Resistance above 75%",
 	[{ "(15-20)% increased Cold Damage per 1% Cold Resistance above 75%", 0.5, 1.5 }] = "27% increased Cold Damage per 1% Cold Resistance above 75%",
+	-- Unscalable unique range
+	[{ "Sacrifice (5-15)% of Life to gain that much Energy Shield when you Cast a Spell", 1.0, 1.5 }] = "Sacrifice 15% of Life to gain that much Energy Shield when you Cast a Spell",
 	-- High precision range
 	[{ "Regenerate (66.7-75) Life per second", 1.0, 1.0 }] = "Regenerate 75 Life per second",
 	[{ "Regenerate (66.7-75) Life per second", 1.0, 1.5 }] = "Regenerate 112.5 Life per second",

--- a/src/Data/ModScalability.lua
+++ b/src/Data/ModScalability.lua
@@ -12081,7 +12081,7 @@ return {
 	["Runebinder"] = {  },
 	["Runic Monsters in your Maps are Duplicated"] = {  },
 	["Sacrifice # Life to not consume the last bolt when firing"] = { { isScalable = true } },
-	["Sacrifice #% of Life to gain that much Energy Shield when you Cast a Spell"] = { { isScalable = true } },
+	["Sacrifice #% of Life to gain that much Energy Shield when you Cast a Spell"] = { { isScalable = false } },
 	["Sacrifice #% of maximum Life to gain that much Guard when you Dodge Roll"] = { { isScalable = true } },
 	["Sacrifice #% of your Life when you Use or Trigger a Spell Skill"] = { { isScalable = true } },
 	["Sacrifice up to # to receive double on Trial completion"] = { { isScalable = false, formats = { "ultimatum_wager_type_hash" } } },


### PR DESCRIPTION
﻿Fixes #113

## Summary
- Mark The Black Doubt's sacrifice percentage as unscalable in mod scalability data.
- Add an `applyRange` regression proving value scaling/catalyst scaling leaves the sacrifice percentage unchanged.

## Root Cause
The generated scalability table marked `Sacrifice #% of Life to gain that much Energy Shield when you Cast a Spell` as scalable. That allows generic value scaling to change the sacrifice percentage, even though the in-game modifier is unscalable.

## Fix
Changed only that exact scalability entry to `isScalable = false`. Nearby sacrifice modifiers remain untouched.

## Validation
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '113 Black Doubt sacrifice scalable' --json number,title,headRefName,author,url --jq '.'` returned `[]`.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- `git show --check --stat --oneline HEAD` passed.
- Added an `itemLib.applyRange` regression in `spec/System/TestItemTools_spec.lua` for the exact Black Doubt sacrifice line.

I did not run the containerized Busted suite locally; this machine is currently being kept free of extra containers/windows. The included spec targets the exact scalability behavior.

## Risk / Rollback
Low risk. The patch touches one exact data row and one focused regression. Rollback is the single commit on this branch.
