### PR TITLE
Scale Force of Will by missing mana

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -221,6 +221,25 @@ describe("TetsItemMods", function()
 		runCallback("OnFrame")
 	end)
 
+	it("Arcane Surge effect per ten percent missing mana", function()
+		build.configTab.input.customMods = [[
+			20% increased Effect of Arcane Surge on you per ten percent missing Mana
+		]]
+		build.configTab.input.multiplierCurrentManaPercentage = 100
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(0, build.calcsTab.mainEnv.modDB:GetMultiplier("MissingManaPercentage"))
+		assert.equals(0, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "ArcaneSurgeEffect"))
+
+		build.configTab.input.multiplierCurrentManaPercentage = 50
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(50, build.calcsTab.mainEnv.modDB:GetMultiplier("MissingManaPercentage"))
+		assert.equals(100, build.calcsTab.mainEnv.modDB:Sum("INC", nil, "ArcaneSurgeEffect"))
+	end)
+
 	it("Jarngreipr - strength satisfies melee weapons and skills", function()
 		build.configTab.input.customMods = "+1000 Strength"
 		build.configTab:BuildModList()

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1833,7 +1833,7 @@ c["20% increased Deflection Rating"]={{[1]={flags=0,keywordFlags=0,name="Deflect
 c["20% increased Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=20}},nil}
 c["20% increased Duration of Damaging Ailments on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=20},[2]={flags=0,keywordFlags=0,name="EnemyBleedDuration",type="INC",value=20},[3]={flags=0,keywordFlags=0,name="EnemyPoisonDuration",type="INC",value=20}},nil}
 c["20% increased Duration of Elemental Ailments on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyElementalAilmentDuration",type="INC",value=20}},nil}
-c["20% increased Effect of Arcane Surge on you per ten percent missing Mana"]={{[1]={flags=0,keywordFlags=0,name="ArcaneSurgeEffect",type="INC",value=20}},"  per ten percent missing Mana "}
+c["20% increased Effect of Arcane Surge on you per ten percent missing Mana"]={{[1]={[1]={div=10,type="Multiplier",var="MissingManaPercentage"},flags=0,keywordFlags=0,name="ArcaneSurgeEffect",type="INC",value=20},[2]={flags=0,keywordFlags=0,name="SkillData",type="LIST",value={key="currentManaPercentage",value=true}}},nil}
 c["20% increased Effect of your Mark Skills"]={{[1]={[1]={skillType=99,type="SkillType"},flags=0,keywordFlags=0,name="LocalEffect",type="INC",value=20}},nil}
 c["20% increased Elemental Ailment Threshold"]={{[1]={flags=0,keywordFlags=0,name="AilmentThreshold",type="INC",value=20}},nil}
 c["20% increased Elemental Damage"]={{[1]={flags=0,keywordFlags=0,name="ElementalDamage",type="INC",value=20}},nil}

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -115,7 +115,9 @@ local configSettings = {
 		modList:NewMod("SkillData", "LIST", { key = "corpseLife", value = val }, "Config")
 	end },
 	{ var = "multiplierCurrentManaPercentage", type = "count", label = "Current ^x7070FFMana^7 %:", ifSkillData = "currentManaPercentage", defaultState = 100, apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:CurrentManaPercentage", "BASE", m_max(m_min(val,100), 0), "Config")
+		local currentManaPercentage = m_max(m_min(val, 100), 0)
+		modList:NewMod("Multiplier:CurrentManaPercentage", "BASE", currentManaPercentage, "Config")
+		modList:NewMod("Multiplier:MissingManaPercentage", "BASE", 100 - currentManaPercentage, "Config")
 	end },
 	{ var = "conditionStationary", type = "count", label = "Time spent stationary", ifCond = "Stationary",
 		tooltip = "Applies mods that use `while stationary` and `per / every second while stationary`",

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4151,6 +4151,10 @@ local specialModList = {
 	["(%d+)%% increased effect of arcane surge on you per hypnotic eye jewel affecting you, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("ArcaneSurgeEffect", "INC", num, { type = "Multiplier", var = "HypnoticEyeJewel", globalLimit = tonumber(limit), globalLimitKey = "KurgalGaze" })
 	} end,
+	["(%d+)%% increased effect of arcane surge on you per ten percent missing mana"] = function(num) return {
+		mod("ArcaneSurgeEffect", "INC", num, { type = "Multiplier", var = "MissingManaPercentage", div = 10 }),
+		mod("SkillData", "LIST", { key = "currentManaPercentage", value = true }),
+	} end,
 	["(%d+)%% increased main hand critical hit chance per murderous eye jewel affecting you, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		mod("CritChance", "INC", num, { type = "Multiplier", var = "MurderousEyeJewel", globalLimit = tonumber(limit), globalLimitKey = "TecrodGazeMainHand" }, { type = "Condition", var = "MainHandAttack" })
 	} end,


### PR DESCRIPTION
﻿Refs #258

## Summary
- Scale Force of Will's Arcane Surge effect by missing mana instead of treating the full line as a flat 20% increased effect.
- Add a missing-mana multiplier derived from the existing Current Mana % config value.
- Add a regression spec for the exact passive text.

## Root Cause
The modifier parser recognized `20% increased Effect of Arcane Surge on you` and left `per ten percent missing Mana` as unparsed trailing text in `ModCache.lua`. That made Force of Will contribute a flat 20% Arcane Surge effect regardless of current mana.

## Fix
- Added a special parser rule for `increased effect of arcane surge on you per ten percent missing mana`.
- Added `Multiplier:MissingManaPercentage` beside the existing clamped `Multiplier:CurrentManaPercentage` config value.
- Tagged the parsed mod with `div = 10`, so it uses full ten-percent chunks through the existing multiplier semantics.
- Updated the generated cache entry for this exact modifier and added a fixture-style regression in `TestItemMods_spec.lua`.

## Validation
- `gh auth status` -> authenticated as `unrealdreamz`.
- Open PR search for this bug family -> no duplicate open PR found.
- `git diff --check` -> passed; Git only reported existing Windows LF-to-CRLF checkout warnings.
- `git diff --cached --check` -> passed; Git only reported existing Windows LF-to-CRLF checkout warnings.
- `git show --check --stat --oneline --no-renames HEAD` -> passed.
- Targeted Busted spec was added but could not be executed locally because this Windows environment has no `lua`, `luajit`, `busted`, `docker`, or `docker-compose` on PATH.

## Risk / Rollback
Risk is limited to modifiers that explicitly use the new missing-mana multiplier and to the existing Current Mana % config path. Rollback is the single commit if CI finds a parser/cache mismatch.
