### PR TITLE
Pin calc stats to sidebar

### DIFF
--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -74,6 +74,7 @@ function CalcSectionClass:IsMouseOver()
 							return mOver, colData
 						end
 					elseif cursorX >= colData.x and cursorY >= colData.y and cursorX < colData.x + colData.width and cursorY < colData.y + colData.height then
+							colData.pinnedLabel = data.label
 						return mOver, colData
 					end
 				end
@@ -330,11 +331,19 @@ function CalcSectionClass:OnKeyDown(key, doubleClick)
 			return
 		end
 		if mOverComp then
+			--Add the stat to siderbar under "Pinned:"
+			if key == "RIGHTBUTTON" then
+				self.calcsTab:AddSidebarPinnedStat(mOverComp)
+				return
+			end
 			-- Pin the stat breakdown
-			self.calcsTab:SetDisplayStat(mOverComp, true)
-			return self.calcsTab.controls.breakdown
+			if key == "LEFTBUTTON" then
+				self.calcsTab:SetDisplayStat(mOverComp, true)
+				return self.calcsTab.controls.breakdown
+			end
 		end
 	end
+
 	return
 end
 

--- a/src/Classes/CalcSectionControl.lua
+++ b/src/Classes/CalcSectionControl.lua
@@ -333,7 +333,7 @@ function CalcSectionClass:OnKeyDown(key, doubleClick)
 		if mOverComp then
 			--Add the stat to siderbar under "Pinned:"
 			if key == "RIGHTBUTTON" then
-				self.calcsTab:AddSidebarPinnedStat(mOverComp)
+				self.calcsTab:ToggleSidebarPinnedStat(mOverComp)
 				return
 			end
 			-- Pin the stat breakdown

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -35,6 +35,16 @@ local CalcsTabClass = newClass("CalcsTab", "UndoHandler", "ControlHost", "Contro
 	self.controls.search = new("EditControl", {"TOPLEFT",self,"TOPLEFT"}, {4, 5, 260, 20}, "", "Search", "%c", 100, nil, nil, nil, true)
 	t_insert(self.controls, self.controls.search)
 
+
+	self.controls.clearSidebarLabel = new("LabelControl", {"TOPLEFT", self, "TOPLEFT"}, {425, 5, 150, 18}, "Right-click any Calcs value to pin/unpin it to the sidebar.")
+	self.controls.clearSideBarPinnedStats = new("ButtonControl", {"TOPLEFT", self, "TOPLEFT"}, {270, 5, 150, 20}, "Clear Pinned Stats", function()
+		if self.sidebarPinnedStats and #self.sidebarPinnedStats > 0 then
+			self:ClearSidebarPinnedStats()
+			return
+		end
+		
+	end)
+
 	-- Special section for skill/mode selection
 	self:NewSection(3, "SkillSelect", 1, colorCodes.NORMAL, {{ defaultCollapsed = false, label = "View Skill Details", data = {
 		{ label = "Socket Group", { controlName = "mainSocketGroup", 
@@ -411,7 +421,7 @@ function CalcsTabClass:SetDisplayStat(displayData, pin)
 	self.controls.breakdown:SetBreakdownData(displayData, pin)
 end
 
-function CalcsTabClass:AddSidebarPinnedStat(displayData)
+function CalcsTabClass:ToggleSidebarPinnedStat(displayData)
 	if not displayData or not displayData.format then
 		return
 	end
@@ -434,6 +444,14 @@ function CalcsTabClass:AddSidebarPinnedStat(displayData)
 
 	table.insert(self.sidebarPinnedStats, displayData)
 
+	self.build:RefreshStatList()
+end
+
+function CalcsTabClass:ClearSidebarPinnedStats()
+	if not self.sidebarPinnedStats or #self.sidebarPinnedStats == 0 then
+		return
+	end
+	wipeTable(self.sidebarPinnedStats)
 	self.build:RefreshStatList()
 end
 function CalcsTabClass:CheckFlag(obj)

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -411,6 +411,31 @@ function CalcsTabClass:SetDisplayStat(displayData, pin)
 	self.controls.breakdown:SetBreakdownData(displayData, pin)
 end
 
+function CalcsTabClass:AddSidebarPinnedStat(displayData)
+	if not displayData or not displayData.format then
+		return
+	end
+
+	self.sidebarPinnedStats = self.sidebarPinnedStats or { }
+
+	local displayLabel = displayData.pinnedLabel or ""
+	local displayFormat = displayData.format or ""
+
+	for index, pinned in ipairs(self.sidebarPinnedStats) do
+		local pinnedLabel = pinned.pinnedLabel or ""
+		local pinnedFormat = pinned.format or ""
+
+		if pinnedLabel == displayLabel and pinnedFormat == displayFormat then
+			table.remove(self.sidebarPinnedStats, index)
+			self.build:RefreshStatList()
+			return
+		end
+	end
+
+	table.insert(self.sidebarPinnedStats, displayData)
+
+	self.build:RefreshStatList()
+end
 function CalcsTabClass:CheckFlag(obj)
 	local actor = self.input.showMinion and self.calcsEnv.minion or self.calcsEnv.player
 	local skillFlags = actor.mainSkill.activeEffect.statSetCalcs.skillFlags

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -2257,6 +2257,16 @@ function buildMode:RefreshStatList()
 		t_insert(statBoxList, { height = 14, align = "CENTER_X", x = 140, self.calcsTab.mainEnv.player.mainSkill.disableReason })
 	end
 	self:AddDisplayStatList(self.displayStats, self.calcsTab.mainEnv.player)
+	if self.calcsTab.sidebarPinnedStats and #self.calcsTab.sidebarPinnedStats > 0 then
+		local actor = self.calcsTab.mainEnv.player
+		t_insert(statBoxList, { height = 10 })
+		t_insert(statBoxList, { height = 18, "^7Pinned:" })
+		for i, pinned in ipairs(self.calcsTab.sidebarPinnedStats) do
+			local label = pinned.pinnedLabel or ("Pinned " .. tostring(i))
+			local value = formatCalcStr(pinned.format, actor, pinned)
+			t_insert(statBoxList, { height = 16, "^7" .. label, "^7" .. tostring(value) })
+		end
+	end
 	self:InsertItemWarnings()
 	self:EstimatePlayerProgress()
 end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -2264,7 +2264,7 @@ function buildMode:RefreshStatList()
 		for i, pinned in ipairs(self.calcsTab.sidebarPinnedStats) do
 			local label = pinned.pinnedLabel or ("Pinned " .. tostring(i))
 			local value = formatCalcStr(pinned.format, actor, pinned)
-			t_insert(statBoxList, { height = 16, "^7" .. label, "^7" .. tostring(value) })
+			t_insert(statBoxList, { height = 16, "^7" .. label .. ":", "^7" .. tostring(value) })
 		end
 	end
 	self:InsertItemWarnings()

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -2260,7 +2260,7 @@ function buildMode:RefreshStatList()
 	if self.calcsTab.sidebarPinnedStats and #self.calcsTab.sidebarPinnedStats > 0 then
 		local actor = self.calcsTab.mainEnv.player
 		t_insert(statBoxList, { height = 10 })
-		t_insert(statBoxList, { height = 18, "^7Pinned:" })
+		t_insert(statBoxList, { height = 18, "^7Pinned Calcs:" })
 		for i, pinned in ipairs(self.calcsTab.sidebarPinnedStats) do
 			local label = pinned.pinnedLabel or ("Pinned " .. tostring(i))
 			local value = formatCalcStr(pinned.format, actor, pinned)


### PR DESCRIPTION
Fixes #1731 

### Description of the problem being solved:
The Calcs tab can be difficult to read at a glance when trying to monitor a small number of specific values. This adds a lightweight way to keep selected calculation values visible without requiring a custom layout system.

- Added the ability to pin/unpin Calcs tab values to the left sidebar by right-clicking them.
- Left-click behavior is unchanged and still pins/preserves the breakdown popup within calcs tab.
- Added a "Clear Pinned Stats" button next to the Calcs tab search field.
- Added helper text explaining that right-clicking a stat pins it to the sidebar.

### Steps taken to verify a working solution:
- Verified that right-clicking a Calcs tab value adds it to the pinned section in the sidebar.
- Verified that right-clicking the same value again removes it from the pinned section.
- Verified that the pinned sidebar values use the existing calc formatting and update correctly.
- Verified that left-clicking still preserves the existing breakdown popup behavior.
- Verified that the "Clear Pinned Stats" button removes all pinned values.

### Before screenshot:
<img width="1585" height="1154" alt="image" src="https://github.com/user-attachments/assets/06535781-7328-452e-8278-20e71039aa12" />


### After screenshot:
<img width="1620" height="1200" alt="image" src="https://github.com/user-attachments/assets/179f0380-ea81-4f30-b9f9-5fdfe3d5db42" />
