### PR TITLE
Surface OAuth token exchange errors

### DIFF
--- a/spec/System/TestPoEAPIAuth_spec.lua
+++ b/spec/System/TestPoEAPIAuth_spec.lua
@@ -1,0 +1,76 @@
+describe("PoEAPI auth", function()
+	local originalLaunchSubScript
+	local originalDownloadPage
+	local originalSubScripts
+
+	before_each(function()
+		originalLaunchSubScript = LaunchSubScript
+		originalDownloadPage = launch.DownloadPage
+		originalSubScripts = launch.subScripts
+		launch.subScripts = { }
+	end)
+
+	after_each(function()
+		LaunchSubScript = originalLaunchSubScript
+		launch.DownloadPage = originalDownloadPage
+		launch.subScripts = originalSubScripts
+	end)
+
+	it("passes token exchange errors to the auth callback", function()
+		local authState
+		LaunchSubScript = function(_, _, _, authUrl)
+			authState = authUrl:match("state=([^&]+)")
+			return 123
+		end
+		launch.DownloadPage = function(_, url, callback)
+			assert.are.equals("https://www.pathofexile.com/oauth/token", url)
+			callback(nil, "SSL connect error")
+		end
+
+		local api = new("PoEAPI")
+		local callbackArgs
+		api:FetchAuthToken(function(response, errMsg, updateSettings)
+			callbackArgs = {
+				response = response,
+				errMsg = errMsg,
+				updateSettings = updateSettings,
+			}
+		end)
+
+		assert.is_not_nil(authState)
+		assert.is_not_nil(launch.subScripts[123])
+		launch.subScripts[123].callback("auth-code", nil, authState, 12345)
+
+		assert.is_nil(callbackArgs.response)
+		assert.are.equals("SSL connect error", callbackArgs.errMsg)
+		assert.True(callbackArgs.updateSettings)
+		assert.is_nil(api.authToken)
+	end)
+
+	it("reports OAuth state mismatches without exchanging a token", function()
+		LaunchSubScript = function()
+			return 123
+		end
+		launch.DownloadPage = function()
+			error("token exchange should not run for mismatched OAuth state")
+		end
+
+		local api = new("PoEAPI")
+		local callbackArgs
+		api:FetchAuthToken(function(response, errMsg, updateSettings)
+			callbackArgs = {
+				response = response,
+				errMsg = errMsg,
+				updateSettings = updateSettings,
+			}
+		end)
+
+		assert.is_not_nil(launch.subScripts[123])
+		launch.subScripts[123].callback("auth-code", nil, "wrong-state", 12345)
+
+		assert.is_nil(callbackArgs.response)
+		assert.are.equals("OAuth state mismatch", callbackArgs.errMsg)
+		assert.True(callbackArgs.updateSettings)
+		assert.is_nil(api.authToken)
+	end)
+end)

--- a/spec/System/TestPoEAPIAuth_spec.lua
+++ b/spec/System/TestPoEAPIAuth_spec.lua
@@ -4,21 +4,21 @@ describe("PoEAPI auth", function()
 	local originalSubScripts
 
 	before_each(function()
-		originalLaunchSubScript = LaunchSubScript
+		originalLaunchSubScript = _G.LaunchSubScript
 		originalDownloadPage = launch.DownloadPage
 		originalSubScripts = launch.subScripts
 		launch.subScripts = { }
 	end)
 
 	after_each(function()
-		LaunchSubScript = originalLaunchSubScript
+		_G.LaunchSubScript = originalLaunchSubScript
 		launch.DownloadPage = originalDownloadPage
 		launch.subScripts = originalSubScripts
 	end)
 
-	it("passes token exchange errors to the auth callback", function()
+	it("passes token exchange errors to the auth callback #auth", function()
 		local authState
-		LaunchSubScript = function(_, _, _, authUrl)
+		_G.LaunchSubScript = function(_, _, _, authUrl)
 			authState = authUrl:match("state=([^&]+)")
 			return 123
 		end
@@ -48,7 +48,7 @@ describe("PoEAPI auth", function()
 	end)
 
 	it("reports OAuth state mismatches without exchanging a token", function()
-		LaunchSubScript = function()
+		_G.LaunchSubScript = function()
 			return 123
 		end
 		launch.DownloadPage = function()

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -49,7 +49,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 
 	-- Stage: Authenticate
 	self.controls.authenticateButton = new("ButtonControl", {"TOPLEFT",self.controls.characterImportAnchor,"TOPLEFT"}, {0, 0, 200, 16}, "^7Authorize with Path of Exile", function()
-		self.api:FetchAuthToken(function()
+		self.api:FetchAuthToken(function(_, errMsg)
 			if self.api.authToken then
 				self.charImportMode = "GETACCOUNTNAME"
 				self.charImportStatus = "Authenticated"
@@ -59,6 +59,8 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 				main.tokenExpiry = self.api.tokenExpiry
 				main:SaveSettings()
 				self:DownloadCharacterList()
+			elseif errMsg and errMsg ~= self.api.ERROR_NO_AUTH then
+				self.charImportStatus = colorCodes.NEGATIVE.."Authentication failed: "..errMsg
 			else
 				self.charImportStatus = colorCodes.WARNING.."Not authenticated"
 			end

--- a/src/Classes/PoEAPI.lua
+++ b/src/Classes/PoEAPI.lua
@@ -57,6 +57,7 @@ local function base64_encode(secret)
 	return base64.encode(secret):gsub("+","-"):gsub("/","_"):gsub("=$", "")
 end
 
+-- func callback(response, errorMsg, updateSettings)
 function PoEAPIClass:FetchAuthToken(callback)
 	math.randomseed(os.time())
 	local secret = math.random(2^32-1)
@@ -86,11 +87,16 @@ function PoEAPIClass:FetchAuthToken(callback)
 					self.authToken = nil
 					self.refreshToken = nil
 					self.tokenExpiry = nil
-					callback(nil, self.ERROR_NO_AUTH, true)
+					callback(nil, errMsg or self.ERROR_NO_AUTH, true)
 					return
 				end
 
 				if initialState ~= state then
+					ConPrintf("OAuth state mismatch during authentication")
+					self.authToken = nil
+					self.refreshToken = nil
+					self.tokenExpiry = nil
+					callback(nil, "OAuth state mismatch", true)
 					return
 				end
 				local formText = "client_id=pob&grant_type=authorization_code&code=" .. code .. "&redirect_uri=http://localhost:" .. port .. "&scope=" .. table.concat(scopesOAuth, " ") .. "&code_verifier=" .. code_verifier
@@ -100,7 +106,7 @@ function PoEAPIClass:FetchAuthToken(callback)
 						self.authToken = nil
 						self.refreshToken = nil
 						self.tokenExpiry = nil
-						callback()
+						callback(nil, errMsg, true)
 						return
 					end
 					local responseLua = dkjson.decode(response.body)


### PR DESCRIPTION
Fixes #1045

## Summary

- Preserve OAuth token-exchange errors instead of collapsing them into generic `Not authenticated`.
- Show the specific authentication failure in the Import tab when the token request fails.
- Report OAuth state mismatches as authentication failures instead of silently leaving the login flow pending.
- Add focused auth callback regressions for token-exchange failures and state mismatches.

## Root Cause

`PoEAPIClass:FetchAuthToken` logged token-exchange errors such as `SSL connect error`, cleared token state, then called `callback()` without passing the error. `ImportTab` therefore had no way to distinguish a real transport/token failure from a normal unauthenticated state and displayed only `Not authenticated`.

The OAuth state-mismatch path also returned without invoking the callback, which could leave the UI in the temporary logging-in status with no actionable reason.

## Fix

`FetchAuthToken` now follows the same callback shape used elsewhere in `PoEAPI`: `callback(response, errorMsg, updateSettings)`. Token-exchange failures pass the original `errMsg`, local auth-code failures preserve their error when available, and state mismatches return `OAuth state mismatch`.

The Import tab auth callback now displays `Authentication failed: <reason>` for specific auth failures while preserving the existing generic `Not authenticated` message for the normal no-auth case.

## Validation

- `git diff --check` - pass.
- `git diff --cached --check` - pass.
- `git show --check --stat --oneline --no-renames HEAD` - pass.
- `python`/lupa syntax smoke for `src/Classes/PoEAPI.lua` and `spec/System/TestPoEAPIAuth_spec.lua` - pass.
- Added `spec/System/TestPoEAPIAuth_spec.lua` regressions for token-exchange error propagation and OAuth state mismatch handling.
- Full Busted/Docker suite not run locally: `docker`, `docker-compose`, `lua`, `luajit`, and `busted` are not installed on PATH on this machine.

## Risk / Rollback

Risk is low: successful authentication still uses the existing token storage path, and generic no-auth handling is unchanged. The changed failure paths only preserve and display errors that were already known to the client. Rollback is the single commit if maintainers prefer the previous generic status.
