### PR TITLE
Scale Vile Effusion by active Chaos DoT debuffs

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -238,6 +238,57 @@ describe("TestSkills", function()
 		assert.True(curseList:match("Flammability") ~= nil and curseList:match("Elemental Weakness") ~= nil)
 	end)
 
+	it("Dark Effigy scales Vile Effusion with Chaos DoT debuffs", function()
+		build.skillsTab:PasteSocketGroup("Dark Effigy 20/0  1")
+		runCallback("OnFrame")
+
+		local noDebuffOutput = build.calcsTab.mainOutput.Minion
+		assert.True(noDebuffOutput ~= nil)
+		assert.are.equals(0, noDebuffOutput.ProjectileCount)
+		assert.are.equals(0, noDebuffOutput.TotalDPS or 0)
+
+		build.skillsTab:PasteSocketGroup("Contagion 20/0  1")
+		runCallback("OnFrame")
+
+		local oneDebuffOutput = build.calcsTab.mainOutput.Minion
+		assert.are.equals(1, oneDebuffOutput.ProjectileCount)
+		assert.True(oneDebuffOutput.TotalDPS > 0)
+		local oneDebuffDPS = oneDebuffOutput.TotalDPS
+
+		build.skillsTab:PasteSocketGroup("Essence Drain 20/0  1")
+		runCallback("OnFrame")
+
+		local twoDebuffOutput = build.calcsTab.mainOutput.Minion
+		assert.are.equals(2, twoDebuffOutput.ProjectileCount)
+		assert.True(twoDebuffOutput.TotalDPS > oneDebuffDPS * 1.9)
+		local twoDebuffDPS = twoDebuffOutput.TotalDPS
+
+		build.skillsTab:PasteSocketGroup("Temporal Chains 20/0  1\nDecaying Hex 1/0  1")
+		runCallback("OnFrame")
+
+		local decayingHexOutput = build.calcsTab.mainOutput.Minion
+		assert.are.equals(3, decayingHexOutput.ProjectileCount)
+		assert.True(decayingHexOutput.TotalDPS > twoDebuffDPS * 1.4)
+		local decayingHexDPS = decayingHexOutput.TotalDPS
+
+		build.skillsTab:PasteSocketGroup("Essence Drain 20/0  1\nPoison I 1/0 1")
+		runCallback("OnFrame")
+
+		local poisonSupportOutput = build.calcsTab.mainOutput.Minion
+		assert.are.equals(4, poisonSupportOutput.ProjectileCount)
+		assert.True(poisonSupportOutput.TotalDPS > decayingHexDPS * 1.3)
+		local poisonSupportDPS = poisonSupportOutput.TotalDPS
+
+		build.configTab.input.conditionEnemyPoisoned = true
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local poisonedOutput = build.calcsTab.mainOutput.Minion
+		assert.are.equals(4, poisonedOutput.ProjectileCount)
+		assert.True(poisonedOutput.TotalDPS > poisonSupportDPS * 0.99)
+		assert.True(poisonedOutput.TotalDPS < poisonSupportDPS * 1.01)
+	end)
+
 	-- skills that don't have a base CD and have more than one use need to use the added cooldown by whatever support allows the +1 limit to be supportable
 	it("Test Added Cooldown interaction with +1 Limit", function()
 		build.skillsTab:PasteSocketGroup("Thunderstorm 20/0  1\nHourglass 1/0 1\nOverabundance I 1/0 1\n")

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -65,6 +65,36 @@ end })
 local globalOutput = nil
 local globalBreakdown = nil
 
+local function isActiveSkillDisabled(env, activeSkill)
+	local statSet = env.mode == "CALCS" and activeSkill.activeEffect.statSetCalcs or activeSkill.activeEffect.statSet
+	return statSet and statSet.skillFlags and statSet.skillFlags.disable
+end
+
+local function countActiveChaosDotDebuffs(env, enemyDB, currentActiveSkill)
+	local count = 0
+	local hasPoisonDebuff = enemyDB:GetCondition("Poisoned")
+	local countedSkills = { }
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		if activeSkill ~= currentActiveSkill and not isActiveSkillDisabled(env, activeSkill) then
+			local skillName = activeSkill.activeEffect.grantedEffect.name
+			local skillData = activeSkill.skillData or { }
+			local isChaosDotSkill = (activeSkill.skillTypes[SkillType.Chaos] and activeSkill.skillTypes[SkillType.DamageOverTime])
+				or skillData.ChaosDot or skillData.decay
+			if not countedSkills[skillName] and isChaosDotSkill then
+				countedSkills[skillName] = true
+				count = count + 1
+			end
+			if not hasPoisonDebuff and activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "PoisonChance", "ChaosPoisonChance") > 0 then
+				hasPoisonDebuff = true
+			end
+		end
+	end
+	if hasPoisonDebuff then
+		count = count + 1
+	end
+	return count
+end
+
 local function calcConvertedDamage(activeSkill, output, cfg, damageType)
 	local skillModList = activeSkill.skillModList
 	-- Calculate conversions
@@ -1246,6 +1276,11 @@ function calcs.offence(env, actor, activeSkill)
 			local projBase = skillModList:Sum("BASE", skillCfg, "ProjectileCount") + 2 * skillModList:Sum("BASE", skillCfg, "TwoAdditionalProjectilesChance") / 100 + skillModList:Sum("BASE", skillCfg, "SurpassingProjectileChance") / 100
 			local projMore = skillModList:More(skillCfg, "ProjectileCount")
 			output.ProjectileCount = projBase * projMore
+		end
+		if activeSkill.activeEffect.grantedEffect.name == "Vile Effusion" then
+			local chaosDotDebuffs = countActiveChaosDotDebuffs(env, enemyDB, activeSkill)
+			output.ProjectileCount = chaosDotDebuffs
+			skillModList:NewMod("DPS", "MORE", (chaosDotDebuffs - 1) * 100, "Vile Effusion")
 		end
 		if skillModList:Flag(skillCfg, "AdditionalProjectilesAddBouncesInstead") then
 			local projBase = skillModList:Sum("BASE", skillCfg, "ProjectileCount") + 2 * skillModList:Sum("BASE", skillCfg, "TwoAdditionalProjectilesChance") / 100 + skillModList:Sum("BASE", skillCfg, "SurpassingProjectileChance") / 100 + skillModList:Sum("BASE", skillCfg, "BounceCount") - 1


### PR DESCRIPTION
﻿# Summary

Fixes #564.

Dark Effigy's hidden Vile Effusion skill now scales from the number of active Chaos damage over time debuffs that the current build can maintain on the enemy.

# Root Cause

`Vile Effusion` is exported with `ProjectilesNumberModifiersNotApplied` and a static `number_of_additional_projectiles = 100` placeholder. The generic projectile path can display that static value, but it does not encode the actual mechanic from the skill text: one projectile/DPS instance per Chaos DoT debuff on the target, with normal projectile-count modifiers ignored.

That left Contagion, Essence Drain, Decaying Hex-supported curses, and Poison unable to change Dark Effigy's calculated DPS.

# Fix

- Add a small Vile Effusion-specific Chaos DoT debuff counter.
- Count enabled active skills that represent Chaos DoT debuffs, including support-granted decay from Decaying Hex.
- Count Poison once when either the enemy Poisoned condition is enabled or an enabled active skill has Poison chance.
- Apply the count as Vile Effusion's effective projectile count and DPS multiplier.
- Keep the behavior scoped to `Vile Effusion`; generic projectile modifiers remain ignored as the skill text requires.

# Validation

- Checked for duplicate/overlapping PRs:
  - `gh pr list --search "#564"` -> no PRs found
  - `gh pr list --search "Dark Effigy"` -> only historical merged PRs #1188 and #836
  - `gh pr list --search "Vile Effusion"` -> only historical merged PR #836
- Added a focused regression spec covering:
  - no Chaos DoT debuffs => zero Vile Effusion DPS/projectiles
  - Contagion adds one debuff
  - Essence Drain adds one debuff
  - Temporal Chains + Decaying Hex adds one debuff
  - Poison support adds one debuff
  - manually setting enemy Poisoned does not double-count Poison
- Lua syntax compile via Lupa:
  - `PASS lua compile src/Modules/CalcOffence.lua`
  - `PASS lua compile spec/System/TestSkills_spec.lua`
- `git diff --check` passed.
- `git show --check --stat --oneline --no-renames HEAD` passed.

Local Busted/Docker validation was not run because this Windows checkout does not currently have `lua`, `luajit`, `busted`, `docker`, or `docker-compose` on PATH.

# Risk / Rollback

Risk is limited to the hidden Vile Effusion skill path. The change does not alter generic projectile-count math, generic totem logic, or other Chaos DoT skill damage.

Rollback is the single commit on this branch.
