### PR TITLE
Parse Breach Ring catalyst quality from game copies

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -54,6 +54,37 @@ describe("TestItemParse", function()
 		assert.are.equals(12, item.quality)
 	end)
 
+	it("Breach Ring catalyst quality from game copy is metadata only", function()
+		local item = new("Item", [[
+			Item Class: Rings
+			Rarity: Rare
+			Sol Turn
+			Breach Ring
+			--------
+			Quality (Attack Modifiers): +50% (augmented)
+			--------
+			Requirements:
+			Level: 60
+			--------
+			Item Level: 79
+			--------
+			Maximum Quality is 50% (implicit)
+			--------
+			Adds 28 to 36 Physical Damage to Attacks
+			Adds 3 to 79 Lightning damage to Attacks
+			+136 to Accuracy Rating
+			18% increased Rarity of Items found
+			+26 to Dexterity
+			+29% to Fire Resistance
+		]])
+
+		assert.are.equals(9, item.catalyst)
+		assert.are.equals(50, item.catalystQuality)
+		assert.are.equals(6, #item.explicitModLines)
+		assert.are.equals("Adds 28 to 36 Physical Damage to Attacks", item.explicitModLines[1].line)
+		assert.are.equals(1, item.explicitModLines[1].valueScalar)
+	end)
+
 	--TODO: impl sockets for POB2
 	--it("Sockets", function()
 	--end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -26,8 +26,32 @@ local catalystTags = {
 	{ "speed" },
 	{ "attribute" },
 }
+local catalystQualityLabelMap = {
+	["Life Modifiers"] = 1,
+	["Mana Modifiers"] = 2,
+	["Defense Modifiers"] = 3,
+	["Defence Modifiers"] = 3,
+	["Physical"] = 4,
+	["Physical Modifiers"] = 4,
+	["Fire Modifiers"] = 5,
+	["Cold Modifiers"] = 6,
+	["Lightning Modifiers"] = 7,
+	["Chaos Modifiers"] = 8,
+	["Attack Modifiers"] = 9,
+	["Caster Modifiers"] = 10,
+	["Speed Modifiers"] = 11,
+	["Attribute Modifiers"] = 12,
+}
 
 local minimumReqLevel = { }
+
+local function parseCatalystQualityLine(line)
+	local label, quality = line:match("^Quality %((.-)%): %+?(%d+)%% %(augmented%)$")
+	if not label then
+		return nil, nil
+	end
+	return catalystQualityLabelMap[label], tonumber(quality)
+end
 
 local function getCatalystScalar(catalystId, tags, quality)
 	if not catalystId or type(catalystId) ~= "number" or not catalystTags[catalystId] or not tags or type(tags) ~= "table" or #tags == 0 then
@@ -395,6 +419,14 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		elseif line == "Requirements:" then
 			-- nothing to do
 		else
+			local catalystId, catalystQuality = parseCatalystQualityLine(line)
+			if catalystId then
+				self.catalyst = catalystId
+				self.catalystQuality = catalystQuality
+				self.checkSection = false
+				goto continue
+			end
+
 			if self.checkSection then
 				if gameModeStage == "IMPLICIT" then
 					if foundImplicit then


### PR DESCRIPTION
﻿Fixes #558

## Summary
- Parse copied game catalyst quality lines such as `Quality (Attack Modifiers): +50% (augmented)`.
- Store the matching catalyst type and catalyst quality on the item.
- Preserve imported post-quality modifier values without applying catalyst scaling a second time.

## Root Cause
The item parser only treated simple `Name: value` special lines as metadata. Game-copied catalyst quality uses `Quality (<modifier family>): +N% (augmented)`, so it was not recognized as quality metadata and the item lost the Breach Ring catalyst quality display.

## Fix
Added a small catalyst-quality label map and a parser for the game-copied quality line before generic mod parsing. The parsed line is metadata-only: it sets `item.catalyst` and `item.catalystQuality`, then skips normal modifier parsing so already-augmented copied affix values are not scaled again.

## Validation
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '558 Breach Rings quality catalyst import' --json number,title,headRefName,author,url --jq '.'` returned `[]`.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- `git show --check --stat --oneline HEAD` passed.
- Added a regression in `spec/System/TestItemParse_spec.lua` using the copied Breach Ring text from the issue. It asserts the attack catalyst and 50 quality are parsed while the attack damage line keeps `valueScalar == 1`.

I did not run the containerized Busted suite locally; this machine is currently being kept free of extra containers/windows. The included spec covers the reported import format and the double-scaling guard.

## Risk / Rollback
Low to moderate risk. The parser is narrow and only handles `Quality (...)` catalyst lines with `(augmented)`. Rollback is the single commit on this branch.
