### PR TITLE
Add support for Dark Effigy DPS scaling with Chaos Debuffs on enemy

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -3797,6 +3797,7 @@ skills["ContagionPlayer"] = {
 			},
 			baseMods = {
 				skill("debuff", true),
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Contagion" }),
 			},
 			constantStats = {
 				{ "base_skill_effect_duration", 5000 },
@@ -4680,6 +4681,10 @@ skills["DarkEffigyProjectilePlayer"] = {
 				area = true,
 				projectile = true,
 				totem = true,
+			},
+			baseMods = {
+				mod("DPS", "MORE", 100, 0, 0, { type = "Multiplier", var = "ChaosDebuff", actor = "enemy" }),
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Poison" }, { type = "Condition", var = "Poisoned" }),
 			},
 			constantStats = {
 				{ "skill_disabled_unless_cloned", 2 },
@@ -6288,6 +6293,9 @@ skills["EssenceDrainPlayer"] = {
 				spell = true,
 				projectile = true,
 			},
+			baseMods = {
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Essence Drain" }),
+			},
 			constantStats = {
 				{ "movement_speed_+%_final_while_performing_action", -70 },
 				{ "movement_speed_acceleration_+%_per_second_while_performing_action", 160 },
@@ -6367,6 +6375,7 @@ skills["EssenceDrainPlayer"] = {
 			},
 			baseMods = {
 				skill("debuff", true),
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Essence Drain" }),
 			},
 			constantStats = {
 				{ "movement_speed_+%_final_while_performing_action", -70 },
@@ -15699,6 +15708,9 @@ skills["ProfaneRitualPlayer"] = {
 				spell = true,
 				area = true,
 			},
+			baseMods = {
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Profane Ritual" }),
+			},
 			constantStats = {
 				{ "base_skill_effect_duration", 2000 },
 				{ "ritual_of_power_maximum_number_of_rituals", 5 },
@@ -19297,6 +19309,9 @@ skills["SoulrendPlayer"] = {
 				spell = true,
 				projectile = true,
 			},
+			baseMods = {
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Soulrend" }),
+			},
 			constantStats = {
 				{ "active_skill_projectile_speed_+%_variation_final", 25 },
 				{ "movement_speed_+%_final_while_performing_action", -70 },
@@ -19370,6 +19385,7 @@ skills["SoulrendPlayer"] = {
 			},
 			baseMods = {
 				skill("debuff", true),
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Soulrend" }),
 			},
 			constantStats = {
 				{ "active_skill_projectile_speed_+%_variation_final", 25 },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2791,6 +2791,9 @@ skills["SupportDecayingHexPlayer"] = {
 			},
 			baseFlags = {
 			},
+			baseMods = {
+				mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Decaying Hex" }),
+			},
 			constantStats = {
 				{ "support_decaying_hex_base_chaos_damage_per_minute_as_%_of_intelligence_for_8_seconds", 6000 },
 			},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -277,6 +277,7 @@ statMap = {
 #set ContagionPlayer
 #flags area duration spell
 #baseMod skill("debuff", true)
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Contagion" })
 #mods
 #skillEnd
 
@@ -324,6 +325,8 @@ statMap = {
 #skill DarkEffigyProjectilePlayer
 #set DarkEffigyProjectilePlayer
 #flags spell area projectile totem
+#baseMod mod("DPS", "MORE", 100, 0, 0, { type = "Multiplier", var = "ChaosDebuff", actor = "enemy" })
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Poison" }, { type = "Condition", var = "Poisoned" })
 #mods
 #skillEnd
 
@@ -434,10 +437,12 @@ statMap = {
 #skill EssenceDrainPlayer
 #set EssenceDrainPlayer
 #flags spell projectile
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Essence Drain" })
 #mods
 #set EssenceDrainDotPlayer
 #flags spell projectile duration
 #baseMod skill("debuff", true)
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Essence Drain" })
 #mods
 #skillEnd
 
@@ -1063,6 +1068,7 @@ statMap = {
 #skill ProfaneRitualPlayer
 #set ProfaneRitualPlayer
 #flags spell area
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Profane Ritual" })
 #mods
 #skillEnd
 
@@ -1299,10 +1305,12 @@ statMap = {
 #skill SoulrendPlayer
 #set SoulrendPlayer
 #flags spell projectile
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Soulrend" })
 #mods
 #set SoulrendDotPlayer
 #flags spell duration
 #baseMod skill("debuff", true)
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Soulrend" })
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -486,6 +486,7 @@ statMap = {
 		div = 60,
 	},
 },
+#baseMod mod("Multiplier:ChaosDebuff", "BASE", 1, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Decaying Hex" })
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #564

### Description of the problem being solved:
Adds a DPS multiplier that scales off the number of a ChaosDebuff multiplier on the enemy
Added the multiplier to skills manually as I'm not sure of a better way to handle it. Potentially there's something in the game files that tags each debuff as being chaos related

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/83r34e03

### Before screenshot:
<img width="342" height="79" alt="image" src="https://github.com/user-attachments/assets/3dedb30f-5b3e-4116-ad7c-6b63a82e00a8" />
<img width="507" height="73" alt="image" src="https://github.com/user-attachments/assets/525e2d9a-0a78-474a-81e9-e982e232faa9" />

### After screenshot:
<img width="503" height="133" alt="image" src="https://github.com/user-attachments/assets/5258af4d-08f3-4e9c-a534-9c99f35f914d" />
<img width="691" height="82" alt="image" src="https://github.com/user-attachments/assets/5f79e802-543a-42b8-a099-c0597decf07b" />
