### PR TITLE
Fix issue creating Loadouts with link identifiers

### DIFF
--- a/spec/System/TestLoadouts_spec.lua
+++ b/spec/System/TestLoadouts_spec.lua
@@ -33,6 +33,22 @@ describe("TestLoadouts", function()
 				assert.are.equals(2, build.configTab.activeConfigSetId)
 				assert.is_true(build.modFlag)
 			end)
+
+			it("Creates a new loadout with the correct name and sets it as active when the name has a link identifier",
+				function()
+					local loadoutName = "Loadout Name {1}"
+					build:NewLoadout(loadoutName)
+					build:SyncLoadouts()
+					assert.are.equals(1, #build.loadoutsList) -- Link identifiers are not yet supported in the loadoutsList
+					-- assert.are.equals(loadoutName, build.loadoutsList[2].title)
+					assert.are.equals(7, #build.controls.buildLoadouts.list)
+					assert.are.equals(loadoutName, build.controls.buildLoadouts.list[3])
+					assert.are.equals(2, build.treeTab.activeSpec)
+					assert.are.equals(2, build.itemsTab.activeItemSetId)
+					assert.are.equals(2, build.skillsTab.activeSkillSetId)
+					assert.are.equals(2, build.configTab.activeConfigSetId)
+					assert.is_true(build.modFlag)
+				end)
 		end)
 
 		describe("CopyLoadout", function()
@@ -658,6 +674,16 @@ describe("TestLoadouts", function()
 				buildSetService:NewLoadout(loadoutName)
 				assert.are.equals(2, #build.loadoutsList)
 				assert.are.equals(loadoutName, build.loadoutsList[2].title)
+				assert.is_true(build.modFlag)
+			end)
+
+			it("creates a new loadout with a linkIdentifier", function()
+				local loadoutName = "Loadout Name {1}"
+				buildSetService:NewLoadout(loadoutName)
+				assert.are.equals(1, #build.loadoutsList) -- link identifiers are not yet supported in the loadoutsList
+				-- assert.are.equals(loadoutName, build.loadoutsList[2].title)
+				assert.are.equals(7, #build.controls.buildLoadouts.list)
+				assert.are.equals(loadoutName, build.controls.buildLoadouts.list[3])
 				assert.is_true(build.modFlag)
 			end)
 		end)

--- a/src/Classes/BuildSetService.lua
+++ b/src/Classes/BuildSetService.lua
@@ -9,7 +9,6 @@ end)
 
 function BuildSetServiceClass:NewLoadout(name)
 	self.buildMode:NewLoadout(name)
-	self.buildMode:SyncLoadouts()
 end
 
 function BuildSetServiceClass:CopyLoadout(copyLoadoutName, newName)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -760,6 +760,7 @@ function buildMode:NewLoadout(loadoutName)
 
 	newSpec.title = loadoutName
 	t_insert(self.treeTab.specList, newSpec)
+	self:SyncLoadouts() -- Sync loadouts to update the dropdown with the new loadout and select it
 	self:SetActiveLoadout(self:GetLoadoutByName(loadoutName))
 
 	self.modFlag = true


### PR DESCRIPTION

Fixes #2032 

### Description of the problem being solved:

* Syncs the Loadouts to rebuild the treeListSpecialLinks before selecting the loadout. This rebuilds the special links when the user is creating a new loadout with a link identifier.
* Calls out in testing that the link identifier loadouts are still not supported in the Management dialog and therefore are not included in the loadoutsList.

### Steps taken to verify a working solution:
- Create new loadout with a link identifier. Ex: "New Loadout {1}"
