### PR TITLE
Copy cached Time-Lost radius mods per node

### DIFF
--- a/spec/System/TestRadiusJewels_spec.lua
+++ b/spec/System/TestRadiusJewels_spec.lua
@@ -1,0 +1,72 @@
+describe("TestRadiusJewels", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	it("copies cached Time-Lost radius mods before adding weapon set conditions", function()
+		GlobalCache.cachedData.MAIN.radiusJewelData = nil
+
+		local function addTimeLostMana(node, modList)
+			if node.type == "Normal" then
+				modList:NewMod("Mana", "INC", 1, "Tree:500")
+			end
+		end
+
+		local env = {
+			mode = "MAIN",
+			radiusJewelList = {
+				{
+					type = "Other",
+					nodeId = 500,
+					jewelHash = "time-lost-mana",
+					item = { baseName = "Time-Lost Diamond" },
+					nodes = {
+						[100] = { type = "Normal" },
+						[101] = { type = "Normal" },
+					},
+					func = addTimeLostMana,
+					data = { },
+				},
+			},
+			allocNodes = {
+				[100] = true,
+				[101] = true,
+			},
+			build = {
+				spec = {
+					nodes = {
+						[500] = { allocMode = 0 },
+					},
+				},
+				itemsTab = {
+					activeItemSet = {
+						useSecondWeaponSet = false,
+					},
+				},
+			},
+			explodeSources = { },
+		}
+		local weaponSetNode = {
+			id = 100,
+			type = "Normal",
+			allocMode = 2,
+			modList = new("ModList"),
+		}
+		local globalNode = {
+			id = 101,
+			type = "Normal",
+			allocMode = 0,
+			modList = new("ModList"),
+		}
+
+		local weaponSetModList = build.calcsTab.calcs.buildModListForNode(env, weaponSetNode, 0)
+		assert.is_not_nil(weaponSetModList[1][1])
+		assert.equals("WeaponSet2", weaponSetModList[1][1].var)
+
+		local globalModList = build.calcsTab.calcs.buildModListForNode(env, globalNode, 0)
+		assert.is_nil(globalModList[1][1])
+
+		assert.is_not_nil(weaponSetModList[1][1])
+		assert.equals("WeaponSet2", weaponSetModList[1][1].var)
+	end)
+end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -117,6 +117,12 @@ local function refreshJewelStatCache(env)
 	end
 end
 
+local function addCopiedModList(modList, cachedList)
+	for i = 1, #cachedList do
+		modList:AddMod(copyTable(cachedList[i], true))
+	end
+end
+
 function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeystoneMods)
 	local localSmallIncEffect = 0
 	local localNotableIncEffect = 0
@@ -144,11 +150,12 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeyst
 				local cache = GlobalCache.cachedData[env.mode].radiusJewelData[rad.nodeId]
 				if not cache or (cache.hash ~= rad.jewelHash) then
 					refreshJewelStatCache(env)
+					cache = GlobalCache.cachedData[env.mode].radiusJewelData[rad.nodeId]
 				end
 				if node.type == "Normal" and cache and #cache.smallModList > 0 then
-					modList:AddList(cache.smallModList)
+					addCopiedModList(modList, cache.smallModList)
 				elseif node.type == "Notable" and cache and #cache.notableModList > 0 then
-					modList:AddList(cache.notableModList)
+					addCopiedModList(modList, cache.notableModList)
 				end
 				break
 			end


### PR DESCRIPTION
﻿Fixes #717

## Summary
- Copy cached Time-Lost / Timeless radius jewel mods before adding them to each passive node.
- Refresh the local cache reference immediately after rebuilding stale radius-jewel cache data.
- Add a focused regression spec for weapon-set condition leakage between cached radius-jewel mods.

## Root Cause
The Time-Lost / Timeless radius-jewel fast path caches the generated small/notable mod lists once, then reuses those same mod table references for every matching passive node.

`buildModListForNode` later mutates each node-local mod to add or remove `Condition:WeaponSet1/2`. Because `ModList:AddList` inserts references, not copies, a weapon-set passive and a normal passive could mutate the same cached mod object. That let weapon-set conditions leak between passives, matching the Against the Darkness mana overcount reported in #717.

## Fix
- Added a small helper that deep-copies cached radius-jewel mods into the node-local mod list.
- Replaced the cached Time-Lost / Timeless `AddList` calls with copied insertion for both small and notable passive cached mods.
- Rebound the local `cache` variable after refreshing stale radius-jewel cache data so the current node uses the rebuilt cache immediately.
- Added `TestRadiusJewels_spec.lua` to prove a weapon-set passive keeps its `WeaponSet2` condition after a normal passive using the same cached Time-Lost mod is processed.

## Validation
- `gh auth status` -> authenticated as `unrealdreamz`.
- Open PR search for `#717 Against the Darkness Time-Lost Diamond` -> no duplicate open PR found.
- `git diff --check` -> passed; Git only reported existing Windows LF-to-CRLF checkout warnings.
- `git diff --cached --check` -> passed; Git only reported existing Windows LF-to-CRLF checkout warnings.
- `git show --check --stat --oneline --no-renames HEAD` -> passed.
- Targeted Busted spec was added but could not be executed locally because this Windows environment has no `lua`, `luajit`, `busted`, `docker`, or `docker-compose` on PATH.

## Risk / Rollback
Risk is limited to Time-Lost / Timeless cached radius-jewel mods. The change preserves the existing cache and parser behavior, but prevents later node-specific mutation from writing back into cached mod objects. Rollback is the single commit if CI exposes an unexpected fixture dependency on shared references.
