### PR TITLE
Add support for Ancestral Bond's Spirit Reservation

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -674,4 +674,45 @@ describe("TetsItemMods", function()
 		assert.are.equals(0, smallModList:Sum("BASE", nil, "Str"))
 		assert.are.equals(11, smallModList:Sum("BASE", nil, "Dex"))
 	end)
+
+	it("ancestral bond", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			Rarity: UNIQUE
+			Hoghunt
+			Felled Greatclub
+			Variant: Pre 0.1.1
+			Variant: Current
+			Selected Variant: 2
+			Quality: 20
+			LevelReq: 0
+			Implicits: 0
+			{variant:1}{range:0.5}(100-150)% increased Physical Damage
+			{variant:2}{range:0.5}Adds (16-20) to (23-27) Physical Damage
+			+15% to Critical Hit Chance
+			10% reduced Attack Speed
+			+10 to Strength
+			Maim on Critical Hit
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Ancestral Warrior Totem 20/0 2")
+		runCallback("OnFrame")
+
+		build.configTab.input.customMods = [[
+		Totems reserve 75 spirit each
+		+100 spirit
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(150, build.calcsTab.mainOutput.SpiritReserved)
+
+		build.configTab.input.customMods = [[
+		Totems reserve 75 spirit each
+		100% increased spirit reservation efficiency
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(76, build.calcsTab.mainOutput.SpiritReserved)
+	end)
 end)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6047,7 +6047,7 @@ c["Totems gain +3% to all Maximum Elemental Resistances 20% increased Area of Ef
 c["Totems have 12% additional Physical Damage Reduction"]={{[1]={flags=0,keywordFlags=16384,name="PhysicalDamageReduction",type="BASE",value=12}},nil}
 c["Totems have 20% additional Physical Damage Reduction"]={{[1]={flags=0,keywordFlags=16384,name="PhysicalDamageReduction",type="BASE",value=20}},nil}
 c["Totems only use Skills when you fire an Attack Projectile"]={nil,"Totems only use Skills when you fire an Attack Projectile "}
-c["Totems reserve 75 Spirit each"]={nil,"Totems reserve 75 Spirit each "}
+c["Totems reserve 75 Spirit each"]={{[1]={flags=0,keywordFlags=0,name="AncestralBond",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="AncestralBondSpirit",type="BASE",value=75},[3]={[1]={skillTypeList={[1]=25,[2]=166},type="SkillType"},flags=0,keywordFlags=0,name="ExtraSpirit",type="BASE",value=75}},nil}
 c["Totems you place grant Embankment Auras"]={nil,"Totems you place grant Embankment Auras "}
 c["Trigger Ancestral Spirits when you Summon a Totem"]={{},nil}
 c["Trigger Decompose every 1.2 metres travelled"]={nil,"Trigger Decompose every 1.2 metres travelled "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6047,7 +6047,7 @@ c["Totems gain +3% to all Maximum Elemental Resistances 20% increased Area of Ef
 c["Totems have 12% additional Physical Damage Reduction"]={{[1]={flags=0,keywordFlags=16384,name="PhysicalDamageReduction",type="BASE",value=12}},nil}
 c["Totems have 20% additional Physical Damage Reduction"]={{[1]={flags=0,keywordFlags=16384,name="PhysicalDamageReduction",type="BASE",value=20}},nil}
 c["Totems only use Skills when you fire an Attack Projectile"]={nil,"Totems only use Skills when you fire an Attack Projectile "}
-c["Totems reserve 75 Spirit each"]={{[1]={flags=0,keywordFlags=0,name="AncestralBond",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="AncestralBondSpirit",type="BASE",value=75},[3]={[1]={skillTypeList={[1]=25,[2]=166},type="SkillType"},flags=0,keywordFlags=0,name="ExtraSpirit",type="BASE",value=75}},nil}
+c["Totems reserve 75 Spirit each"]={{[1]={flags=0,keywordFlags=0,name="AncestralBond",type="FLAG",value=true},[2]={[1]={skillType=25,type="SkillType"},flags=0,keywordFlags=0,name="ExtraSpirit",type="BASE",value=75}},nil}
 c["Totems you place grant Embankment Auras"]={nil,"Totems you place grant Embankment Auras "}
 c["Trigger Ancestral Spirits when you Summon a Totem"]={{},nil}
 c["Trigger Decompose every 1.2 metres travelled"]={nil,"Trigger Decompose every 1.2 metres travelled "}

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -190,7 +190,8 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 		breakdown.SpiritReserved = { reservations = { } }
 	end
 	for _, activeSkill in ipairs(actor.activeSkillList) do
-		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] then
+		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost]
+				or (activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond")) then
 			local skillModList = activeSkill.skillModList
 			local skillCfg = activeSkill.skillCfg
 			local mult = floor(skillModList:More(skillCfg, "ReservationMultiplier"), 4)
@@ -209,7 +210,8 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 			end
 			pool.Mana.baseFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
 			pool.Spirit.baseFlat = activeSkill.skillData.spiritReservationFlat or activeSkill.activeEffect.grantedEffectLevel.spiritReservationFlat or 0
-			pool.Spirit.baseFlat = pool.Spirit.baseFlat + skillModList:Sum("BASE", skillCfg, "ExtraSpirit")
+			pool.Spirit.baseFlat = pool.Spirit.baseFlat + skillModList:Sum("BASE", skillCfg, "ExtraSpirit") *
+				((activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond")) and activeSkill.actor.modDB:Override(nil, "TotemsSummoned") or 1)
 			if skillModList:Flag(skillCfg, "ManaCostGainAsReservation") and activeSkill.activeEffect.grantedEffectLevel.cost then
 				pool.Spirit.baseFlat = skillModList:Sum("BASE", skillCfg, "ManaCostBase") + (activeSkill.activeEffect.grantedEffectLevel.cost.Mana or 0)
 			end
@@ -952,6 +954,9 @@ function calcs.defence(env, actor)
 	end
 	if actor == env.minion or actor == env.player then
 		calcs.doActorLifeManaSpirit(actor)
+		if modDB:Flag(nil, "AncestralBond") then -- need spirit for the perStat and need the override before reservation is calced
+			modDB:NewMod("TotemsSummoned", "OVERRIDE", 1, { type = "PerStat", stat = "Spirit", div = modDB:Sum("BASE", nil, "AncestralBondSpirit") })
+		end
 		calcs.doActorLifeManaSpiritReservation(actor)
 	end
 

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -190,8 +190,8 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 		breakdown.SpiritReserved = { reservations = { } }
 	end
 	for _, activeSkill in ipairs(actor.activeSkillList) do
-		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost]
-				or (activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond")) then
+		local isTotemAndAncestralBond = activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond")
+		if (activeSkill.skillTypes[SkillType.HasReservation] or activeSkill.skillData.SupportedByAutoexertion) and not activeSkill.skillTypes[SkillType.ReservationBecomesCost] or isTotemAndAncestralBond then
 			local skillModList = activeSkill.skillModList
 			local skillCfg = activeSkill.skillCfg
 			local mult = floor(skillModList:More(skillCfg, "ReservationMultiplier"), 4)
@@ -210,8 +210,7 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 			end
 			pool.Mana.baseFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
 			pool.Spirit.baseFlat = activeSkill.skillData.spiritReservationFlat or activeSkill.activeEffect.grantedEffectLevel.spiritReservationFlat or 0
-			pool.Spirit.baseFlat = pool.Spirit.baseFlat + skillModList:Sum("BASE", skillCfg, "ExtraSpirit") *
-				(activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond") and calcs.getActiveSkillCount(activeSkill) or 1)
+			pool.Spirit.baseFlat = pool.Spirit.baseFlat + skillModList:Sum("BASE", skillCfg, "ExtraSpirit")
 			if skillModList:Flag(skillCfg, "ManaCostGainAsReservation") and activeSkill.activeEffect.grantedEffectLevel.cost then
 				pool.Spirit.baseFlat = skillModList:Sum("BASE", skillCfg, "ManaCostBase") + (activeSkill.activeEffect.grantedEffectLevel.cost.Mana or 0)
 			end
@@ -261,7 +260,7 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount
 					values.reservedPercent = values.reservedPercent * activeSkill.activeMineCount
 				end
-				if activeSkill.skillTypes[SkillType.MultipleReservation] then
+				if activeSkill.skillTypes[SkillType.MultipleReservation] or isTotemAndAncestralBond then
 					local activeSkillCount, enabled = calcs.getActiveSkillCount(activeSkill)
 					values.count = activeSkillCount
 					local minionFreeSpiritCount = skillModList:Sum("BASE", skillCfg, "MinionFreeSpiritCount")

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -211,7 +211,7 @@ function calcs.doActorLifeManaSpiritReservation(actor)
 			pool.Mana.baseFlat = activeSkill.skillData.manaReservationFlat or activeSkill.activeEffect.grantedEffectLevel.manaReservationFlat or 0
 			pool.Spirit.baseFlat = activeSkill.skillData.spiritReservationFlat or activeSkill.activeEffect.grantedEffectLevel.spiritReservationFlat or 0
 			pool.Spirit.baseFlat = pool.Spirit.baseFlat + skillModList:Sum("BASE", skillCfg, "ExtraSpirit") *
-				((activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond")) and activeSkill.actor.modDB:Override(nil, "TotemsSummoned") or 1)
+				(activeSkill.skillTypes[SkillType.SummonsTotem] and modDB:Flag(nil, "AncestralBond") and calcs.getActiveSkillCount(activeSkill) or 1)
 			if skillModList:Flag(skillCfg, "ManaCostGainAsReservation") and activeSkill.activeEffect.grantedEffectLevel.cost then
 				pool.Spirit.baseFlat = skillModList:Sum("BASE", skillCfg, "ManaCostBase") + (activeSkill.activeEffect.grantedEffectLevel.cost.Mana or 0)
 			end
@@ -954,9 +954,6 @@ function calcs.defence(env, actor)
 	end
 	if actor == env.minion or actor == env.player then
 		calcs.doActorLifeManaSpirit(actor)
-		if modDB:Flag(nil, "AncestralBond") then -- need spirit for the perStat and need the override before reservation is calced
-			modDB:NewMod("TotemsSummoned", "OVERRIDE", 1, { type = "PerStat", stat = "Spirit", div = modDB:Sum("BASE", nil, "AncestralBondSpirit") })
-		end
 		calcs.doActorLifeManaSpiritReservation(actor)
 	end
 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4525,6 +4525,11 @@ local specialModList = {
 	["each totem applies (%d+)%% increased damage taken to enemies in their presence"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num, { type = "Multiplier", var = "TotemsSummoned" }) }) } end,
 	["totems gain %+(%d+)%% to (%w+) resistance"] = function(num, _, resistance) return { mod("Totem"..firstToUpper(resistance).."Resist", "BASE", num) } end,
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
+	["totems reserve (%d+) spirit each"] = function(num) return {
+		flag("AncestralBond"),
+		mod("AncestralBondSpirit", "BASE", num),
+		mod("ExtraSpirit", "BASE", num, { type = "SkillType", skillTypeList = { SkillType.SummonsTotem, SkillType.SummonsAttackTotem } })
+	} end,
 	-- Minions
 	["minions revive (%d+)%% faster"] = function(num) return { mod("MinionRevivalSpeed", "INC", num) } end,
 	["your strength is added to your minions"] = { flag("StrengthAddedToMinions") },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4527,7 +4527,6 @@ local specialModList = {
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
 	["totems reserve (%d+) spirit each"] = function(num) return {
 		flag("AncestralBond"),
-		mod("AncestralBondSpirit", "BASE", num),
 		mod("ExtraSpirit", "BASE", num, { type = "SkillType", skillTypeList = { SkillType.SummonsTotem, SkillType.SummonsAttackTotem } })
 	} end,
 	-- Minions

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4527,7 +4527,7 @@ local specialModList = {
 	["totems gain %+(%d+)%% to all elemental resistances"] = function(num) return { mod("TotemElementalResist", "BASE", num) } end,
 	["totems reserve (%d+) spirit each"] = function(num) return {
 		flag("AncestralBond"),
-		mod("ExtraSpirit", "BASE", num, { type = "SkillType", skillTypeList = { SkillType.SummonsTotem, SkillType.SummonsAttackTotem } })
+		mod("ExtraSpirit", "BASE", num, { type = "SkillType", skillType = SkillType.SummonsTotem })
 	} end,
 	-- Minions
 	["minions revive (%d+)%% faster"] = function(num) return { mod("MinionRevivalSpeed", "INC", num) } end,


### PR DESCRIPTION
### Description of the problem being solved:
Adds flat spirit reservation to all totems. Uses fullDPS activeSkillCount to scale the reservation.

### Steps taken to verify a working solution:
- Scales with skillCount
- Affected by Reservation Efficiency

### Link to a build that showcases this PR:
<pre>eNqtG9ty27byOf4KjmY6086RLV5EXTJ2z8iyHTu1E1ey49O-ZGASktCApEKCtpVO__3sAqRE6kbQbh4cEtxdLPaG3QV0_N-XgBtPNE5YFJ40rCOzYdDQi3wWTk8a93cXh73Gf389OL4lYvZ5cpoyjl_sXw_eHcsXw5uRmHiCxtf0ifJBKqKbyKcnDRGntGFwHDxpOEDV4yRJPpEAvj0w4c0aBkk8GvrD1fhVOKFxSDhLRMMICAvHkfeNig9xlM6Bt4bxxOizIn91c_t5dNcwBImnVHzJ-Te_Wg3g7d3xLScLGo8FEcYT4SlgAAsJvJ40BrBaMqVnJIC_jZYm-GkaJ6IK56jfz9HGc0r9PZCdHPAuEjQACI8GNBR3LNhN385xhjETNykXbM4ZjXfCt7s5wiUTwxkJPY31Aj-En92OdSEjUQ0JCp-dchCIFl2EvpqGTFBt8NuIJVFYi2st4GHKOdi7FuyIJjR-IoJpMjKMgkcW7pdJ38qhb0hIhlGiIWyEvKUx-JbYi2C51lFn-a-7hj6mXgTOWXfGmpjXbEL1IXVWtY5Ql5vXreN8rAtXm_DrGBpBnNKDHEcp328nvWXcGYt4jzl1V57wfR_kEu6Mvuwhl0NdhRqrOKNPEXqehv_H7DEVuwOh2-scObbT7XVtt7fyPxk2zi9vd6-q38thb2eLhHmE35AXFqQBBN878o3u5s117JUJTmcihJDzCtwLFtNXoA0j7uuiFRYJ-0mU6OLZVmcVLFh4SUJ_4HkpZA4LDd2S-FtIk0Q3BENIrcIorAOdfreYCtu59x5Br0JPl-p9GGf86GKMwMMx3Xjku1myTHP7JFmg0AtzIzqlYTbdQg_lmlJv9gG0NyJ73Mfq9Yvbgkb8Qcki6D7JrlHVkGxBTGWMKjF1jzpFxJqCQhRNQZkFETBI6HY7T6cMqLH63SjaVnIe0ni6GM8Y5X496FxaQzLXVH8Re58Z7JiuloaKqHqaKm2qerMtt7jzJ5JobUtKDgpaTwRPxKe6Sf0Nhey7FsZtHP1FPcF4PTRYBuf1MV452xmdcESLUIGwaWpj6E4wiIMojTW1p4C1lJdnCKqgHFE_9fSyl_PJBBf8RE851Ma6y1hiSWHXQh0IQbxvZ5E_rafRWhhl_sbpfA7hCj2hgsChaxaTH9j-mU7Ku4L9DF68L0wVJsA0SXeCFWyNCZapn-4sawhVU5mlzE17KSvgqgmsDXXeQJTEroZshtxEu_eR9irswD4FKh8Rn6XJDRXwrqFQKNO1am4JqFn730bPsN4ZNph2s-Bsg4asWIOVmIY_Ftr0S-BaE5yHPiTYIEvtOdYx9k1jrSKEVLVsY12zYJnHnKaTSWJAjp_QazCek0bD8KLgkYj87REAsmeFgb0vDn5_RgQx_Kyg-0JiRkJhSfNaG7SVzckm4QXjgsZnQA8XoMRASezN8ulWbxeE80cIatnExy3ZycSnu5hSg-SRyEPykjN8ydqVQH0BFansU175WS8TuABDpYU2ZDtreBZBrXzMl4VFGPk0gVGr07WbTt90us2e2-k33Z5j95t2u2e7Tbfdbnebjtnvwnin77jNds91AbxtOZ1mu-v0mwDgOE2r0-6YMGB1u822a5t2s91x3F7TdpweUu_1OkDAbLtN225b_Wa3D-CO1Xfhr93pAxmn2waQbtcym27f6XaaTs9qA-E2Uu-1zW6zY1l9BAHibt_sOzCd6wLBfruL_HaAUwsYs4Cu7fSARxMYcDsd18JubgKCWKjIkCh9YDeDxIvBqg2MkgkZL7WGleRQDe-O70fX8uHdTIh58r7Ven5-PpoTMYsm9AWShyOwsNYckECBh8k3xvkh6qU1gH-n0_vTj2P7j-DSnFF6--cft9wd9N3wibCLh9PfzuLYGtxdzz4mH3-zLrh4CHpd0v1C7y5fZr0f32PWfuiGvY93X0__5JfuYe_m4ttjYD2GZ97Cn45-jP6iU3IxFNY1THUimW3l3B6rNnbSUm8YRmMGuldLOYYdVrUk8g_gV_GnTeNQci5ax0672DSJDWNQmlLGoOzgDRYgda_Mq6h7NOeGwUKRrQYd-CV_zqTRKonjuIWuJp0SfREfxqjGJPdKfBlTkUWDCUm5-ABxRx0zhFEcLLsuGBhi_JicLiDeX2C-X266GsksesZkQ8HdLebI2OD6eg01P8xYzfd7SjgTC4wyKj5kbBmsYKxyEFbv8dSnV2G2R500JoQnVJ1vDFaLkitaGxsS7iXyAyePuEA8m8HmgJ-xlFkQcCRjMXBwFYKIMyf6vuLSkM6ArjSA6Aj2RfgDAbFHcX78AOE9g7phIQSxNQYKX7LBJSFVYd6lseB0k4RiX-nHNkvfd9LwojQU8rhDLfcDjx4Jt3I9lGVQgrHzwZAEWQhfzmFkKzbkkhvGlAYoEMgxiA87TusKRpMWar0lOYenrcJqwBYot5-d4myUtJHJC1WS27ykn9l7ZjrS5pWt5zvRF0afs21rLGLU_o8oym29r97-d9LouO0jt-20O-DLPaenxv84afRM88gxHbPdc7r9fjczd2DsjEEUjjHLSjJxyW3wKkBHMOgL_ndLYrQcZavqM4pnD43MQxEsd9A0oapn_UDJHOwBhxVFuXYEzWUptV3wnhEMi8V74_7T1e_35weX0XQGNnFwAeUB9Y0PMSUC_OrxIMsE3huQOBrmkXVkrYaGaQwcioMxxZIP0JZf7IPMg-HRPJASHdHv7w3zAITAmcdEgi9_Z8y9t_75G_KiKX1vHrn__GyZ5qHlmr_8hM4NnCRAOi_oDFXRrVDtIurA9xPjZ6tzaJu_GCIyfradQ7v7ywb2fyz3J_yO53xy_JIJQ9VCB5b5kxFjwQizquLMkOk1IJmIA6ZCw6mYHdwQFhhRWCIizQ8S8RGylMnbkPzhmaSbG2gJwq6EcCoh2pUQ7ibEsXTJpams4muFYUHo5RHAYmB7hE0YPSeUB8yY1wYGWppQzm_mvKgt-soHcJmY4UfMkRrbyHykz5Qb8nNr_4TXdLp9ur0MWjUwLiBH-lYL45RyUQMcl1CfoTqLHtRcslJ6EcWqnCJIOa2z6kvKg1oIGVN11n0a-Qsj6zDpY8FG9wTFXJ1pIlEHfsTCehqXCHZdBKe2Wzg1bcp-hfqM8TOZv8IWt-OpCKZ2d9zTiQ9xC_fzB4q9m0SVn3JnxSeZKah4F85TgXWAvIZzfnFxPry7-nKezxqwxPuK9TNehsmmUihhGjzSWAZJBSrzra9qOIMcq5YppFmck3mCmVSWk2J4zRIS3DIhZUgfEwV90sB0RH48g4yJ8USLGuw52aWZEi1JZ_VNhxIkWF7M0PKLhM5faIyd3-VXHVJ4Z2WTHcUL9vULl3AqZCUv-ZRIqS15COVu4UxhPxXcoMtEcERvKZCvEL4m3GxMW9lY-GBOl2wRisCiCPJoNmGegtHUeta5LcumfOS7n4a8L1TGV0M6yOo-UBk7G9OSqrx9tCZVNaZlX9QjizK2GtJBXp5JlQksh6Pwctlj20_pnNMB49h_XdPspyiUxg5-swTQIXgDYSfr4JQJfhYzGudfdCgtex7Jhvfk41qywrP7sphWp_kVa8HD6RJq4bi6yuvZhseWjnAr1FI8WC0Hs80j1_2ksiZ-iYga01RDlnyUVFA88qpYSXa4WV5E6cSzwlFkyB08RczfjBbrH99MUJ57_Qt84cnWv0BmeXapRUum1Wveko3tRFd1-S7se8GwBH4bEfS3t1FAt3sbBZkdamGPNhKR0d70Y4WZn6FsTDylyavxl-ctr6agToVejS4PrbRDP1isbPhsif3LT2-jNRZpeAYi2e8Vq0VVcKURO_RpqY2y1kKV_6ubcVtCW_HK3FsIwTZ-qZsv7qS0PLO9pITjheqIv43g9quBe1Wwkxbet0nnJPRzap_rZOm7pQeFMRCVx39neK8neROXsH0HiwKd41Ze0B3Ldqrh0wRqFZLtsxzPueZzGq64Hc-i54H_hCZ7BwpISg3YT5FQhyRIOX85HkbhhE2z5qt6ydqvciXLkbx1JpjgVO4-eJaR9cvK5eaBZVrF3mYicxsjXt1vN-gE6gEGnrDI60wvTUQUQD2a5CWz_E3DLOI-jZdlab_j5ggUpbW8wlAsBLej4oFzNlUU-gzZGEZxnM6x_BvGC6hOlrF4O4Xy1FhjFa-X6DGMNzs0eF01LrCYxopwL2fOxhy3ucdsRzDLCOsXOrYjdc0yWuEnKjvYMjckVr12u4yUn8jvQ8EL5kWjwH68lniD5W9g8vMIMQiCCO_3-DUJyAbC4h7sHYIN0OELfYXhfBUK2zIjbnah3nQ9s1OesZikV0w49iJ5gFRlg665YYTVJmW5WyTJcL-kvpxyiEd5Y8onWrwmbMr454lMS6r92dkeSio0sbbOrbeudkUgc3O12SHTZulWpZYZFCPVWtln6h_gD_FppbV31zxS3TmErU2evujFXJ8GUXgRxUE1y-shE_mrDhtOr7MZ02pHm_ys64ES-QOA-tyWb2bWMKT1C4g7JGp1y_OVy-XWcr9W-YN8-_XguLXx-8v_A9SYinc=</pre>
### After screenshot:
<img width="730" height="424" alt="image" src="https://github.com/user-attachments/assets/e525fe58-b577-4ae3-b8a9-bbaf705c9ad7" />

--

<img width="639" height="224" alt="image" src="https://github.com/user-attachments/assets/0ac6fcf1-77d6-475a-a368-f063805a426c" />

