### PR TITLE
Fix Charm quality applying to effect instead of duration

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1680,7 +1680,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		local charmData = self.charmData
 		local durationInc = calcLocal(modList, "Duration", "INC", 0)
 		local durationMore = calcLocal(modList, "Duration", "MORE", 0)
-		charmData.duration = round(self.base.charm.duration * (1 + durationInc / 100) * durationMore, 1)
+		charmData.duration = round(self.base.charm.duration * (1 + durationInc / 100) * (1 + self.quality / 100) * durationMore, 1)
 		charmData.chargesMax = (self.base.charm.chargesMax + calcLocal(modList, "FlaskCharges", "BASE", 0)) * (1 + calcLocal(modList, "FlaskCharges", "INC", 0) / 100)
 		charmData.chargesUsed = m_floor(self.base.charm.chargesUsed * (1 + calcLocal(modList, "FlaskChargesUsed", "INC", 0) / 100))
 		charmData.gainBase = calcLocal(modList, "FlaskChargesGenerated", "BASE", 0)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1508,7 +1508,7 @@ function calcs.perform(env, skipEHP)
 			if item.rarity == "MAGIC" then
 				charmEffectInc = charmEffectInc + effectIncMagic
 			end
-			local effectMod = (1 + (charmEffectInc) / 100) * (1 + (item.quality or 0) / 100)
+			local effectMod = 1 + (charmEffectInc) / 100
 
 			-- same deal as flasks, go look at the comment there
 			if buffModList[1] then


### PR DESCRIPTION
### Description of the problem being solved:
For some reason quality on Charms was increasing the effect of the Charm mods instead of increasing the duration

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/ek53on0w

### Before screenshot:
<img width="780" height="265" alt="image" src="https://github.com/user-attachments/assets/72446797-8fca-44d6-ae05-9c4fdafba900" />
<img width="435" height="38" alt="image" src="https://github.com/user-attachments/assets/58f40ca4-510e-4632-8d35-a4df0c92e55a" />

### After screenshot:
<img width="837" height="263" alt="image" src="https://github.com/user-attachments/assets/297a7b26-cff1-4fad-ae9c-8a78d6b7043f" />
<img width="431" height="40" alt="image" src="https://github.com/user-attachments/assets/30ec2986-c884-4131-b46b-fbafa30111a9" />
