### PR TITLE
Fix rangeless mods not getting pasted properly

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -461,7 +461,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				if #self.pendingAffixList == 0 and #backupAffixList > 0 then
 					self.pendingAffixList = backupAffixList
 				end
-				if #self.pendingAffixList == 0 and #backupAffixList == 0 then
+				if #self.pendingAffixList == 0 then
 					-- Could be a veiled, temple, or other custom mod, so just keep it around
 					linePrefix = "{custom}"
 				end
@@ -853,12 +853,17 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				end
 				if self.pendingAffixList and #self.pendingAffixList > 0 then
 					if #self.pendingAffixList > 1 then
-						-- Probably a conqueror mod since the mod name is the same for all of them
+						-- Probably a conqueror or Essence mod since the mod name is the same for all of them
 						-- Try to match the line against one of the mods there
 						local valueStrippedLine = line:gsub("%-?%d+%.?%d*%(", "("):gsub("%-?%d+%.?%d*", "#")
 						for _, pendingAffix in ipairs(self.pendingAffixList) do
 							local modData = self.affixes[pendingAffix.modId]
 							for _, modDataLine in ipairs(modData) do
+								-- Prefer the exact match
+								if line == modDataLine then
+									self.pendingAffixList = { pendingAffix }
+									break
+								end
 								if valueStrippedLine == modDataLine:gsub("%-?%d+%.?%d*", "#") then
 									self.pendingAffixList = { pendingAffix }
 									break
@@ -881,7 +886,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					end
 					t_insert(self.pendingAffixList[1].table, {
 						modId = self.pendingAffixList[1].modId,
-						range = tonumber(bestPrecisionRange),
+						range = bestPrecisionRange >= 0 and bestPrecisionRange <= 1 and bestPrecisionRange or 0.5,
 					})
 					self.pendingAffixList = {}
 				else
@@ -906,7 +911,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						end
 					end
 					if bestPrecisionRange <= 1 and bestPrecisionRange >= 0 then
-						modLine.range = tonumber(bestPrecisionRange)
+						modLine.range = bestPrecisionRange
 					end
 				end
 				local rangedLine = itemLib.applyRange(line, 1, catalystScalar, modLine.corruptedRange)


### PR DESCRIPTION
### Description of the problem being solved:
Mods that didn't have an advanced copy/paste range were disappearing when changing any of the item's sliders

Tested with the following items:
```
Item Class: Amulets
Rarity: Rare
Hate Scarab
Gold Amulet
--------
Quality (Defence Modifiers): +20% (augmented)
--------
Requires: Level 61
--------
Item Level: 79
--------
Allocates Stormcharged (enchant)
--------
{ Implicit Modifier }
14(12-20)% increased Rarity of Items found
--------
{ Prefix Modifier "Mirage's" (Tier: 1) — Defences  — 20% Increased }
47(45-50)% increased Evasion Rating
{ Prefix Modifier "Scintillating" (Tier: 2) — Defences  — 20% Increased }
+77(71-79) to maximum Energy Shield
{ Desecrated Prefix Modifier "Amanamu's" (Tier: 1) — Defences  — 20% Increased }
25(15-25)% increased Global Defences
{ Suffix Modifier "of Battle" (Tier: 1) — Attack }
+3 to Level of all Melee Skills
{ Suffix Modifier "of Archaeology" (Tier: 1) }
17(15-18)% increased Rarity of Items found
{ Suffix Modifier "of the Maelstrom" (Tier: 3) — Elemental, Lightning, Resistance }
+33(31-35)% to Lightning Resistance
```
```
Item Class: Quarterstaves
Rarity: Rare
Rapture Goad
Sinister Quarterstaff
--------
Quality: +20% (augmented)
Physical Damage: 66-109 (augmented)
Elemental Damage: 119-183 (cold), 19-417 (lightning)
Critical Hit Chance: 16.99% (augmented)
Attacks per Second: 1.40
--------
Requires: Level 67, 104 Dex, 41 Int
--------
Sockets: S S S S 
--------
Item Level: 81
--------
Adds 1 to 60 Lightning Damage (rune)
Gain 13% of Damage as Extra Chaos Damage (rune)
50% increased Attack Damage against Rare or Unique Enemies (rune)
Gain 5% of Damage as Extra Damage of all Elements (rune)
--------
{ Prefix Modifier "Crystalising" (Tier: 1) — Damage, Elemental, Cold, Attack }
Adds 119(112-124) to 183(168-189) Cold Damage
{ Prefix Modifier "Vapourising" (Tier: 1) — Damage, Elemental, Lightning, Attack }
Adds 18(1-19) to 357(310-358) Lightning Damage
{ Prefix Modifier "Devastating" (Tier: 1) — Damage, Elemental, Attack }
136(120-139)% increased Elemental Damage with Attacks
{ Fractured Suffix Modifier "of Unmaking" (Tier: 1) — Attack, Critical }
+4.99(4.41-5)% to Critical Hit Chance
{ Suffix Modifier "of the Essence" — Attack }
+5 to Level of all Attack Skills
{ Desecrated Suffix Modifier "of Destruction" (Tier: 1) — Damage, Attack, Critical }
+25(23-25)% to Critical Damage Bonus
--------
Corrupted
--------
Fractured Item
```