### PR TITLE
Reduce EstimatePlayerProgress calls

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -172,7 +172,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 	end
 	self.controls.pointDisplay = new("Control", {"LEFT",self.anchorTopBarRight,"RIGHT"}, {function() return getPointDisplayX() end, 0, 0, 20})
 	self.controls.pointDisplay.width = function(control)
-		control.str, control.req = self:EstimatePlayerProgress()
 		return DrawStringWidth(16, "FIXED", control.str) + 8
 	end
 	self.controls.pointDisplay.Draw = function(control)
@@ -831,78 +830,80 @@ function buildMode:SyncLoadouts()
 end
 
 function buildMode:EstimatePlayerProgress()
-	local PointsUsed, AscUsed, SecondaryAscUsed, socketsUsed, weaponSet1Used, weaponSet2Used = self.spec:CountAllocNodes()
-	local extra = self.calcsTab.mainOutput and self.calcsTab.mainOutput.ExtraPoints or 0
-	local maxWeaponSets = self.maxWeaponSets
-	local extraWeaponSets = self.calcsTab.mainOutput and self.calcsTab.mainOutput.PassivePointsToWeaponSetPoints or 0
-	local usedMax, ascMax, secondaryAscMax, level, act = 99 + maxWeaponSets + extra, 8, 8, 1, 0
+	if self.spec then
+		local PointsUsed, AscUsed, SecondaryAscUsed, socketsUsed, weaponSet1Used, weaponSet2Used = self.spec:CountAllocNodes()
+		local extra = self.calcsTab.mainOutput and self.calcsTab.mainOutput.ExtraPoints or 0
+		local maxWeaponSets = self.maxWeaponSets
+		local extraWeaponSets = self.calcsTab.mainOutput and self.calcsTab.mainOutput.PassivePointsToWeaponSetPoints or 0
+		local usedMax, ascMax, secondaryAscMax, level, act = 99 + maxWeaponSets + extra, 8, 8, 1, 0
 
-	repeat
-		act = act + 1
-		level = m_min(m_max(PointsUsed + 1 -  self.acts[act].questPoints - extra - m_min(weaponSet1Used, weaponSet2Used), self.acts[act].level), 100)
-	until act == self.maxActs or level <= self.acts[act + 1].level
-	
-	if self.characterLevelAutoMode and self.characterLevel ~= level then
-		self.characterLevel = level
-		self.controls.characterLevel:SetText(self.characterLevel)
-		self.configTab:BuildModList()
-	end
+		repeat
+			act = act + 1
+			level = m_min(m_max(PointsUsed + 1 -  self.acts[act].questPoints - extra - m_min(weaponSet1Used, weaponSet2Used), self.acts[act].level), 100)
+		until act == self.maxActs or level <= self.acts[act + 1].level
 
-	-- Ascendancy points for lab
-	-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
-	local labSuggest = level < 33 and ""
-		or level < 55 and "\nLabyrinth: Normal Lab"
-		or level < 68 and "\nLabyrinth: Cruel Lab"
-		or level < 75 and "\nLabyrinth: Merciless Lab"
-		or level < 90 and "\nLabyrinth: Uber Lab"
-		or ""
-	
-	local normalPassives = PointsUsed - m_min(weaponSet1Used, weaponSet2Used)
-	if normalPassives > usedMax then InsertIfNew(self.controls.warnings.lines, "You have too many passive points allocated") end
-	if AscUsed > ascMax then InsertIfNew(self.controls.warnings.lines, "You have too many ascendancy points allocated") end
-	if SecondaryAscUsed > secondaryAscMax then InsertIfNew(self.controls.warnings.lines, "You have too many secondary ascendancy points allocated") end
+		if self.characterLevelAutoMode and self.characterLevel ~= level then
+			self.characterLevel = level
+			self.controls.characterLevel:SetText(self.characterLevel)
+			self.configTab:BuildModList()
+		end
 
-	-- if you are using more than maxWeaponSets + extraWeaponSets, you are using too many weapon sets
-	local warningsWeaponSet = false
-	if weaponSet1Used > (maxWeaponSets + extraWeaponSets) then
-		warningsWeaponSet = true
-		InsertIfNew(self.controls.warnings.lines, string.format(
-			"You have allocated %d too many weapon set 1 passives",
-			math.abs((maxWeaponSets + extraWeaponSets) - weaponSet1Used)
-		))
-	end
-	if weaponSet2Used > (maxWeaponSets + extraWeaponSets) then
-		warningsWeaponSet = true
-		InsertIfNew(self.controls.warnings.lines, string.format(
-			"You have allocated %d too many weapon set 2 passives",
-			math.abs((maxWeaponSets + extraWeaponSets) - weaponSet2Used)
-		))
-	end
+		-- Ascendancy points for lab
+		-- this is a recommendation for beginners who are using Path of Building for the first time and trying to map out progress in PoB
+		local labSuggest = level < 33 and ""
+			or level < 55 and "\nLabyrinth: Normal Lab"
+			or level < 68 and "\nLabyrinth: Cruel Lab"
+			or level < 75 and "\nLabyrinth: Merciless Lab"
+			or level < 90 and "\nLabyrinth: Uber Lab"
+			or ""
 
-	if not warningsWeaponSet and weaponSet1Used ~= weaponSet2Used then
-		InsertIfNew(self.controls.warnings.lines, string.format(
-			"You have %d Weapon set 2 passives available",
-			math.abs(weaponSet2Used - weaponSet1Used)
-		))
-	end
-	
-	self.Act = act == self.maxActs and "Endgame" or "Act " .. act
-	
-	return string.format(
-		"%s%3d / %3d %s%2d / %2d %s%2d / %2d   %s%d / %d",
-		normalPassives > usedMax and colorCodes.NEGATIVE or "^7",
-		normalPassives, usedMax,
-		colorCodes.NEGATIVE,
-		weaponSet1Used, maxWeaponSets + extraWeaponSets,
-		colorCodes.POSITIVE,
-		weaponSet2Used, maxWeaponSets + extraWeaponSets,
-		AscUsed > ascMax and colorCodes.NEGATIVE or "^7",
-		AscUsed, ascMax
-		), 
-		string.format(
+		local normalPassives = PointsUsed - m_min(weaponSet1Used, weaponSet2Used)
+		if normalPassives > usedMax then InsertIfNew(self.controls.warnings.lines, "You have too many passive points allocated") end
+		if AscUsed > ascMax then InsertIfNew(self.controls.warnings.lines, "You have too many ascendancy points allocated") end
+		if SecondaryAscUsed > secondaryAscMax then InsertIfNew(self.controls.warnings.lines, "You have too many secondary ascendancy points allocated") end
+
+		-- if you are using more than maxWeaponSets + extraWeaponSets, you are using too many weapon sets
+		local warningsWeaponSet = false
+		if weaponSet1Used > (maxWeaponSets + extraWeaponSets) then
+			warningsWeaponSet = true
+			InsertIfNew(self.controls.warnings.lines, string.format(
+				"You have allocated %d too many weapon set 1 passives",
+				math.abs((maxWeaponSets + extraWeaponSets) - weaponSet1Used)
+			))
+		end
+		if weaponSet2Used > (maxWeaponSets + extraWeaponSets) then
+			warningsWeaponSet = true
+			InsertIfNew(self.controls.warnings.lines, string.format(
+				"You have allocated %d too many weapon set 2 passives",
+				math.abs((maxWeaponSets + extraWeaponSets) - weaponSet2Used)
+			))
+		end
+
+		if not warningsWeaponSet and weaponSet1Used ~= weaponSet2Used then
+			InsertIfNew(self.controls.warnings.lines, string.format(
+				"You have %d Weapon set 2 passives available",
+				math.abs(weaponSet2Used - weaponSet1Used)
+			))
+		end
+
+		self.Act = act == self.maxActs and "Endgame" or "Act " .. act
+
+		self.controls.pointDisplay.str = string.format(
+			"%s%3d / %3d %s%2d / %2d %s%2d / %2d   %s%d / %d",
+			normalPassives > usedMax and colorCodes.NEGATIVE or "^7",
+			normalPassives, usedMax,
+			colorCodes.NEGATIVE,
+			weaponSet1Used, maxWeaponSets + extraWeaponSets,
+			colorCodes.POSITIVE,
+			weaponSet2Used, maxWeaponSets + extraWeaponSets,
+			AscUsed > ascMax and colorCodes.NEGATIVE or "^7",
+			AscUsed, ascMax
+		)
+		self.controls.pointDisplay.req = string.format(
 			"Required Level: %d\nEstimated Progress:\nAct: %s\nExtra Skillpoints: %d%s",
 			level, self.Act, extra, labSuggest
 		)
+	end
 end
 
 function buildMode:CanExit(mode)
@@ -2078,6 +2079,7 @@ function buildMode:RefreshStatList()
 	end
 	self:AddDisplayStatList(self.displayStats, self.calcsTab.mainEnv.player)
 	self:InsertItemWarnings()
+	self:EstimatePlayerProgress()
 end
 
 function buildMode:CompareStatList(tooltip, statList, actor, baseOutput, compareOutput, header, nodeCount)


### PR DESCRIPTION
### Description of the problem being solved:
We're calling EstimatePlayerProgress in a width function that is called onFrame all the time. It's a TON and I wanna stop that, so I'm moving the call to RefreshStatList which is called every buildFlag, which might still be too often but much much less.

Note during the first gif, the before, I hover over some tree nodes which spikes the kB usage. Keep an eye on the gain rate when nothing is happening towards the end of the gif and compare that to the after gain rate. PS: I don't know if this actually means anything, graphics have never been my strong suit 😆 

### Steps taken to verify a working solution:
- Validate progress string in top bar is accurate and warnings still work

### Link to a build that showcases this PR:
<pre>eNqtG1tX4kjzefdXcHiOkvtlD-4ebiozogg6jvMyJyYNZGwSJumozK__qroDBBVM4-cD00nq3l3VVdU9zf9e5rT2RNIsSuKTunas1mskDpIwiqcn9dub0yO3_t-_fzeHPptdTdp5RPGL_u_ffzX5Q4356ZSwbysC6k-tXguon2WX_pyc1Ed-PCVpvfYUkedBEsKb_mB4NboBoJmf-gEj6QV5IrSVs0R8Z2lO6rW5H8XjJHgk7CxN8gVIVq9RBISRCjL6WUDisLNhhAJOojgEZiDcX80h9ZckHTOf1TL4Oam3QEl_Srr-HH5BIJ_mBBU2Dc-zDE236o29iO08zZg89nhBSFhCcE13F-gwJb3JhAQseiKdNGKdmR8HG2Y7WbwDax7re8EHOWXRgkZ8agSKvgv-_A11dyftm4T5tDscb6ge27amGobhfICTsDWOugvyLmKzNgV7SnJAvP40jhg5AHGYRFkSH6hTGW2nWp2cUnCqSrAjkpH0yWfRtki7aSfzhyiWttjAj_1OklWYE4QckhS8kUkhjEmQgAPL8pDEvIgmpDqklB4Fgqw0h-nRG1eFkyZ8mEAjCIPVIMdJTitCslI0Up1dYF3ysgHbuYL78YajsYfWU4K-9LFwN2n0kDNSARBdv3c-3MR83TGODdXRHFDK2x39Z8ssCnw68F-ieT6HqHvjP5KNZJpjGLsX1nTGYoghO5E1a6elTqOUHILXSWh4EN7MT7JDtBxATnDux2ErCHJIHZZrJMc0d06wnz7GJMuqRlaIlJUx0J0rCQ45QPAPQvfj4OPtHAFv47QQp-L8T8gIvBczlQdKKuNs2BRRYIOpqvuZTUlccFxWs9QFIcHsDKZw5FdxI4z5G1vp3l7bInDZtnupvmPbPfS3MSTMhIjvm0k3j419WJKWGi8iyOiqiCQg31tb1XEkLNCLSTpdjmcRoWGFnagEvTJZx19U0R9WQBm7vBIctxo_qeVcRpWcrFG5fNgLJSvTk5-VNzLtA3sJ8LKpdhcmABySVzXA7nVPIEOXwhimyS-seqgcGuhBqTzGgdy6ZEIRLcGJhp22MkZVBq10nuRpxeUugCuFvFVeIUrXEQnzoFrGs65F2xQK8apqrLG4saVQW4z5wWM3CadyMyqFsS3fOF8sILKhK1QlgOkS5ApRKaM9sipAX4EfV4pnmFdVZ7CBrsxgnS1W5_IKpboumOu9YlMFuDKD9XQOIE7OYWPi_ZZBUm65qOaejktGYNZHfhjl2YAweC71UHanzFCxVyq_OWDFNsAweQalZ9hPy-SgIZneSL1TlJTEf5aV6W-BlxkYu3fFENJysGZlHq8x3mPTzieTrBYk8wefXcDKOKnXaw_wbjWGUiAjxYPAuInmsAVlWddnfi3jPcTTiDKSdgEKuaFEtbCo_L75aeTHTOMdxlcvdf4yI34azFb8Nk-nPqUPELAKxs0Gb4ji6CYlpOavokyAVLhk-FDuXPZDbLuJdimOVSSPNbifLlvbYHFEV4AxqBL7tECe-xk8L4UfZChhnIQEBrprurpiqJZlKYZrO6qia4ZhK5rtmTC2NFtXNNO2TAUKU1tVDFPDr5qh2orl2KqraPBKU3TPUnXF9DQP4KGWtRTdUYGybmueDfQdF6i5lusBF800FFNX8ce0gLmueaai65blKrbuuaZiWZ4BX4GhAUxcQLVsD8joIKuF4njw3rYtDcQxdAfGrmMrNhR4ClSUuq5Ypud5wNu0FMtwNE8BEXXAR80MqK9dfO1aSNB2QTpVdRTH8OCFCpiKYRugjGWYYALNcA1PsXQAAhMYpgtKegaorauokQqAmuEZDlDRTLCDo4OglucAMU1TTcW2dNcBXdDAmmmBwUBPtDIIDVY2waaWpXkqgICVQCET0DXVQrNbYFhLx2cNrGJoFuhjGgYwMD3DAr0N2wPauqMBQROEBj1tHeQ00VqGY6keyAyqK5YLE6RYqmnBG9dELVzNQ3uDtTTH8TQF8FEumDAwpWqDdTTLBTsDOxDR1TTgpzkwdaAuANqaAzNoqGgXUNcB0TUXNIKxhSKBpW0PtNA91TFBagf1MkFQTQXVFRfkwoViogwmWNj0dJDcQ6uAWgauIodTBkEsx9M1xVMNLgIoYpsesLVBD5gsFc3umY6Ha8jEtyAkTICLttIUsAKuVBAfjKMBrmGq4BEQxEnpPMJcHRaA6y_LziOOJgzumn81b0cXfPDXjLFF9k-j8fz8fLzw2SyZkBdIFo8hBDUW4H_g1EfZY0TpETJqtOCvPW11pndeJ9Ty7116eX8dvUTjX49H1_ry9K7z_Nu8nqr3xuDouTPNOnr89QcdmcOzI0aH7rVvf7-dBF_uz5_u-3qsm_FR_974PZoe3VBq3OZnp56ZndGpm7CH7x36faTZnXln3PZuWP_H_XikXb78-XXbvrr8w7qty-nPwU1v2Ht-6feyMy26jE-1p7vfU_vHoHc7dM_zYGCm7e-Db7126-aS3OWD7DLMwuzqq9vpZpNn8me-mA26l2pwNtfmLT1ZXNv0y9fTa_brF1On10-9-_ubx28_2fjl_u5KvVSzX7_aQTK5XPx5aRs_Avu-Nwi7Vrx4aj18PT8b_8773_oRyc6PstQdDuPn3jW9vzxrtb9cLCLypd1Xja-3P_Xe0dHjhfl9EHcGjpMvf5z1rrKOk_dGSfLT-D1ttfgENVYz1BTnQllDPGGqkEYQ8sT0NSGLFK261YdaFLNLERMhvrK0GAvHKfu2iJUiFPG1V_g2X8tlt-bxSPgzj0FFoOQOJjxGeIWIc8JlRNAsQiT3ceGtwiGFv4sQzAOoWPZFQOJRWoTRUnASsaTwYh6WRLwVniWckcdb3NdeVhYorNbYMluzgVsT38Rw78JBJ4kn0bTYxcTDmLD1VrZ-U2MRo4RXO35OIcuLwhUQ3_EDMoMMlaS1OJ8_kPSk7qo2SBTzQzsSk_myKHwau1GsLfjScdceHG2F05mBr46xssgqwWfRNKJXE55fARomMnvQXH1LNn6WWYnNfH0C141g74Zsi53BD1SkWDKE-2gY6ht7FOeSe5Be4ZTy8j1IzjZWUUImlPLYuXfKtjFflxz7tHsfcUjivXZd8wvJPIlPk3T-8Zx7tvU-s4_N-c48jlkexwR7VzCXdLlfWvUtfidPcRVsdc32zs22icVBs4S2uM4-VtR4g_PRTGjONp9VZ0pCtO2eheQ83EGCni5vs2pT8WqhlorvfVytd9hGbAZuHPJl10lyKEUJnVSSfTyDHU1-uaKsFSy0VhAriwjLm06SpvkCu1iddPlxjHtlolID5MBA15rPkw-j3MY6QQIV18fm0d-GRVxDd8Tn5zkfE4Aq6W2Q_NjAr_iuqszqToXzuHaqZmO9tfL9WDzhcIxJZ1bLZskztq2SlJ2R-c1ygdt66-Kivqo4EazYqmHj57syAF7nPo3YUhSZAjdrL7vD8erGzdbLU4w-r24PbGhdiIs4MQTZ9XllUeEWzIssQNTFQnAc9ucodo284D9DP0V5Jj7NhLGafQb8a3lGxEk0zNwiibkqAqjQEMFWCnJrMJ-t1laA1uAKcXkK0H00y_nKmCasmJkzmjxhDyMCCsMHyD0xe8QHUag33iC0k4TJwI_A_WqaLIIui2BIIAjj1LTa-Bl7bx_g8Sy8H8J33nLAj7zefYUoSH8hz4TWxPe3jC-InGYIL2M6SDGl4E-pnz1WkOgdE_C2yB4TiO9vWWILTE7INuHptowNdPnFoFdbDK8V0aUxDOn50Q5Y2jIGg52LyFj4nNC5FMLKxFJRJlzWVkdF-7CajSL2iZ5oCoXFmLcu7whmuZkIzTzi8nLPp4EoBfvxIscGbcpvgPZOT3udm_633no7j7LgJzZg8bZmwUqgvK2kMO7_FK8LyLE4QqsFUEP4C0jR1mE4yx8y8fGk_i0iz3zT6BLmRzQTQbrYW_BMTYoaxztf10ic1vl2yVSRUu-FpJg18QwzIoVc6ydpoYQIeMCLPWtBDS9CyhASh2YdP2PiAJpbalMKVKSCyVKhDg6lcGFT92nBuRhLW4JhGrMgQTSJAtzOy1OOKY54J2WX9SWhYr7LLYOKNPhdU0FADGWQxb1RgV2MpazK76sWVhVjGfQuCfxCdzGUQV7faUji86ho6azfSVG6TGK-yMFpWhHF87liZnuUrF_IELzCIqs47BCUBhCQVi8kHUf0CQs6pWcpW_FLYNxCOJJBFVecuA44knKa4s6P8PZI1mW3b-bw-XjTdahISlSChQ3LZWHVaVjtZeF6LKXJ6toLV6LcaajqKDwGt56SKBTn_9xlXr2UCxqQFX6eDL_U8H8gs7628nlaPOsqZroY70QvasoS9i2LsAD9HBH0sc9RQFf7HAWerh6MPVrnIKO96cf7fKeraLV6kMBfn7YfTEHcCTgYnbfUK2LvCv2wnnmRv4n96zdS8ZPlcRessXGMaqTeKsWlehU-PkdLbIv_J0WFvxd3rDcBQLyQJgTb-Pk6UTyU0vrKzjnxKf7_moR-juCbu-SVib3jniRI8oUfhytqV9vZ-aHWS1gGRPkNkS5e7Mw-JWWPNxr30Gk2VgVdk7fZav5iQeKNbONZ8twKn3DJ3oD9s_WHkGRQ4fjF3kzFWVbzMmHioBAprx74NRcs1Wp_kmR-f1I_0j31WPUMzzNt-HPq_EPRLPRWV2fGLOUHsTsbdxzr-0nd0OxjF--duDr88ftAzcab_4f4P7T-5tI=</pre>

### Before screenshot:
<img width="1284" height="749" alt="beforeEstimate" src="https://github.com/user-attachments/assets/72736767-40f5-4774-9ef1-e09a0443b323" />


### After screenshot:
<img width="1284" height="749" alt="afterEstimate" src="https://github.com/user-attachments/assets/ec5700f4-734c-4465-ad10-5e0190b7ee5f" />
