### PR TITLE
Add support for double Corrupting + fix corruptions removing anoints

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -54,8 +54,8 @@ for _, entry in pairs(data.flavourText) do
 end
 
 local function isAnointable(item)
-	return (item.canBeAnointed or item.base.type == "Amulet") and not item.sanctified
-		and not item.corrupted and not item.mirrored
+	return (item.canBeAnointed or item.base.type == "Amulet")
+		-- and not item.sanctified and not item.corrupted and not item.mirrored
 end
 
 local function buildModSortList()
@@ -916,7 +916,7 @@ holding Shift will put it in the second.]])
 		if not self.displayItem or not self.displayItem.rangeLineList[1] then
 			return 0
 		end
-		if main.showAllItemAffixes and self.displayItem.rarity == "UNIQUE" then
+		if main.showAllItemAffixes and (self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC") then
 			local count = #self.displayItem.rangeLineList
 			return count * 22 + 4
 		else
@@ -927,7 +927,8 @@ holding Shift will put it in the second.]])
 		self.controls.displayItemRangeSlider.val = self.displayItem.rangeLineList[index].range
 	end)
 	self.controls.displayItemRangeLine.shown = function()
-		return self.displayItem and self.displayItem.rangeLineList[1] ~= nil and not (main.showAllItemAffixes and self.displayItem.rarity == "UNIQUE")
+		return self.displayItem and self.displayItem.rangeLineList[1] ~= nil and
+		not (main.showAllItemAffixes and (self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC"))
 	end
 	self.controls.displayItemRangeSlider = new("SliderControl", {"LEFT",self.controls.displayItemRangeLine,"RIGHT"}, {8, 0, 100, 18}, function(val)
 		self.displayItem.rangeLineList[self.controls.displayItemRangeLine.selIndex].range = val
@@ -956,7 +957,9 @@ holding Shift will put it in the second.]])
 			return ""
 		end)
 		self.controls["displayItemStackedRangeSlider"..i].shown = function()
-			return main.showAllItemAffixes and self.displayItem and self.displayItem.rarity == "UNIQUE" and self.displayItem.rangeLineList[i] ~= nil
+			return main.showAllItemAffixes and self.displayItem and
+			(self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC") and
+			self.displayItem.rangeLineList[i] ~= nil
 		end
 
 		self.controls["displayItemStackedRangeLine"..i].shown = function()
@@ -2008,6 +2011,7 @@ function ItemsTabClass:UpdateDisplayItemRangeLines()
 	end
 end
 
+---@param line string
 local function checkLineForAllocates(line, nodes)
 	if nodes and string.match(line, "Allocates") then
 		local nodeId = tonumber(string.match(line, "%d+"))
@@ -2465,15 +2469,17 @@ end
 function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outcomes this code is for poe 1
 	local controls = { }
 	local enchantList = { }
-	local enchantNum = 1
+	local enchantNum = 2
 	local shownExplicits = {}
 	local explicitOffset = 0
 	local corruptedRanges = {}
 	local currentModType = "Corrupted"
 	local sourceList = { "Corrupted" }
 	local sortList, sortTransforms = buildModSortList()
+
 	if self.displayItem.base.type == "Helmet" then
 		t_insert(sourceList, "Glimpse of Chaos")
+		enchantNum = 8
 	end
 	local function buildEnchantList(modType)
 		if enchantList[modType] then
@@ -2528,6 +2534,17 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 				end
 			end
 		end
+
+		local temp = {}
+		-- currently enchants are always either corruptions or anoints, so we
+		-- can just save the anoints
+		for _, mod in ipairs(item.enchantModLines) do
+			if mod.line:match("Allocates .*") then
+				table.insert(temp, mod)
+			end
+		end
+		item.enchantModLines = temp
+
 		if #newEnchant > 0 then
 			table.sort(newEnchant, function(a, b)
 				return a.order < b.order
@@ -2553,7 +2570,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		end
 	end
 	local function rebuildEnchantControls(resetSelection)
-		for i = 1, 8 do
+		for i = 1, enchantNum do
 			local shown = i <= enchantNum
 			controls["enchant"..i].shown = shown
 			controls["enchant"..i.."Label"].shown = shown
@@ -2571,7 +2588,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 			end
 		end
 	end
-	local function corruptItem()
+	local function corruptItem(enchanting)
 		local item = new("Item", self.displayItem:BuildRaw())
 		item.id = self.displayItem.id
 		item.corrupted = true
@@ -2582,14 +2599,20 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 				t_insert(mods, control.list[control.selIndex].mod)
 			end
 		end
-		applyCorruptionMods(item, mods)
-		for i, modLine in ipairs(item.explicitModLines) do
-			if corruptedRanges[i] ~= 1 then modLine.corruptedRange = corruptedRanges[i] end
+		-- avoid removing corruption mods or rolls so that the user can make a
+		-- vaal rolled item with enchants
+		if enchanting then
+			applyCorruptionMods(item, mods)
+
+		else
+			for i, modLine in ipairs(item.explicitModLines) do
+				if corruptedRanges[i] ~= 1 then modLine.corruptedRange = corruptedRanges[i] end
+			end
 		end
 		item:BuildAndParseRaw()
 		return item
 	end
-	if self.displayItem.rarity == "UNIQUE" then
+	if self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC" then
 		local item = new("Item", self.displayItem:BuildRaw())
 		local offset = 20
 		for i, mod in ipairs(item.explicitModLines) do
@@ -2660,10 +2683,10 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		controls.save.y = 73 + 20 * enchantNum
 	end)
 	controls.enchants.shown = function ()
-		return self.displayItem.rarity == "UNIQUE"
+		return self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC"
 	end
 	controls.rolls = new("ButtonControl", {"LEFT", controls.enchants, "RIGHT"}, {5, 0, 80, 20}, "Roll Ranges", function()
-		for i = 1, 8 do
+		for i = 1, enchantNum do
 			controls["enchant"..i].shown = false
 			controls["enchant"..i.."Label"].shown = false
 		end
@@ -2681,7 +2704,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		controls.save.y = 25 + explicitOffset
 	end)
 	controls.rolls.shown = function ()
-		return self.displayItem.rarity == "UNIQUE"
+		return self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC"
 	end
 	controls.sourceLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {95, 30, 0, 16}, "^7Source:")
 	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {100, 30, 150, 18}, sourceList, function(index, value)
@@ -2696,7 +2719,6 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 				enchantNum = 2
 			end
 		end
-
 		if controls.sort then
 			sortEnchantList(controls.sort.list[controls.sort.selIndex].stat)
 		end
@@ -2710,7 +2732,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		sortEnchantList(value.stat)
 		rebuildEnchantControls()
 	end)
-	for i = 1, 8 do
+	for i = 1, enchantNum do
 		if i == 1 then
 			controls.enchant1Label = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {95, 55, 0, 16}, function()
 				if enchantNum == 1 then -- update label so 1 doesn't appear in case of 1 enchant.
@@ -2737,12 +2759,12 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 	end
 	rebuildEnchantControls()
 	controls.save = new("ButtonControl", nil, {-45, 69 + enchantNum * 20, 80, 20}, "Corrupted", function()
-		self:SetDisplayItem(corruptItem())
+		self:SetDisplayItem(corruptItem(controls.enchant1.shown))
 		main:ClosePopup()
 	end)
 	controls.save.tooltipFunc = function(tooltip)
 		tooltip:Clear()
-		self:AddItemTooltip(tooltip, corruptItem(), nil, true)
+		self:AddItemTooltip(tooltip, corruptItem(controls.enchant1.shown), nil, true)
 	end	
 	controls.close = new("ButtonControl", nil, {45, 69 + enchantNum * 20, 80, 20}, "Cancel", function()
 		main:ClosePopup()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2334,7 +2334,7 @@ end
 function ItemsTabClass:getAnoint(item)
 	local result = { }
 	if item then
-		for _, modList in ipairs{item.enchantModLines, item.implicitModLines, item.explicitModLines} do
+		for _, modList in ipairs{item.enchantModLines} do
 			for _, mod in ipairs(modList) do
 				local line = mod.line
 				local anoint = line:find("Allocates ([a-zA-Z ]+)")
@@ -2532,7 +2532,6 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 			table.sort(newEnchant, function(a, b)
 				return a.order < b.order
 			end)
-			wipeTable(item.enchantModLines)
 			for i, enchant in ipairs(newEnchant) do
 				enchant.order = nil
 				t_insert( item.enchantModLines, i, enchant)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2479,7 +2479,10 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 
 	if self.displayItem.base.type == "Helmet" then
 		t_insert(sourceList, "Glimpse of Chaos")
-		enchantNum = 8
+		if self.displayItem.title == "Glimpse of Chaos" then
+			currentModType = "SpecialCorrupted"
+			enchantNum = 8
+		end
 	end
 	local function buildEnchantList(modType)
 		if enchantList[modType] then
@@ -2487,7 +2490,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		end
 		enchantList[modType] = {}
 		for modId, mod in pairs(data.itemMods.Corruption) do
-			if mod.type == modType and self.displayItem:GetModSpawnWeight(mod) > 0 then
+			if mod.type == modType and (modType == "SpecialCorrupted" or self.displayItem:GetModSpawnWeight(mod) > 0) then
 				t_insert(enchantList[modType], { mod = mod })
 			end
 		end
@@ -2570,7 +2573,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		end
 	end
 	local function rebuildEnchantControls(resetSelection)
-		for i = 1, enchantNum do
+		for i = 1, 8 do
 			local shown = i <= enchantNum
 			controls["enchant"..i].shown = shown
 			controls["enchant"..i.."Label"].shown = shown
@@ -2686,7 +2689,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		return self.displayItem.rarity == "UNIQUE" or self.displayItem.rarity == "RELIC"
 	end
 	controls.rolls = new("ButtonControl", {"LEFT", controls.enchants, "RIGHT"}, {5, 0, 80, 20}, "Roll Ranges", function()
-		for i = 1, enchantNum do
+		for i = 1, 8 do
 			controls["enchant"..i].shown = false
 			controls["enchant"..i.."Label"].shown = false
 		end
@@ -2710,7 +2713,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {100, 30, 150, 18}, sourceList, function(index, value)
 		if value == "Corrupted" then
 			currentModType = "Corrupted"
-			enchantNum = 1
+			enchantNum = 2
 		elseif value == "Glimpse of Chaos" and self.displayItem.base.type == "Helmet" then -- special corruption enchants
 			currentModType = "SpecialCorrupted"
 			if self.displayItem.title == "Glimpse of Chaos" then -- glimpse of chaos can have all 8 special enchants
@@ -2727,12 +2730,13 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		controls.close.y = 73 + 20 * enchantNum
 		controls.save.y = 73 + 20 * enchantNum
 	end)
+	controls.source:SelByValue(currentModType == "SpecialCorrupted" and "Glimpse of Chaos" or "Corrupted")
 	controls.sortLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {350, 30, 0, 16}, "^7Sort by:")
 	controls.sort = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {355, 30, 240, 18}, sortList, function(index, value)
 		sortEnchantList(value.stat)
 		rebuildEnchantControls()
 	end)
-	for i = 1, enchantNum do
+	for i = 1, 8 do
 		if i == 1 then
 			controls.enchant1Label = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {95, 55, 0, 16}, function()
 				if enchantNum == 1 then -- update label so 1 doesn't appear in case of 1 enchant.

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4547,8 +4547,7 @@ c["Can Attack as though using a Quarterstaff while both of your hand slots are e
 c["Can Attack as though using a Quarterstaff while both of your hand slots are empty Unarmed Attacks that would use your Quarterstaff's damage gain: Physical damage based on their Skill Level 1% more Attack Speed per 75 Item Evasion Rating on Equipped Armour Items"]={nil,"Can Attack as though using a Quarterstaff while both of your hand slots are empty Unarmed Attacks that would use your Quarterstaff's damage gain: Physical damage based on their Skill Level 1% more Attack Speed per 75 Item Evasion Rating on Equipped Armour Items "}
 c["Can Attack as though using a Quarterstaff while both of your hand slots are empty Unarmed Attacks that would use your Quarterstaff's damage gain: Physical damage based on their Skill Level 1% more Attack Speed per 75 Item Evasion Rating on Equipped Armour Items +0.1% to Critical Hit Chance per 10 Item Energy Shield on Equipped Armour Items"]={{[1]={[1]={type="Condition",var="HollowPalm"},[2]={div=75,stat="EvasionOnAllArmourItems",type="PerStat"},flags=1,keywordFlags=0,name="Speed",type="MORE",value=1},[2]={[1]={type="Condition",var="HollowPalm"},[2]={div="10",stat="EnergyShieldOnAllArmourItems",type="PerStat"},flags=1,keywordFlags=0,name="CritChance",type="BASE",value=0.1}},nil}
 c["Can Socket a non-Unique Basic Jewel into the Phylactery"]={{},nil}
-c["Can be modified while Corrupted"]={nil,"Can be modified while Corrupted "}
-c["Can be modified while Corrupted +150 to maximum Life"]={nil,"Can be modified while Corrupted +150 to maximum Life "}
+c["Can be modified while Corrupted"]={{},nil}
 c["Can have 2 additional Instilled Modifiers"]={{},nil}
 c["Can have 3 additional Instilled Modifiers"]={{},nil}
 c["Can instead consume 25% of maximum Mana to trigger Charms with insufficient charges"]={nil,"Can instead consume 25% of maximum Mana to trigger Charms with insufficient charges "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6086,6 +6086,7 @@ local specialModList = {
 	} end,
 	["you can socket an additional copy of each lineage support gem, in different skills"] = { mod("MaxLineageCount", "BASE", 1) },
 	["you can socket (%d+) additional copies of each lineage support gem, in different skills"] = function(num) return { mod("MaxLineageCount", "BASE", num) } end,
+	["can be modified while corrupted"] = {}
 }
 for _, name in pairs(data.keystones) do
 	specialModList[name:lower()] = { mod("Keystone", "LIST", name) }


### PR DESCRIPTION
Fixes #1979.

### Description of the problem being solved:
- anointing now possible on corrupted item
- double corrupting possible as the e.g. adding enchants doesn't remove the roll multipliers and vice versa
- enchant count is now 2 for normal items. old corruption enchants are removed, but anoints are kept
- unique controls also now show up for foil uniques

### Steps taken to verify a working solution:
- Manually tested crafting items

### Link to a build that showcases this PR:
N/A item database used

### Before screenshot:
<img width="653" height="190" alt="image" src="https://github.com/user-attachments/assets/c3a6c632-1528-455d-92e2-22bcb061b94f" />

### After screenshot:
<img width="652" height="196" alt="image" src="https://github.com/user-attachments/assets/8f6dbae8-0ad3-4e6e-a5a6-bd1aabe12f06" />

Changes mostly non-visual