### PR TITLE
Apply Infernal Cry extra fire to empowered attacks

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -229,6 +229,40 @@ describe("TestSkills", function()
 		assert.True(baseCorruptingCryDps == build.calcsTab.mainOutput.CorruptingBloodDPS)
 	end)
 
+	it("Infernal Cry grants extra fire damage to empowered melee attacks", function()
+		build.skillsTab:PasteSocketGroup("Infernal Cry 20/0  1")
+		runCallback("OnFrame")
+
+		local infernalCry
+		for _, activeSkill in ipairs(build.calcsTab.mainEnv.player.activeSkillList) do
+			if activeSkill.activeEffect.grantedEffect.name == "Infernal Cry" then
+				infernalCry = activeSkill
+				break
+			end
+		end
+
+		assert.is_not_nil(infernalCry)
+		assert.are.equals("Warcry", infernalCry.buffList[1].type)
+		local foundExtraFire = false
+		for _, mod in ipairs(infernalCry.buffList[1].modList) do
+			if mod.name == "DamageGainAsFire" then
+				foundExtraFire = true
+				assert.are.equals("BASE", mod.type)
+				assert.True(mod.value > 0)
+				assert.are.equals(ModFlag.Melee, mod.flags)
+				local hasWarcryTag
+				local hasEmpoweredCondition
+				for _, tag in ipairs(mod) do
+					hasWarcryTag = hasWarcryTag or tag.type == "GlobalEffect" and tag.effectType == "Warcry"
+					hasEmpoweredCondition = hasEmpoweredCondition or tag.type == "Condition" and tag.var == "Empowered"
+				end
+				assert.True(hasWarcryTag)
+				assert.True(hasEmpoweredCondition)
+			end
+		end
+		assert.True(foundExtraFire)
+	end)
+
 	it("Test Atziri's Allure - ignore curse limit", function()
 		build.skillsTab:PasteSocketGroup("Elemental Weakness 20/0  1\nAtziri's Allure 1/0 1")
 		build.skillsTab:PasteSocketGroup("Flammability 20/0  1\n")

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -7512,6 +7512,11 @@ skills["InfernalCryPlayer"] = {
 			label = "Infernal Cry",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "infernal_cry",
+			statMap = {
+				["infernal_cry_exerted_attack_all_damage_%_to_gain_as_fire_%"] = {
+					mod("DamageGainAsFire", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Condition", var = "Empowered" }),
+				},
+			},
 			baseFlags = {
 				warcry = true,
 				area = true,

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -481,6 +481,11 @@ statMap = {
 #skill InfernalCryPlayer
 #set InfernalCryPlayer
 #flags warcry area duration
+statMap = {
+	["infernal_cry_exerted_attack_all_damage_%_to_gain_as_fire_%"] = {
+		mod("DamageGainAsFire", "BASE", nil, ModFlag.Melee, 0, { type = "GlobalEffect", effectType = "Warcry" }, { type = "Condition", var = "Empowered" }),
+	},
+}
 #mods
 #skillEnd
 


### PR DESCRIPTION
﻿## Summary

Refs #714

Adds the missing stat mapping for Infernal Cry's empowered attack bonus so its `Gain x% of Damage as Extra Fire Damage` stat is emitted as a Warcry buff for empowered melee attacks.

## Root Cause

Infernal Cry's exported skill data already included `infernal_cry_exerted_attack_all_damage_%_to_gain_as_fire_%`, and the stat description rendered it for users, but the skill had no `statMap` entry. The stat therefore never became a live modifier, so enabling Infernal Cry could show no extra fire damage effect on empowered melee attacks.

This PR intentionally does not claim to finish the broader automatic Full DPS / Warcry Power behavior discussed in #714; it fixes the missing damage modifier path only.

## Fix

- Add a generated-data and export-source `statMap` entry for Infernal Cry.
- Emit `DamageGainAsFire` as a melee-only Warcry global effect.
- Gate the modifier behind the existing `Empowered` condition so non-empowered attacks are not affected.
- Add a system regression that verifies Infernal Cry now produces a Warcry buff modifier with the melee flag and Empowered condition tag.

## Validation

- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '714 Infernal Cry empowered fire' --json number,title,headRefName,author,url --jq '.'` -> `[]`
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- `git show --check --stat --oneline HEAD` -> passed

I did not run Docker/Busted locally in this pass because this machine is currently in active foreground use; the regression is included for CI to run in the repository's normal test container.

## Risk / Rollback

Low risk. The change is data-scoped to Infernal Cry and applies only when the active skill is an empowered melee attack. Rollback is reverting this commit, which removes the stat mapping and the regression test.
