### PR TITLE
Recognize Ngamahu's Chosen Rage source

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -193,60 +193,6 @@ describe("TestSkills", function()
 		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
 	end)
 
-	it("Test configured Rage still requires a recognised Rage source", function()
-		build.itemsTab:CreateDisplayItemFromRaw([[
-			New Item
-			Fanatic Greathammer
-			Quality: 0
-		]])
-		build.itemsTab:AddDisplayItem()
-		runCallback("OnFrame")
-
-		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
-		runCallback("OnFrame")
-
-		local baseLeapSlamHit = build.calcsTab.mainOutput.AverageDamage
-
-		build.configTab.input.multiplierRage = 30
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
-
-		assert.are.equals(nil, build.calcsTab.mainOutput.Rage)
-		assert.are.equals(baseLeapSlamHit, build.calcsTab.mainOutput.AverageDamage)
-	end)
-
-	it("Test Ngamahu's Chosen rage charm modifier is recognised", function()
-		build.itemsTab:CreateDisplayItemFromRaw([[
-			New Item
-			Fanatic Greathammer
-			Quality: 0
-		]])
-		build.itemsTab:AddDisplayItem()
-		runCallback("OnFrame")
-
-		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
-		runCallback("OnFrame")
-
-		local baseLeapSlamHit = build.calcsTab.mainOutput.AverageDamage
-
-		build.configTab.input.customMods = "Grants up to your maximum Rage on use"
-		build.configTab.input.multiplierRage = 30
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
-
-		assert.are.equals(30, build.calcsTab.mainOutput.Rage)
-		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
-
-		local modList, extra = modLib.parseMod("Grants up to your maximum Rage on use")
-		local grantsRage = false
-		for _, mod in ipairs(modList) do
-			grantsRage = grantsRage or mod.name == "Condition:CanGainRage"
-		end
-
-		assert.are.equals(nil, extra)
-		assert.True(grantsRage)
-	end)
-
 	it("Test stacking persistent buff supports of same category", function()
 		build.skillsTab:PasteSocketGroup("Arctic Armour 20/0  1\nClarity I 1/0  1")
 		build.skillsTab:PasteSocketGroup("Time of Need 20/0  1\nClarity II 1/0  1")

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -193,6 +193,60 @@ describe("TestSkills", function()
 		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
 	end)
 
+	it("Test configured Rage still requires a recognised Rage source", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Fanatic Greathammer
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
+		runCallback("OnFrame")
+
+		local baseLeapSlamHit = build.calcsTab.mainOutput.AverageDamage
+
+		build.configTab.input.multiplierRage = 30
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(nil, build.calcsTab.mainOutput.Rage)
+		assert.are.equals(baseLeapSlamHit, build.calcsTab.mainOutput.AverageDamage)
+	end)
+
+	it("Test Ngamahu's Chosen rage charm modifier is recognised", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Fanatic Greathammer
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
+		runCallback("OnFrame")
+
+		local baseLeapSlamHit = build.calcsTab.mainOutput.AverageDamage
+
+		build.configTab.input.customMods = "Grants up to your maximum Rage on use"
+		build.configTab.input.multiplierRage = 30
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(30, build.calcsTab.mainOutput.Rage)
+		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
+
+		local modList, extra = modLib.parseMod("Grants up to your maximum Rage on use")
+		local grantsRage = false
+		for _, mod in ipairs(modList) do
+			grantsRage = grantsRage or mod.name == "Condition:CanGainRage"
+		end
+
+		assert.are.equals(nil, extra)
+		assert.True(grantsRage)
+	end)
+
 	it("Test stacking persistent buff supports of same category", function()
 		build.skillsTab:PasteSocketGroup("Arctic Armour 20/0  1\nClarity I 1/0  1")
 		build.skillsTab:PasteSocketGroup("Time of Need 20/0  1\nClarity II 1/0  1")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5689,6 +5689,7 @@ local specialModList = {
 		flag("Condition:CanGainRage"),
 	} end,
 	["when you lose temporal chains you gain maximum rage"] = { flag("Condition:CanGainRage") },
+	["grants up to your maximum rage on use"] = { flag("Condition:CanGainRage") },
 	["with a murderous eye jewel socketed, melee attacks grant (%d+) rage on hit, no more than once every second"] = { flag("Condition:CanGainRage", { type = "Condition", var = "HaveMurderousEyeJewelIn{SlotName}" }) },
 	["gain %d+ rage after spending a total of %d+ mana"] = { flag("Condition:CanGainRage") },
 	["rage grants cast speed instead of attack speed"] = { flag("Condition:RageCastSpeed") },


### PR DESCRIPTION
﻿## Summary
- Recognise `Grants up to your maximum Rage on use` as a Rage-enabling modifier.
- Add a regression proving configured Rage still requires a recognised Rage source.
- Add a regression proving the Ngamahu's Chosen wording enables configured Rage and increases attack damage through the existing Rage calculation path.

Refs #387

## Root Cause
The Rage calculation intentionally requires a recognised Rage source before configured Rage stacks are applied. That invariant is important because otherwise a stale or manually-entered Rage value could silently grant impossible attack damage.

The later #387 reproduction uses Ngamahu's Chosen. Its unique modifier, `Grants up to your maximum Rage on use`, was not recognised by the modifier parser, so the build did not get `Condition:CanGainRage`; configured Rage then stayed inactive even though the item is a valid Rage source.

## Fix
- Add a parser entry for `Grants up to your maximum Rage on use` that emits `Condition:CanGainRage`.
- Leave the core Rage gate unchanged: configured Rage still applies only when the build has a recognised Rage source or Rage regeneration.
- Cover both sides in tests: no source means no Rage output/damage increase; the Ngamahu wording means configured Rage is applied.

## Validation
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '387 rage configured CanGainRage Ngamahu' --json number,title,headRefName,author,url --jq '.'` -> `[]` before PR creation
- `git diff --check` -> passed
- `git diff --cached --check` -> passed before commit/amend
- `git show --check --stat --oneline HEAD` -> passed
- `where/Get-Command lua` -> not found on PATH
- `where/Get-Command luajit` -> not found on PATH
- `where/Get-Command busted` -> not found on PATH
- `docker --version` / `docker-compose --version` -> not found on PATH

Targeted Busted coverage was added in `spec/System/TestSkills_spec.lua`, but I could not execute it locally because this checkout does not have Lua/LuaJIT/Busted or Docker available on PATH.

## Risk / Rollback
Risk is narrow: one exact Rage-source parser line plus two tests. The core Rage calculation and config semantics are unchanged.

Rollback is the single commit on this branch.
