### PR TITLE
Fix crash wehn opening some old builds

### DIFF
--- a/spec/System/TestPassiveSpec_spec.lua
+++ b/spec/System/TestPassiveSpec_spec.lua
@@ -1,0 +1,46 @@
+describe("TestPassiveSpec", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	local function firstLoadedSocketNode(spec)
+		for nodeId in pairs(spec.tree.sockets) do
+			if spec.nodes[nodeId] then
+				return nodeId
+			end
+		end
+	end
+
+	it("ignores stale jewel socket item ids when loading saved builds", function()
+		local spec = new("PassiveSpec", build, latestTreeVersion)
+		local socketNodeId = firstLoadedSocketNode(spec)
+
+		spec:Load({
+			attrib = { title = "Stale Socket Test" },
+			{
+				elem = "Sockets",
+				{
+					elem = "Socket",
+					attrib = {
+						nodeId = tostring(socketNodeId),
+						itemId = "999999",
+					}
+				}
+			}
+		}, "stale_socket.xml")
+
+		assert.is_nil(spec.jewels[socketNodeId])
+	end)
+
+	it("does not crash when radius helpers see a stale jewel socket item id", function()
+		local spec = new("PassiveSpec", build, latestTreeVersion)
+		local socketNodeId = firstLoadedSocketNode(spec)
+		spec.jewels[socketNodeId] = 999999
+
+		local ok, err = pcall(function()
+			return spec:NodesInIntuitiveLeapLikeRadius(spec.nodes[socketNodeId])
+		end)
+
+		assert.is_true(ok, err)
+	end)
+end)

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1079,8 +1079,11 @@ function PassiveSpecClass:NodesInIntuitiveLeapLikeRadius(node)
 	local result = { }
 	if self.jewels[node.id] and self.jewels[node.id] > 0 then
 		local item = self:GetJewel(self.jewels[node.id])
-		if item and item.jewelData and item.jewelData.intuitiveLeapLike then
-			local radiusIndex = item.jewelRadiusIndex
+		if not item then
+			return result
+		end
+		local radiusIndex = item.jewelRadiusIndex
+		if item.jewelData.intuitiveLeapLike then
 			local inRadius = self.nodes[node.id].nodesInRadius and self.nodes[node.id].nodesInRadius[radiusIndex]
 			for affectedNodeId, affectedNode in pairs(inRadius or {}) do
 				if self.nodes[affectedNodeId].alloc then

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -117,11 +117,14 @@ function PassiveSpecClass:Load(xml, dbFileName)
 							launch:ShowErrMsg("^1Error parsing '%s': 'Socket' element missing 'itemId' attribute", dbFileName)
 							return true
 						end
-						-- there are files which have been saved poorly and have empty jewel sockets saved as sockets with itemId zero.
-						-- this check filters them out to prevent dozens of invalid jewels
-						jewelIdNum = tonumber(child.attrib.itemId)
-						if jewelIdNum > 0 then
-							self.jewels[tonumber(child.attrib.nodeId)] = jewelIdNum
+						-- Some saved builds contain stale jewel socket item IDs after the
+						-- referenced item has been removed from the item list. Keep those
+						-- broken references out of the active tree state so later radius and
+						-- loadout code doesn't try to index a missing item.
+						local jewelIdNum = tonumber(child.attrib.itemId)
+						local nodeIdNum = tonumber(child.attrib.nodeId)
+						if nodeIdNum and jewelIdNum and jewelIdNum > 0 and self.build.itemsTab.items[jewelIdNum] then
+							self.jewels[nodeIdNum] = jewelIdNum
 						end
 					end
 				end
@@ -1075,9 +1078,9 @@ end
 function PassiveSpecClass:NodesInIntuitiveLeapLikeRadius(node)
 	local result = { }
 	if self.jewels[node.id] and self.jewels[node.id] > 0 then
-		local item = self.build.itemsTab.items[self.jewels[node.id]]
-		local radiusIndex = item.jewelRadiusIndex
+		local item = self:GetJewel(self.jewels[node.id])
 		if item and item.jewelData and item.jewelData.intuitiveLeapLike then
+			local radiusIndex = item.jewelRadiusIndex
 			local inRadius = self.nodes[node.id].nodesInRadius and self.nodes[node.id].nodesInRadius[radiusIndex]
 			for affectedNodeId, affectedNode in pairs(inRadius or {}) do
 				if self.nodes[affectedNodeId].alloc then


### PR DESCRIPTION
## Summary

Fixes #522.

- ignore saved jewel socket entries whose `itemId` no longer exists in the build item list
- make the intuitive-leap radius helper use the existing safe jewel lookup path before reading jewel fields
- add a regression spec for stale socket IDs so malformed saved builds do not poison passive tree state

## Root Cause

The issue attachment contains a `<Socket nodeId="36044" itemId="13"/>` entry, but the saved `<Items>` list has no `<Item id="13">`. `PassiveSpec:Load` still copied that stale ID into `self.jewels`, leaving later passive tree/radius/loadout code with a socket reference to a missing item.

One crash path was `PassiveSpecClass:NodesInIntuitiveLeapLikeRadius`, which read `item.jewelRadiusIndex` before proving that `self.build.itemsTab.items[itemId]` actually existed.

## Fix

`PassiveSpec:Load` now keeps only socket IDs that resolve to an existing saved item. The radius helper also routes through `GetJewel`, preserving the invariant that jewel radius logic only sees real jewel items.

This does not invent replacement items or change valid sockets; it only drops stale references that cannot be loaded correctly.

## Validation

- `gh pr list --repo PathOfBuildingCommunity/PathOfBuilding-PoE2 --state all --search "#522" ...` found no active crash/socket fix PR; the only hit was unrelated merged PR #1871.
- Issue fixture check against `Ice.Slammer.txt`: `items=18 sockets=5 stale=[(36044, 13)]`.
- `python` + `lupa` syntax compile:
  - `PASS lua compile src/Classes/PassiveSpec.lua`
  - `PASS lua compile spec/System/TestPassiveSpec_spec.lua`
- `git diff --cached --check`: passed.
- `git show --check --stat --oneline --no-renames HEAD`: passed.

Local Busted/Docker execution was not available in this checkout: `lua`, `luajit`, `busted`, `docker`, `docker-compose` were not found on PATH.

## Risk / Rollback

Low risk. The load path already treats zero socket item IDs as invalid/empty; this extends that same containment to non-existent positive item IDs. Rolling back restores the previous behavior of retaining stale socket references and risking nil indexing during tree/loadout processing.