### PR TITLE
Fix Flame Breath attack rate calculation

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -229,6 +229,31 @@ describe("TestSkills", function()
 		assert.True(baseCorruptingCryDps == build.calcsTab.mainOutput.CorruptingBloodDPS)
 	end)
 
+	it("Flame Breath attack speed scales DPS and is not capped by its channel cooldown", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Roaring Talisman
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Flame Breath 20/0  1")
+		runCallback("OnFrame")
+
+		local baseSpeed = build.calcsTab.mainOutput.Speed
+		local baseDPS = build.calcsTab.mainOutput.TotalDPS
+
+		assert.True(baseSpeed > 1)
+		assert.True(baseDPS > 0)
+
+		build.configTab.input.customMods = "100% increased attack speed"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.True(build.calcsTab.mainOutput.Speed > baseSpeed * 1.9)
+		assert.True(build.calcsTab.mainOutput.TotalDPS > baseDPS * 1.9)
+	end)
+
 	it("Test Atziri's Allure - ignore curse limit", function()
 		build.skillsTab:PasteSocketGroup("Elemental Weakness 20/0  1\nAtziri's Allure 1/0 1")
 		build.skillsTab:PasteSocketGroup("Flammability 20/0  1\n")

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -589,6 +589,9 @@ return {
 ["display_this_skill_cooldown_does_not_recover_during_buff"] = {
 	flag("NoCooldownRecoveryInDuration"),
 },
+["channelled_skill_do_not_go_on_cooldown_on_finishing_channel"] = {
+	flag("CooldownDoesNotLimitSkillSpeed"),
+},
 ["totem_skill_cast_speed_+%"] = {
 	mod("Speed", "INC", nil, ModFlag.Cast, KeywordFlag.Totem),
 },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2846,7 +2846,7 @@ function calcs.offence(env, actor, activeSkill)
 					t_insert(breakdown.Speed, s_format("= %.2f ^8(eff. attack rate)", output.Speed))
 				end
 				-- Cooldown:
-				if output.Cooldown and (1 / output.Cooldown) < output.CastRate then
+				if output.Cooldown and (1 / output.Cooldown) < output.CastRate and not skillModList:Flag(skillCfg, "CooldownDoesNotLimitSkillSpeed") then
 					t_insert(breakdown.Speed, s_format("\n"))
 					t_insert(breakdown.Speed, s_format("1 / %.2f ^8(skill cooldown)", output.Cooldown))
 					if output.Repeats > 1 then

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2741,7 +2741,9 @@ function calcs.offence(env, actor, activeSkill)
 			end
 			if globalOutput.Cooldown then
 				output.Cooldown = globalOutput.Cooldown
-				output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
+				if not skillModList:Flag(skillCfg, "CooldownDoesNotLimitSkillSpeed") then
+					output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
+				end
 			end
 			if output.Cooldown and skillFlags.selfCast or skillData.maxHitRatePerEnemy or skillData.hitTimeOverride then
 				skillFlags.notAverage = true


### PR DESCRIPTION
﻿## Summary

Fixes #1673
Fixes #1706

Makes Flame Breath use its channel hit rate for speed/DPS instead of being capped to one use per 10-second cooldown.

## Root Cause

Flame Breath already has the correct attack-speed data: its 700% attack speed multiplier produces the intended 8x base weapon rate. The calculation then applies the generic cooldown cap:

```lua
output.Speed = m_min(output.Speed, 1 / output.Cooldown * output.Repeats)
```

Because Flame Breath has a 10-second cooldown, that clamps the final skill speed to `0.1/s`, so attack speed and Rapid Attacks affect the intermediate value but not the displayed DPS.

The skill data also already contains `channelled_skill_do_not_go_on_cooldown_on_finishing_channel`, but that stat was not mapped to any internal behavior.

## Fix

- Map `channelled_skill_do_not_go_on_cooldown_on_finishing_channel` to a skill flag.
- Preserve cooldown display/output, but skip the cooldown speed cap when that flag is present.
- Add a regression test that equips a Roaring Talisman, calculates Flame Breath speed/DPS, then verifies `100% increased attack speed` scales both speed and DPS instead of leaving them clamped at the cooldown rate.

## Validation

- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S 'Flame Breath attack speed cooldown' --json number,title,headRefName,author,url --jq '.'` -> `[]`
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- `git show --check --stat --oneline HEAD` -> passed
- Checked local test executables: `lua`, `luajit`, and `busted` are not installed on this machine, so the included regression is left for CI's Docker/Busted path.

## Risk / Rollback

Low-to-moderate risk. The calculation change is generic, but only skills that emit the new `CooldownDoesNotLimitSkillSpeed` flag bypass the cooldown cap. At present this is driven by the explicit channel stat used by Flame Breath. Rollback is reverting this commit, which restores the previous cooldown-clamped behavior.
