### PR TITLE
Use highest weapon set maximum Rage cap

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -193,6 +193,17 @@ describe("TestSkills", function()
 		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
 	end)
 
+	it("Test maximum Rage can use the highest weapon set cap", function()
+		build.configTab.input.multiplierRage = 48
+		build.configTab:BuildModList()
+		build.configTab.modList:NewMod("Condition:CanGainRage", "FLAG", true, "Test")
+		build.configTab.modList:NewMod("MaximumRage", "BASE", 18, "Weapon Set 2 Test", { type = "Condition", var = "WeaponSet2" })
+		runCallback("OnFrame")
+
+		assert.are.equals(48, build.calcsTab.mainOutput.MaximumRage)
+		assert.are.equals(48, build.calcsTab.mainOutput.Rage)
+	end)
+
 	it("Test stacking persistent buff supports of same category", function()
 		build.skillsTab:PasteSocketGroup("Arctic Armour 20/0  1\nClarity I 1/0  1")
 		build.skillsTab:PasteSocketGroup("Time of Need 20/0  1\nClarity II 1/0  1")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -478,6 +478,21 @@ local function doActorMisc(env, actor)
 	local output = actor.output
 	local condList = modDB.conditions
 
+	local function getMaximumRageWithWeaponSetCaps(baseCfg)
+		local maxStacks = modDB:Sum("BASE", baseCfg, "MaximumRage")
+		if actor == env.player then
+			for weaponSet = 1, 2 do
+				local weaponSetCfg = baseCfg and copyTable(baseCfg) or { }
+				weaponSetCfg.overrideCond = setmetatable({
+					WeaponSet1 = weaponSet == 1,
+					WeaponSet2 = weaponSet == 2,
+				}, { __index = baseCfg and baseCfg.overrideCond })
+				maxStacks = m_max(maxStacks, modDB:Sum("BASE", weaponSetCfg, "MaximumRage"))
+			end
+		end
+		return maxStacks
+	end
+
 	-- Add misc buffs/debuffs
 	if env.mode_combat then
 		if env.player.mainSkill.baseSkillModList:Flag(nil, "Cruelty") then
@@ -665,7 +680,7 @@ local function doActorMisc(env, actor)
 			condList["LeechingEnergyShield"] = true
 		end
 		if modDB:Flag(nil, "Condition:CanGainRage") or modDB:Sum("BASE", nil, "RageRegen") > 0 then
-			local maxStacks = modDB:Sum("BASE", skillCfg, "MaximumRage")
+			local maxStacks = getMaximumRageWithWeaponSetCaps(skillCfg)
 			local minStacks = m_min(modDB:Sum("BASE", nil, "MinimumRage"), maxStacks)
 			local rageConfig = modDB:Sum("BASE", nil, "Multiplier:RageStack")
 			local stacks = m_max(m_min(rageConfig, maxStacks), (minStacks > 0 and minStacks) or 0)


### PR DESCRIPTION
Fixes #1079

## Summary

- Clamp configured Rage against the highest persistent maximum Rage cap available from either weapon set.
- Keep inactive weapon-set offensive stats inactive; only the persistent maximum Rage cap is considered across weapon sets.
- Add a regression for a Weapon Set 2 maximum Rage bonus while calculating the active Weapon Set 1 skill.

## Root Cause

Rage was clamped with `modDB:Sum("BASE", skillCfg, "MaximumRage")` under the current active weapon-set condition. If a build could generate a higher maximum Rage cap on the other weapon set, the configured Rage value was still truncated to the active weapon set's cap before damage was calculated.

That matches #1079: a build that can reach 48 Rage through Weapon Set 2 still calculated Weapon Set 1/totem damage as though Rage capped at 30.

## Fix

The Rage block now evaluates `MaximumRage` three ways and uses the maximum result:

1. the normal active-condition result,
2. the result with `WeaponSet1` forced true and `WeaponSet2` forced false,
3. the result with `WeaponSet2` forced true and `WeaponSet1` forced false.

This uses `cfg.overrideCond`, so it does not enable unrelated inactive weapon-set stats. It only asks: "what is the highest maximum Rage cap this player can sustain from either weapon set?"

## Validation

- `git diff --check` - pass.
- `git diff --cached --check` - pass.
- `git show --check --stat --oneline --no-renames HEAD` - pass.
- `python`/lupa syntax smoke for `spec/System/TestSkills_spec.lua` - pass.
- Added targeted regression in `spec/System/TestSkills_spec.lua`.
- Full Busted/Docker suite not run locally: `docker`, `docker-compose`, `lua`, `luajit`, and `busted` are not installed on PATH on this machine.

## Risk / Rollback

Risk is moderate-low and isolated to Rage clamping. The change does not apply inactive weapon-set damage/speed/passive bonuses; it only allows the configured Rage stack count to use the highest available maximum Rage cap. Rollback is the single commit if maintainers prefer maximum Rage to remain strictly active-weapon-set-scoped.
