### PR TITLE
Fix compare colors

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -705,12 +705,14 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			end
 		end
 
+		-- Compare added node color
 		if baseState == "Active" and state ~= "Active" then
 			state = "Active"
-			setConnectorColor(0, 1, 0)
+			setConnectorColor(0.00, 0.95, 1.00)
 		end
+		-- Compare removed node color
 		if baseState ~= "Active" and state == "Active" then
-			setConnectorColor(1, 0, 0)
+			setConnectorColor(1.00, 0.00, 0.85)
 		end
 
 		if baseState == "Intermediate" and spec.allocMode > 0 and not connector.ascendancyName then
@@ -1057,12 +1059,12 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				self:DrawAsset(base, scrX, scrY, scale)
 			else
 
-				if not self.showHeatMap and not launch.devModeAlt and not node.alloc then
+				if not self.showHeatMap and not launch.devModeAlt and not node.alloc and not (compareNode and compareNode.alloc) then
 					self:LessLuminance()
 				end
 
 				self:DrawAsset(base, scrX, scrY, scale)
-				if not self.showHeatMap and not launch.devModeAlt and not node.alloc then
+				if not self.showHeatMap and not launch.devModeAlt and not node.alloc and not (compareNode and compareNode.alloc) then
 					SetDrawColor(1, 1, 1, 1);
 				end
 			end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -705,12 +705,12 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			end
 		end
 
-		-- Compare added node color
+		-- Compare added nodes pathing color
 		if baseState == "Active" and state ~= "Active" then
 			state = "Active"
 			setConnectorColor(0.00, 0.95, 1.00)
 		end
-		-- Compare removed node color
+		-- Compare removed node pathing color
 		if baseState ~= "Active" and state == "Active" then
 			setConnectorColor(1.00, 0.00, 0.85)
 		end


### PR DESCRIPTION
- Fix added nodes in compare mode correctly appearing green
- Added/Removed node pathing in compare mode changed to teal/pink to distinguish from weapon set 1-2 point pathing (in green/red)

### Before screenshot:

<img width="1830" height="998" alt="image" src="https://github.com/user-attachments/assets/fc3d7f92-b8e8-440a-9020-5013042e4857" />


### After screenshot:

<img width="2206" height="1340" alt="image" src="https://github.com/user-attachments/assets/d30151f8-8cd0-4b8d-a6d9-d36aaf75a359" />

