### PR TITLE
Keep corrupted gem requirements at base level

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -72,6 +72,31 @@ describe("TestSkills", function()
 		assert.True(math.abs(finalCost - 8.67) < 0.1) -- floor(9 * 1.5) / 1.5
 	end)
 
+	it("Corrupted gem levels do not raise gem requirements", function()
+		build.skillsTab:PasteSocketGroup("Lightning Arrow 20/0  1")
+		local socketGroup = build.skillsTab.socketGroupList[1]
+		local gemInstance = socketGroup.gemList[1]
+		gemInstance.requirementGemLevel = 19
+
+		build.skillsTab:ProcessSocketGroup(socketGroup)
+
+		local grantedEffect = gemInstance.gemData.grantedEffect
+		local level19Requirement = grantedEffect.levels[19].levelRequirement
+		local level20Requirement = grantedEffect.levels[20].levelRequirement
+
+		assert.are.equals(20, gemInstance.level)
+		assert.are.equals(level19Requirement, gemInstance.reqLevel)
+		assert.are_not.equals(level20Requirement, gemInstance.reqLevel)
+		assert.are.equals(calcLib.getGemStatRequirement(level19Requirement, gemInstance.gemData.reqDex, grantedEffect.support), gemInstance.reqDex)
+
+		gemInstance.level = 19
+		gemInstance.requirementGemLevel = 20
+		build.skillsTab:ProcessSocketGroup(socketGroup)
+
+		assert.are.equals(19, gemInstance.level)
+		assert.are.equals(level20Requirement, gemInstance.reqLevel)
+	end)
+
 	it("Test mana cost efficiency with support gems", function()
 		-- Test interaction between cost efficiency and cost multipliers
 		build.skillsTab:PasteSocketGroup("Contagion 6/0  1\nMagnified Area I 1/0  1")

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -69,6 +69,7 @@ function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, useFullDPS)
 	-- Create gemInstance to represent the hovered gem
 	local gemInstance = gemList[self.index]
 	gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
+	gemInstance.requirementGemLevel = nil
 	gemInstance.gemData = gemData
 	gemInstance.displayEffect = nil
 	-- Calculate the impact of using this gem
@@ -77,6 +78,7 @@ function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, useFullDPS)
 	if oldGem then
 		gemInstance.gemData = oldGem.gemData
 		gemInstance.level = oldGem.level
+		gemInstance.requirementGemLevel = oldGem.requirementGemLevel
 		gemInstance.displayEffect = oldGem.displayEffect
 	else
 		gemList[self.index] = nil
@@ -694,7 +696,7 @@ function GemSelectClass:AddGrantedEffectInfo(gemInstance, grantedEffect, addReq)
 	end
 	self.tooltip:AddSeparator(10)
 	if addReq then
-		local reqLevel = grantedEffect.levels[gemInstance.level] and grantedEffect.levels[gemInstance.level].levelRequirement or 1
+		local reqLevel = calcLib.getGemLevelRequirement(gemInstance, grantedEffect)
 		local reqStr = calcLib.getGemStatRequirement(reqLevel, gemInstance.gemData.reqStr, grantedEffect.support)
 		local reqDex = calcLib.getGemStatRequirement(reqLevel, gemInstance.gemData.reqDex, grantedEffect.support)
 		local reqInt = calcLib.getGemStatRequirement(reqLevel, gemInstance.gemData.reqInt, grantedEffect.support)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -900,19 +900,27 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 			end
 
 			gemInstance.nameSpec = self.build.data.gems[gemId].name
-			for _, property in pairs(skillData.properties) do
+			local displayLevel
+			local gemLevel
+			local corruptionLevel = 0
+			for _, property in ipairs(skillData.properties) do
 				if property.name == "Level" then
-					if skillData.properties[_ + 1] and skillData.properties[_ + 1].values[1][1]:match("(%d+) Level[s]? from Gem") then
-						gemInstance.level = tonumber(skillData.properties[_ + 1].values[1][1]:match("(%d+) Level[s]? from Gem"))
-					else
-						gemInstance.level = tonumber(property.values[1][1]:match("%d+"))
-					end
-					if skillData.properties[_ + 2] and skillData.properties[_ + 2].values[1][1]:match("(%d+) Level[s]? from Corruption") then
-						gemInstance.level = gemInstance.level + tonumber(skillData.properties[_ + 2].values[1][1]:match("(%d+) Level[s]? from Corruption"))
-					end
+					displayLevel = tonumber(property.values[1][1]:match("%d+"))
 				elseif escapeGGGString(property.name) == "Quality" then
 					gemInstance.quality = tonumber(property.values[1][1]:match("%d+"))
+				elseif property.values and property.values[1] and property.values[1][1] then
+					gemLevel = tonumber(property.values[1][1]:match("(%d+) Level[s]? from Gem")) or gemLevel
+					corruptionLevel = tonumber(property.values[1][1]:match("([%+%-]?%d+) Level[s]? from Corruption")) or corruptionLevel
 				end
+			end
+			if gemLevel then
+				gemInstance.level = gemLevel + corruptionLevel
+			else
+				gemInstance.level = displayLevel
+				gemLevel = displayLevel and displayLevel - corruptionLevel
+			end
+			if corruptionLevel ~= 0 and gemLevel then
+				gemInstance.requirementGemLevel = gemLevel
 			end
 
 			return gemInstance

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -307,6 +307,7 @@ function SkillsTabClass:LoadSkill(node, skillSetId)
 			end
 		end
 		gemInstance.level = tonumber(child.attrib.level)
+		gemInstance.requirementGemLevel = tonumber(child.attrib.requirementGemLevel)
 		gemInstance.quality = tonumber(child.attrib.quality)
 		gemInstance.enabled = not child.attrib.enabled and true or child.attrib.enabled == "true"
 		gemInstance.enableGlobal1 = not child.attrib.enableGlobal1 or child.attrib.enableGlobal1 == "true"
@@ -435,6 +436,7 @@ function SkillsTabClass:Save(xml)
 					gemId = gemInstance.gemData and gemInstance.gemData.gameId,
 					variantId = gemInstance.gemData and gemInstance.gemData.variantId,
 					level = tostring(gemInstance.level),
+					requirementGemLevel = gemInstance.requirementGemLevel and tostring(gemInstance.requirementGemLevel),
 					quality = tostring(gemInstance.quality),
 					enabled = tostring(gemInstance.enabled),
 					enableGlobal1 = tostring(gemInstance.enableGlobal1),
@@ -680,6 +682,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			return
 		end
 		gemInstance.gemId = gemId
+		gemInstance.requirementGemLevel = nil
 		gemInstance.skillId = nil
 		self:ProcessSocketGroup(self.displayGroup)
 		-- New gems need to be constrained by ProcessGemLevel
@@ -708,6 +711,7 @@ function SkillsTabClass:CreateGemSlot(index)
 			slot.count:SetText(gemInstance.count)
 		end
 		gemInstance.level = tonumber(buf) or self.displayGroup.gemList[index].naturalMaxLevel or self:ProcessGemLevel(gemInstance.gemData) or 20
+		gemInstance.requirementGemLevel = nil
 		self:ProcessSocketGroup(self.displayGroup)
 		self:AddUndoState()
 		self.build.buildFlag = true
@@ -1087,14 +1091,16 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 			if prevDefaultLevel and gemInstance.gemData and gemInstance.gemData.naturalMaxLevel ~= prevDefaultLevel then
 				gemInstance.level = gemInstance.gemData.naturalMaxLevel
 				gemInstance.naturalMaxLevel = gemInstance.level
+				gemInstance.requirementGemLevel = nil
 			elseif gemInstance.new then
 				gemInstance.level = gemInstance.gemData.naturalMaxLevel
 				gemInstance.naturalMaxLevel = gemInstance.level
+				gemInstance.requirementGemLevel = nil
 				gemInstance.new = nil
 			end
 			calcLib.validateGemLevel(gemInstance)
 			if gemInstance.gemData then
-				gemInstance.reqLevel = grantedEffect.levels[gemInstance.level].levelRequirement
+				gemInstance.reqLevel = calcLib.getGemLevelRequirement(gemInstance, grantedEffect)
 				gemInstance.reqStr = calcLib.getGemStatRequirement(gemInstance.reqLevel, gemInstance.gemData.reqStr, grantedEffect.support)
 				gemInstance.reqDex = calcLib.getGemStatRequirement(gemInstance.reqLevel, gemInstance.gemData.reqDex, grantedEffect.support)
 				gemInstance.reqInt = calcLib.getGemStatRequirement(gemInstance.reqLevel, gemInstance.gemData.reqInt, grantedEffect.support)

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -132,6 +132,17 @@ function calcLib.getGemStatRequirement(level, multi, isSupport)
 	return req < 8 and 0 or req
 end
 
+function calcLib.getGemLevelRequirement(gemInstance, grantedEffect)
+	local requirementGemLevel = gemInstance.requirementGemLevel or gemInstance.level
+	if grantedEffect.levels[requirementGemLevel] then
+		return grantedEffect.levels[requirementGemLevel].levelRequirement
+	elseif grantedEffect.levels[gemInstance.level] then
+		return grantedEffect.levels[gemInstance.level].levelRequirement
+	else
+		return 1
+	end
+end
+
 -- Build table of stats for the given skill instance statset
 function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet)
 	local stats = { }


### PR DESCRIPTION
﻿## Summary

Fixes #1738.

Keeps imported level-corrupted gems using their effective corrupted level for skill calculations, while using the uncorrupted gem level for level/attribute requirements.

## Root Cause

Character import folded `Levels from Corruption` directly into `gemInstance.level`. `SkillsTabClass:ProcessSocketGroup()` then used that same effective level to compute `reqLevel`, `reqStr`, `reqDex`, and `reqInt`, so a +1/-1 corrupted gem incorrectly changed its requirements.

## Fix

- Import now preserves the gem's natural requirement level separately as `requirementGemLevel` when a level corruption is present.
- Requirement calculation uses `requirementGemLevel` when present, falling back to the effective gem level for normal gems.
- The separate requirement level is saved/loaded with the build so imported characters stay correct after reopening.
- Manual gem level/gem selection/default-level changes clear the import-only override to avoid stale requirement data.
- Gem tooltips use the same requirement-level helper as the skills tab.
- Added a regression covering both +level and -level corruption semantics.

## Validation

Local, non-GUI validation only:

```text
gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S "1738 corrupted skill gem requirements import" -> []
git diff --check -> passed
git diff --cached --check -> passed
git show --check --stat --oneline HEAD -> passed
where.exe lua -> not found
where.exe luajit -> not found
where.exe busted -> not found
```

I did not run Busted locally because this Windows checkout does not have Lua/LuaJIT/Busted on PATH. I also avoided Docker/GUI validation so no visible command windows or heavy processes were launched.

## Risk / Rollback

Moderate-low risk. Normal gems continue to use their effective gem level for requirements. Only imported/saved gems with `requirementGemLevel` take the alternate path, and manual edits clear it. Rollback is this commit.
