### PR TITLE
Fixes the damage calculation for Spectres and Tamed Beasts

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -293,7 +293,7 @@ describe("TestSkills", function()
 		local expectedPhysicalMax = round(build.calcsTab.mainEnv.data.monsterAllyDamageTable[minion.level] * (1 + minion.minionData.damageSpread))
 
 		assert.are.equals(expectedPhysicalMax, minion.weaponData1.PhysicalMax)
-		assert.are.equals(-30, minion.mainSkill.skillModList:Sum("MORE", minion.mainSkill.skillCfg, "Damage"))
+		assert.are.near(-30, minion.mainSkill.skillModList:Sum("MORE", minion.mainSkill.skillCfg, "Damage"), 0.0001)
 	end)
 
 	it("Inspiring Ally only mirrors companion damage, not generic minion damage", function()

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -285,6 +285,17 @@ describe("TestSkills", function()
 		assert.True(baseLeapSlamHit < build.calcsTab.mainOutput.AverageDamage)
 	end)
 
+	it("applies minion offensive multiplier to all attack damage", function()
+		build.skillsTab:PasteSocketGroup("Wolf Pack 20/0  1")
+		runCallback("OnFrame")
+
+		local minion = build.calcsTab.mainEnv.minion
+		local expectedPhysicalMax = round(build.calcsTab.mainEnv.data.monsterAllyDamageTable[minion.level] * (1 + minion.minionData.damageSpread))
+
+		assert.are.equals(expectedPhysicalMax, minion.weaponData1.PhysicalMax)
+		assert.are.equals(-30, minion.mainSkill.skillModList:Sum("MORE", minion.mainSkill.skillCfg, "Damage"))
+	end)
+
 	it("Inspiring Ally only mirrors companion damage, not generic minion damage", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 			New Item

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -898,9 +898,6 @@ skills["SummonBeastPlayer"] = {
 				summonBeast = true,
 				duration = true,
 			},
-			baseMods = {
-				mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3,
-			},
 			constantStats = {
 				{ "minion_base_resummon_time_ms", 12000 },
 			},

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -19767,9 +19767,6 @@ skills["SummonSpectrePlayer"] = {
 				spectre = true,
 				duration = true,
 			},
-			baseMods = {
-				mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3,
-			},
 			constantStats = {
 				{ "minion_base_resummon_time_ms", 12000 },
 				{ "spectre_warp_start_distance", 100 },

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -91,7 +91,6 @@ statMap = {
 #skill SummonBeastPlayer
 #set SummonBeastPlayer
 #flags spell minion summonBeast duration
-#baseMod mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3
 #mods
 #skillEnd
 

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1354,7 +1354,6 @@ statMap = {
 #skill SummonSpectrePlayer
 #set SummonSpectrePlayer
 #flags spell minion spectre duration
-#baseMod mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", 25) }), --Server side damage mod added in 0.3
 #mods
 #skillEnd
 

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -638,9 +638,13 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- The damage fixup stat applies x% less base Attack Damage and x% more base Attack Speed as confirmed by Openarl Jan 4th 2024
 	-- Implemented in this manner as the stat exists on the minion not the skills 
-	if activeSkill.actor and activeSkill.actor.minionData and activeSkill.actor.minionData.damageFixup then
-		skillModList:NewMod("Damage", "MORE", -100 * activeSkill.actor.minionData.damageFixup, "Damage Fixup", ModFlag.Attack)
-		skillModList:NewMod("Speed", "MORE", 100 * activeSkill.actor.minionData.damageFixup, "Damage Fixup", ModFlag.Attack)
+	if activeSkill.actor and activeSkill.actor.minionData then
+		if activeSkill.actor.minionData.damageFixup then
+			skillModList:NewMod("Damage", "MORE", -100 * activeSkill.actor.minionData.damageFixup, "Damage Fixup", ModFlag.Attack)
+			skillModList:NewMod("Speed", "MORE", 100 * activeSkill.actor.minionData.damageFixup, "Damage Fixup", ModFlag.Attack)
+		elseif activeSkill.actor.minionData.damage ~= 1 then
+			skillModList:NewMod("Damage", "MORE", (activeSkill.actor.minionData.damage - 1) * 100, activeSkill.actor.minionData.name .." Damage Multiplier", ModFlag.Attack)
+		end
 	end
 	if skillModList:Flag(activeSkill.skillCfg, "DisableSkill") and not skillModList:Flag(activeSkill.skillCfg, "EnableSkill") then
 		skillFlags.disable = true
@@ -881,7 +885,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			local attackTime = minion.minionData.attackTime
 			local damageTable = (monsterDamage or minion.minionData.hostile) and env.data.monsterDamageTable or env.data.monsterAllyDamageTable
 			minion.minionData.DamageFixup = monsterDamage and (round(env.data.monsterAllyDamageTable[minion.level] / damageTable[minion.level] * data.misc.SpectreBeastDamageFixup, 2) - 1) or 0
-			local damage = damageTable[minion.level] * minion.minionData.damage
+			local damage = damageTable[minion.level]
 			if not minion.minionData.baseDamageIgnoresAttackSpeed then -- minions with this flag do not factor attack time into their base damage
 				 damage = damage * attackTime
 			end

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -884,7 +884,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			end
 			local attackTime = minion.minionData.attackTime
 			local damageTable = (monsterDamage or minion.minionData.hostile) and env.data.monsterDamageTable or env.data.monsterAllyDamageTable
-			minion.minionData.DamageFixup = monsterDamage and (round(env.data.monsterAllyDamageTable[minion.level] / damageTable[minion.level] * data.misc.SpectreBeastDamageFixup, 2) - 1) or 0
+			minion.hiddenDamageFixup = monsterDamage and (round(env.data.monsterAllyDamageTable[minion.level] / damageTable[minion.level] * data.misc.SpectreBeastDamageFixup, 2) - 1) or 0
 			local damage = damageTable[minion.level]
 			if not minion.minionData.baseDamageIgnoresAttackSpeed then -- minions with this flag do not factor attack time into their base damage
 				 damage = damage * attackTime

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -819,13 +819,13 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	end
 
 	-- Create minion
-	local minionList, isSpectre, isBeastCompanion
+	local minionList, monsterDamage
 	if activeGrantedEffect.minionList and activeGrantedEffect.name:match("^Spectre") then
 			minionList = copyTable(env.build.spectreList)
-			isSpectre = true
+			monsterDamage = true
 	elseif activeGrantedEffect.minionList and activeGrantedEffect.name:match("^Companion") then
 			minionList = copyTable(env.build.beastList)
-			isBeastCompanion = true
+			monsterDamage = true
 	elseif activeGrantedEffect.minionList and activeGrantedEffect.minionList[1] then
 			minionList = copyTable(activeGrantedEffect.minionList)
 	else
@@ -879,7 +879,8 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				minion.lifeTable = env.data.monsterAllyLifeTable
 			end
 			local attackTime = minion.minionData.attackTime
-			local damageTable = (isSpectre or minion.minionData.hostile) and env.data.monsterDamageTable or env.data.monsterAllyDamageTable
+			local damageTable = (monsterDamage or minion.minionData.hostile) and env.data.monsterDamageTable or env.data.monsterAllyDamageTable
+			minion.minionData.DamageFixup = monsterDamage and (round(env.data.monsterAllyDamageTable[minion.level] / damageTable[minion.level] * data.misc.SpectreBeastDamageFixup, 2) - 1) or 0
 			local damage = damageTable[minion.level] * minion.minionData.damage
 			if not minion.minionData.baseDamageIgnoresAttackSpeed then -- minions with this flag do not factor attack time into their base damage
 				 damage = damage * attackTime

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1001,6 +1001,7 @@ function calcs.perform(env, skipEHP)
 		env.minion.modDB:NewMod("ProjectileCount", "BASE", 1, "Base")
 		env.minion.modDB:NewMod("PhysicalHeavyStunBuildup", "MORE", data.monsterConstants["physical_hit_damage_stun_multiplier_+%_final_from_ot"], "Physical Damage")
 		env.minion.modDB:NewMod("EnemyHeavyStunBuildup", "MORE", data.monsterConstants["melee_hit_damage_stun_multiplier_+%_final_from_ot"], "Melee Damage", ModFlag.Melee)
+		env.minion.modDB:NewMod("Damage", "MORE", env.minion.minionData.DamageFixup * 100, "Hidden Level Scaling")
 		for _, mod in ipairs(env.minion.minionData.modList) do
 			env.minion.modDB:AddMod(mod)
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1001,7 +1001,7 @@ function calcs.perform(env, skipEHP)
 		env.minion.modDB:NewMod("ProjectileCount", "BASE", 1, "Base")
 		env.minion.modDB:NewMod("PhysicalHeavyStunBuildup", "MORE", data.monsterConstants["physical_hit_damage_stun_multiplier_+%_final_from_ot"], "Physical Damage")
 		env.minion.modDB:NewMod("EnemyHeavyStunBuildup", "MORE", data.monsterConstants["melee_hit_damage_stun_multiplier_+%_final_from_ot"], "Melee Damage", ModFlag.Melee)
-		env.minion.modDB:NewMod("Damage", "MORE", env.minion.minionData.DamageFixup * 100, "Hidden Level Scaling")
+		env.minion.modDB:NewMod("Damage", "MORE", env.minion.hiddenDamageFixup * 100, "Hidden Level Scaling")
 		for _, mod in ipairs(env.minion.minionData.modList) do
 			env.minion.modDB:AddMod(mod)
 		end

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -246,6 +246,7 @@ data.misc = { -- magic numbers
 	PvpElemental2 = 150,
 	PvpNonElemental1 = 0.57,
 	PvpNonElemental2 = 90,
+	SpectreBeastDamageFixup = 1.25 -- 25% more damage server side mod added in 0.3
 }
 
 data.skillColorMap = { colorCodes.STRENGTH, colorCodes.DEXTERITY, colorCodes.INTELLIGENCE, colorCodes.NORMAL }


### PR DESCRIPTION
### Description of the problem being solved:
Spectres and Tamed Beasts use the monster damage values for their base damage stats but in an effort for GGG to have them equal the minion stats at the same level they have added a global damage multiplier to make them even
e.g. For level 42 monster
Monster Damage: 97.1
Minion Damage: 230.37 (2.37x)
So the spectre needs a 137% more damage multiplier
I also rolled the 25% more damage server side mod into this calc so that they are in 1 place

### Steps taken to verify a working solution:
- Confirm values in PoB are matching in-game screenshots
- 
<img width="621" height="460" alt="image" src="https://github.com/user-attachments/assets/778e65c4-982c-4160-a166-0d79e41c8460" />


### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/a315c10y

### Before screenshot:
<img width="714" height="193" alt="image" src="https://github.com/user-attachments/assets/c39a7775-6602-410d-8d76-b52b7804a216" />
<img width="438" height="52" alt="image" src="https://github.com/user-attachments/assets/9fce9dfb-804f-4ff9-ab0e-2db576c41fbf" />


### After screenshot:
<img width="711" height="192" alt="image" src="https://github.com/user-attachments/assets/074961fd-8e64-476c-adc0-f8b2cb04ecb1" />
<img width="636" height="66" alt="image" src="https://github.com/user-attachments/assets/10a03c29-8a77-41c4-84f2-bb885b1b8ac3" />

