### PR TITLE
Fix Adnonia's Ego power charge mod slider crash

### DIFF
--- a/spec/System/TestItemTools_spec.lua
+++ b/spec/System/TestItemTools_spec.lua
@@ -45,4 +45,12 @@ describe("TestItemTools", function()
 			assert.are.equals(expected, result)
 		end)
 	end
+
+	it("keeps range sliders for lines that resolve to zero", function()
+		local item = new("Item", "Rarity: Rare\nName\nArcane Raiment\n{range:0.5}+(-1-1) to Maximum Power Charges")
+
+		assert.are.equals(1, #item.rangeLineList)
+		assert.are.equals(0.5, item.rangeLineList[1].range)
+		assert.are.equals(0, item.baseModList:Sum("BASE", nil, "PowerChargesMax"))
+	end)
 end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1789,6 +1789,10 @@ function ItemClass:BuildModList()
 						local line = itemLib.applyRange(strippedModeLine, modLine.range, catalystScalar, modLine.corruptedRange)
 						-- Check if we can parse it before adding the mods
 						local list, extra = modLib.parseMod(line)
+						if itemLib.isZeroValueLine(line) then
+							list = { }
+							extra = nil
+						end
 						if list and not extra then
 							modLine.modList = list
 							t_insert(self.rangeLineList, modLine)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -77,10 +77,6 @@ c["+(8-10)% to all Elemental Resistances"]={nil,"+(8-10)% to all Elemental Resis
 c["+(9-14)% to Cold Resistance"]={nil,"+(9-14)% to Cold Resistance "}
 c["+(9-14)% to Fire Resistance"]={nil,"+(9-14)% to Fire Resistance "}
 c["+(9-14)% to Lightning Resistance"]={nil,"+(9-14)% to Lightning Resistance "}
-c["+0 to Maximum Power Charges"]={{[1]={flags=0,keywordFlags=0,name="PowerChargesMax",type="BASE",value=0}},nil}
-c["+0% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=0}},nil}
-c["+0% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=0}},nil}
-c["+0% to Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=0}},nil}
 c["+0.15% to Thorns Critical Hit Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="BASE",value=0.15}}," Thorns  "}
 c["+0.15% to Thorns Critical Hit Chance +25% to Thorns Critical Hit Chance"]={{[1]={flags=0,keywordFlags=0,name="CritChance",type="BASE",value=0.15}}," Thorns  +25% to Thorns Critical Hit Chance "}
 c["+0.5 metres to Dodge Roll distance while Surrounded"]={{}," metres to Dodge Roll distance  "}
@@ -897,6 +893,7 @@ c["-4 Physical Damage taken from Attack Hits"]={{[1]={flags=0,keywordFlags=0,nam
 c["-5% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=-5}},nil}
 c["-5% to amount of Damage Prevented by Deflection"]={{[1]={flags=0,keywordFlags=0,name="DeflectEffect",type="BASE",value=-5}},nil}
 c["-7% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=-7}},nil}
+c["0 to Maximum Power Charges"]={{[1]={flags=0,keywordFlags=0,name="PowerChargesMax",type="BASE",value=0}}," to  "}
 c["0% reduced Charm Charges gained"]={{[1]={flags=0,keywordFlags=0,name="CharmChargesGained",type="INC",value=-0}},nil}
 c["0% reduced Charm Charges used"]={{[1]={flags=0,keywordFlags=0,name="CharmChargesUsed",type="INC",value=-0}},nil}
 c["0% reduced Flask Life Recovery rate"]={{[1]={flags=0,keywordFlags=0,name="FlaskLifeRecoveryRate",type="INC",value=-0}},nil}
@@ -905,6 +902,9 @@ c["0% reduced Life Regeneration rate"]={{[1]={flags=0,keywordFlags=0,name="LifeR
 c["0% reduced Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=-0}},nil}
 c["0% reduced Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootRarity",type="INC",value=-0}},nil}
 c["0% reduced Skill Effect Duration"]={{[1]={flags=0,keywordFlags=0,name="Duration",type="INC",value=-0}},nil}
+c["0% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=0}},"% to  "}
+c["0% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=0}},"% to  "}
+c["0% to Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=0}},"% to  "}
 c["0.1 Life Regeneration per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=0.1}},nil}
 c["0.5% of maximum Life Regenerated per second per Fragile Regrowth"]={{[1]={[1]={type="Multiplier",var="FragileRegrowthCount"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=0.5}},nil}
 c["1 Rage Regenerated for every 25 Mana Regeneration per Second"]={{[1]={[1]={div=25,stat="ManaRegen",type="PerStat"},flags=0,keywordFlags=0,name="RageRegen",type="BASE",value=1},[2]={flags=0,keywordFlags=0,name="Condition:CanGainRage",type="FLAG",value=true}},nil}

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -69,6 +69,10 @@ local function antonymFunc(num, word)
 	return antonym and (num.." "..antonym) or ("-"..num.." "..word)
 end
 
+function itemLib.isZeroValueLine(line)
+	return line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]") and not line:match("0%% to %d+%%")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ")
+end
+
 -- Apply range value (0 to 1) to a modifier that has a range: "(x-x)" or "(x-x) to (x-x)"
 function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 	-- stripLines down to # in place of any number and store numbers inside values also remove all + signs are kept if value is positive
@@ -76,7 +80,7 @@ function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 	local strippedLine = line:gsub("([%+-]?)%((%-?%d+%.?%d*)%-(%-?%d+%.?%d*)%)", function(sign, min, max)
 		local value = min + range * (tonumber(max) - min)
 		if sign == "-" then value = value * -1 end
-		return (sign == "+" and value >= 0 ) and sign..tostring(value) or tostring(value)
+		return (sign == "+" and value > 0 ) and sign..tostring(value) or tostring(value)
 	end)
 	:gsub("%-(%d+%.?%d*%%) (%a+)", antonymFunc)
 	:gsub("(%-?%d+%.?%d*)", function(value)
@@ -320,7 +324,7 @@ end
 
 function itemLib.formatModLine(modLine, dbMode)
 	local line = (not dbMode and modLine.range and itemLib.applyRange(modLine.line, modLine.range, modLine.valueScalar, modLine.corruptedRange)) or modLine.line
-	if line:match("^%+?0%%? ") or (line:match(" %+?0%%? ") and not line:match("0 to [1-9]") and not line:match("0%% to %d+%%")) or line:match(" 0%-0 ") or line:match(" 0 to 0 ") then -- Hack to hide 0-value modifiers
+	if itemLib.isZeroValueLine(line) then -- Hack to hide 0-value modifiers
 		return
 	end
 	local colorCode


### PR DESCRIPTION
Fixes #1412

### Description of the problem being solved:
When using the slider for the power charge mod, it would crash when the value was set to 0
It now just hides the mod but keeps the slider

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/314o0e0w

### Before screenshot:
<img width="575" height="353" alt="image" src="https://github.com/user-attachments/assets/67c5efae-16dc-4bbb-a991-b7a4b52bd7c3" />

### After screenshot:
<img width="491" height="485" alt="image" src="https://github.com/user-attachments/assets/9e5eeba0-67a9-462f-898d-3111257d0012" />
