### PR TITLE
Use totem actor level for totem life

### DIFF
--- a/spec/System/TestTotems_spec.lua
+++ b/spec/System/TestTotems_spec.lua
@@ -1,0 +1,25 @@
+describe("TestTotems", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	teardown(function()
+		-- newBuild() takes care of resetting everything in setup()
+	end)
+
+	it("uses exported actor level for Shockwave Totem life", function()
+		build.skillsTab:PasteSocketGroup("Shockwave Totem 20/0  1")
+		runCallback("OnFrame")
+
+		local checkedTotems = 0
+		for _, activeSkill in ipairs(build.calcsTab.calcsEnv.player.activeSkillList) do
+			local totemBase = activeSkill.skillData.totemBase
+			if totemBase and totemBase.grantedEffect and totemBase.grantedEffect.name == "Shockwave Totem" then
+				checkedTotems = checkedTotems + 1
+				assert.are.equals(98, activeSkill.skillData.totemLevel)
+			end
+		end
+		assert.True(checkedTotems > 0)
+		assert.are.equals(data.monsterAllyLifeTable[98], build.calcsTab.mainOutput.TotemLife)
+	end)
+end)

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -289,6 +289,26 @@ local function getTotemBaseStats(activeSkill)
 	return totemBase
 end
 
+local function getTotemLevel(totemBase)
+	if not totemBase.skillLevel then
+		return 1
+	end
+	local grantedEffectLevel = totemBase.grantedEffect and totemBase.grantedEffect.levels
+		and totemBase.grantedEffect.levels[totemBase.skillLevel]
+	local actorLevel = grantedEffectLevel and grantedEffectLevel.actorLevel
+	if not actorLevel and totemBase.grantedEffect and totemBase.grantedEffect.statSets then
+		for _, statSet in ipairs(totemBase.grantedEffect.statSets) do
+			local statSetLevel = statSet.levels and statSet.levels[totemBase.skillLevel]
+			if statSetLevel and statSetLevel.actorLevel then
+				actorLevel = statSetLevel.actorLevel
+				break
+			end
+		end
+	end
+	local totemLevel = actorLevel and round(actorLevel) or data.minionLevelTable[totemBase.skillLevel] or 1
+	return m_min(m_max(totemLevel, 1), #data.monsterAllyLifeTable)
+end
+
 --- Applies additional modifiers to skills with the "Empowered" flag.
 --- Checks for "ExtraEmpoweredMod" mods and applies them
 --- if they match the conditions set by the empowering effect.
@@ -539,7 +559,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		if totemBase.grantedEffect and totemBase.gemData then
 			activeSkill.skillData.totemBase = totemBase
 		end
-		activeSkill.skillData.totemLevel = data.minionLevelTable[totemBase.skillLevel] or 1
+		activeSkill.skillData.totemLevel = getTotemLevel(totemBase)
 
 		-- Get skill totem ID for totem skills
 		-- This is used to calculate totem life


### PR DESCRIPTION
﻿## Summary

Refs #261

Use the totem skill's exported actor level when calculating totem level/life, with the previous minion-gem-level table kept as the fallback for totem sources that do not export an actor level.

## Root Cause

Totem life is calculated from `monsterAllyLifeTable[skillData.totemLevel]`, but `skillData.totemLevel` was always derived from `data.minionLevelTable[gemLevel]`.

For Shockwave Totem, the exported skill stat set gives level 20 an actor level of about 97.7. The minion level table maps gem level 20 to level 40, so the totem life calculation used level 40 monster life instead of the skill's own exported actor level.

## Fix

- Add a small `getTotemLevel` helper beside the existing totem base-skill resolution.
- Prefer `actorLevel` from the totem granted effect/stat set when present.
- Round and clamp the result to the available monster ally life table.
- Preserve the old `data.minionLevelTable` behavior as the fallback for totem sources without exported actor levels.
- Add a regression spec for level 20 Shockwave Totem, asserting its totem level resolves to 98 and its displayed totem life uses `monsterAllyLifeTable[98]`.

## Validation

- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S 'Shockwave Totem actor level totem life' --json number,title,headRefName,author,url --jq '.'` -> `[]`
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state open -S '261 Shockwave Totem' --json number,title,headRefName,author,url --jq '.'` -> `[]`
- `git diff --check` -> passed (Git emitted only local CRLF conversion warnings)
- `git diff --cached --check` -> passed (Git emitted only local CRLF conversion warnings)
- `git show --check --oneline --no-renames HEAD` -> passed
- `Get-Command lua`, `luajit`, `busted`, `docker`, `docker-compose` -> not found on this Windows PATH, so I could not execute the Busted suite locally here.

## Risk / Rollback

Risk is limited to totem level/life calculations. Totems that do not export actor levels keep the previous minion-level fallback. Rollback is the single commit on this branch.
