### PR TITLE
Fix Smith of Kitava Flowing Metal node not working

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2334,10 +2334,8 @@ function calcs.buildDefenceEstimations(env, actor)
 		if not modDB:Flag(nil, "ArmourDoesNotApplyTo" .. damageType .. "DamageTaken") then
 			percentOfArmourApplies = (modDB:Sum("BASE", nil, "ArmourAppliesTo" .. damageType .. "DamageTaken") or 0)
 		end
-		if not modDB:Flag(nil, "ArmourDoesNotApplyToElementalDamageTaken")
-			and (damageType == "Fire" or damageType == "Cold" or damageType == "Lightning") then
-			percentOfArmourApplies = percentOfArmourApplies
-				+ (modDB:Sum("BASE", nil, "ArmourAppliesToElementalDamageTaken") or 0)
+		if not modDB:Flag(nil, "ArmourDoesNotApplyToElementalDamageTaken") and (damageType == "Fire" or damageType == "Cold" or damageType == "Lightning") then
+			percentOfArmourApplies = percentOfArmourApplies + (modDB:Sum("BASE", nil, "ArmourAppliesToElementalDamageTaken") or 0)
 		end
 		local effectiveAppliedArmour = (output.Armour * percentOfArmourApplies / 100) * (1 + output.ArmourDefense)
 		local effectiveArmourFromArmour = effectiveAppliedArmour;

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2330,12 +2330,12 @@ function calcs.buildDefenceEstimations(env, actor)
 		--armour/PDR calculations
 		local armourReduct = 0
 		local impaleArmourReduct = 0
-		local percentOfArmourApplies = 0.0
-		if not modDB:Flag(nil, "ArmourDoesNotApplyTo" .. damageType .. "DamageTaken") then
-			percentOfArmourApplies = (modDB:Sum("BASE", nil, "ArmourAppliesTo" .. damageType .. "DamageTaken") or 0)
+		local percentOfArmourApplies = 0
+		if not modDB:Flag(nil, "ArmourDoesNotApplyTo"..damageType.."DamageTaken") then
+			percentOfArmourApplies = modDB:Sum("BASE", nil, "ArmourAppliesTo"..damageType.."DamageTaken")
 		end
-		if not modDB:Flag(nil, "ArmourDoesNotApplyToElementalDamageTaken") and (damageType == "Fire" or damageType == "Cold" or damageType == "Lightning") then
-			percentOfArmourApplies = percentOfArmourApplies + (modDB:Sum("BASE", nil, "ArmourAppliesToElementalDamageTaken") or 0)
+		if isElemental[damageType] and not modDB:Flag(nil, "ArmourDoesNotApplyToElementalDamageTaken") then
+			percentOfArmourApplies = percentOfArmourApplies + modDB:Sum("BASE", nil, "ArmourAppliesToElementalDamageTaken")
 		end
 		local effectiveAppliedArmour = (output.Armour * percentOfArmourApplies / 100) * (1 + output.ArmourDefense)
 		local effectiveArmourFromArmour = effectiveAppliedArmour;

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -2330,7 +2330,15 @@ function calcs.buildDefenceEstimations(env, actor)
 		--armour/PDR calculations
 		local armourReduct = 0
 		local impaleArmourReduct = 0
-		local percentOfArmourApplies = (not modDB:Flag(nil, "ArmourDoesNotApplyTo"..damageType.."DamageTaken") and modDB:Sum("BASE", nil, "ArmourAppliesTo"..damageType.."DamageTaken") or 0)
+		local percentOfArmourApplies = 0.0
+		if not modDB:Flag(nil, "ArmourDoesNotApplyTo" .. damageType .. "DamageTaken") then
+			percentOfArmourApplies = (modDB:Sum("BASE", nil, "ArmourAppliesTo" .. damageType .. "DamageTaken") or 0)
+		end
+		if not modDB:Flag(nil, "ArmourDoesNotApplyToElementalDamageTaken")
+			and (damageType == "Fire" or damageType == "Cold" or damageType == "Lightning") then
+			percentOfArmourApplies = percentOfArmourApplies
+				+ (modDB:Sum("BASE", nil, "ArmourAppliesToElementalDamageTaken") or 0)
+		end
 		local effectiveAppliedArmour = (output.Armour * percentOfArmourApplies / 100) * (1 + output.ArmourDefense)
 		local effectiveArmourFromArmour = effectiveAppliedArmour;
 		local effectiveArmourFromOther = { }


### PR DESCRIPTION
Fixes #2015 .

### Description of the problem being solved:

Seems the node grants armour elemental DR, but the calc only summed individual element DR mods

### Steps taken to verify a working solution:
- Tested using pob linked in issue
- Tests pass

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="642" height="293" alt="image" src="https://github.com/user-attachments/assets/d94dca51-1fc0-41a5-b5a1-7810ae4606ee" />
<img width="719" height="287" alt="image" src="https://github.com/user-attachments/assets/6a0f24c8-6141-4b79-b8a5-5a1a1f2fbb03" />

