### PR TITLE
Fix Ascendancy Start deallocation and Abyssal Lich node allocation

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -260,7 +260,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		-- Cursor is over the tree, check if it is over a node
 		local curTreeX, curTreeY = screenToTree(cursorX, cursorY)
 		for nodeId, node in pairs(spec.nodes) do
-			if node.rsq and node.group and not node.isProxy and not node.group.isProxy then
+			if node.rsq and node.group and not node.isProxy and not node.group.isProxy and not node.isAscendancyStart then
 				-- Node has a defined size (i.e. has artwork)
 				local vX = curTreeX - node.x
 				local vY = curTreeY - node.y
@@ -417,7 +417,8 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					local targetBaseClass = nil
 					
 					-- Check if it's different from current primary or secondary ascendancy
-					if spec.curAscendClassId == 0 or hoverNode.ascendancyName ~= spec.curAscendClassBaseName then
+					-- always check for alternate ascendancy class first
+					if spec.curAscendClassId == 0 or (hoverNode.ascendancyName ~= (spec.curAscendClass.replace or spec.curAscendClassBaseName)) then
 						if not (spec.curSecondaryAscendClass and hoverNode.ascendancyName == spec.curSecondaryAscendClass.id) then
 							isDifferentAscendancy = true
 						end


### PR DESCRIPTION
### Description of the problem being solved:
This PR prevent users from deallocating the AscendancyStart node, bricking any further allocation until they change ascendancies, and stops Abyssal Lich converting to Lich when allocating any Abyssal Lich ascendancy node.

If we want to keep the tooltip with the name of the Ascendancy on hover, I've got an alternate solution for that, but the current solution matches pob1 behavior.

Sorry about the art, the recording software butchers it.

### Before screenshot:
<img width="1291" height="749" alt="beforeAbyssalLich" src="https://github.com/user-attachments/assets/32095452-cbe8-4e19-b308-99fe864e71e4" />

### After screenshot:
<img width="1291" height="749" alt="afterAbyssalLich" src="https://github.com/user-attachments/assets/9ceccb26-1a0c-49b6-a41f-31b1ad2f54ad" />
