### PR TITLE
[0.5] Update Deflection formula

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -49,8 +49,8 @@ function calcs.deflectChance(deflection, accuracy)
 	if deflection < 1 then
 		return 0
 	end
-	local rawChance = ( accuracy * 0.9 ) / ( accuracy + deflection * 0.2 ) * 100
-	return 100 - m_max(m_min(round(rawChance), 100), 0)
+	local rawChance = accuracy / ( accuracy + deflection * 0.12 ) * 150
+	return 100 - m_max(m_min(round(rawChance), data.misc.DeflectionChanceCap), 0)
 end
 -- Calculate damage reduction from armour, float
 function calcs.armourReductionF(armour, raw)

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -49,8 +49,8 @@ function calcs.deflectChance(deflection, accuracy)
 	if deflection < 1 then
 		return 0
 	end
-	local rawChance = accuracy / ( accuracy + deflection * 0.12 ) * 150
-	return 100 - m_max(m_min(round(rawChance), data.misc.DeflectionChanceCap), 0)
+	local chanceToNotDeflect = accuracy / ( accuracy + deflection * 0.12 ) * 150 - 50
+	return 100 - m_max(m_min(round(chanceToNotDeflect), data.misc.DeflectionChanceCap), 0)
 end
 -- Calculate damage reduction from armour, float
 function calcs.armourReductionF(armour, raw)

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -180,6 +180,7 @@ data.misc = { -- magic numbers
 	ResistFloor = -200,
 	MaxResistCap = 90,
 	EvadeChanceCap = data.gameConstants["DefaultMaxEvadeChancePercent"],
+	DeflectionChanceCap = 95, -- maybe a gameConstant?
 	DodgeChanceCap = 75,
 	BlockChanceCap = 90,
 	SuppressionChanceCap = 100,


### PR DESCRIPTION
### Description of the problem being solved:
`The formula for chance to Deflect has been adjusted to provide better scaling with investment into Deflection Rating, with a cap of 95% chance to Deflect (similar to chance to Evade being capped at 95%).`

`The new chance to Deflect is = 150*(1 - A/(A + 0.12*D)), where A = attacker accuracy rating, and D = defender deflection rating. This makes for a linear path, that gets rewarded at higher investments. `
