### PR TITLE
Fix Pounce support socket counting

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -85,6 +85,33 @@ describe("TestSkills", function()
 		assert.are.equals(16, round(finalCost))
 	end)
 
+	it("does not count active skill internal support effects as socketed support gems", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Nettle Talisman
+			Quality: 0
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Pounce 20/0  1\nBrutality I 1/0  1\nExecute I 1/0  1\nHeft 1/0  1\nClose Combat I 1/0  1\nRage I 1/0  1")
+		runCallback("OnFrame")
+
+		local socketGroup = build.skillsTab.socketGroupList[#build.skillsTab.socketGroupList]
+		assert.True(socketGroup.gemList[1].supportEffect ~= nil)
+
+		local warnings = build.calcsTab.mainEnv.itemWarnings and build.calcsTab.mainEnv.itemWarnings.socketLimitWarning
+		assert.is_nil(warnings)
+
+		newBuild()
+		build.skillsTab:PasteSocketGroup("Pounce 20/0  1\nBrutality I 1/0  1\nExecute I 1/0  1\nHeft 1/0  1\nClose Combat I 1/0  1\nRage I 1/0  1\nMagnified Area I 1/0  1")
+		runCallback("OnFrame")
+
+		warnings = build.calcsTab.mainEnv.itemWarnings and build.calcsTab.mainEnv.itemWarnings.socketLimitWarning
+		assert.True(warnings ~= nil)
+		assert.are.equals(1, #warnings)
+	end)
+
 	it("Consumed Charge Effect", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 			New Item

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1872,19 +1872,26 @@ function calcs.initEnv(build, mode, override, specEnv)
 	-- Calculate skill gem and support gem counts
 	-- Currently PoB2 doesn't associate weapon skill supports with the actual weapon sets
 	-- so it ends up counting all support gems when it should only take into account the active weapon set
+	local function getSocketedSupportGemEffect(gem)
+		if gem.gemData and gem.gemData.grantedEffect then
+			return gem.gemData.grantedEffect.support and gem.gemData.grantedEffect
+		end
+		return gem.grantedEffect and gem.grantedEffect.support and gem.grantedEffect
+	end
 	local slotSupportGemSocketsCount = { R = 0, G = 0, B = 0 }
 	-- Loop through socket groups to calculate number of socketed gems
 	for _, socketGroup in pairs(env.build.skillsTab.socketGroupList) do
 		local socketedSupportGems = 0
 		if (socketGroup.enabled and socketGroup.gemList) then
 			for _, gem in pairs(socketGroup.gemList) do
-				if gem.supportEffect and gem.supportEffect.grantedEffect then
+				local supportGrantedEffect = getSocketedSupportGemEffect(gem)
+				if supportGrantedEffect then
 					socketedSupportGems = socketedSupportGems + 1
-					if gem.supportEffect.grantedEffect.color == 1 then
+					if supportGrantedEffect.color == 1 then
 						slotSupportGemSocketsCount.R = slotSupportGemSocketsCount.R + 1
-					elseif gem.supportEffect.grantedEffect.color == 2 then
+					elseif supportGrantedEffect.color == 2 then
 						slotSupportGemSocketsCount.G = slotSupportGemSocketsCount.G + 1
-					elseif gem.supportEffect.grantedEffect.color == 3 then
+					elseif supportGrantedEffect.color == 3 then
 						slotSupportGemSocketsCount.B = slotSupportGemSocketsCount.B + 1
 					end
 				end


### PR DESCRIPTION
## Summary

Fixes #1672

Stop active-skill internal support effects from being counted as socketed support gems when validating the five-support socket limit.

## Root Cause

Pounce is an active skill gem that also exports an internal support effect. During setup, socket-limit validation counted any gem instance with `supportEffect`, so Pounce itself was counted as one support before the five actual socketed supports were counted. A legal Pounce setup with five support gems therefore appeared to have six supports and produced the "too many gems" warning.

## Fix

- Count only gem instances whose own granted effect is a support gem when calculating socketed support-gem totals.
- Use that same socketed support effect for red/green/blue support requirement counters.
- Add a regression covering Pounce with five socketed supports and a control case with six actual socketed supports.

## Validation

- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state all --search "#1672" --json number,title,state,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state all --search "Pounce too many gems" --json number,title,state,url,headRefName,author --limit 20` -> `[]`
- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state all --search "support gems socket limit" --json number,title,state,url,headRefName,author --limit 20` -> `[]`
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- `git show --check --oneline --no-renames HEAD` -> passed
- Lua syntax check with Python/Lupa for `spec/System/TestSkills_spec.lua` -> passed
- Lua syntax check with Python/Lupa for `src/Modules/CalcSetup.lua` -> blocked by a pre-existing upstream Lupa parse failure at line 970 (`attempt to assign to const variable 'slot'`); confirmed the same failure on `upstream/dev` before this change.
- `lua`, `luajit`, `busted`, `docker`, and `docker-compose` are not installed on this Windows PATH, so I could not run the Busted suite locally.

## Risk / Rollback

Risk is limited to socketed support-gem counting and support-color requirement totals. Item-granted/internal support effects should not consume sockets, while actual support gems still do. Rollback is the single commit on this branch.
