### PR TITLE
Fix Amazon's Critical Strike

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2613,7 +2613,7 @@ function calcs.offence(env, actor, activeSkill)
 			local cannotBeEvaded = skillModList:Flag(cfg, "CannotBeEvaded") or skillData.cannotBeEvaded or (env.mode_effective and enemyDB:Flag(nil, "CannotEvade"))
 			output.AccuracyHitChance = (cannotBeEvaded and 100) or calcs.hitChance(enemyEvasion, accuracyVsEnemy) * hitChanceMod
 			-- Accounting for mods that enable "Chance to hit with Attacks can exceed 100%"
-			local exceedsHitChance = skillModList:Flag(nil,"Condition:HitChanceCanExceed100") and calcs.hitChance(enemyEvasion, (m_floor(accuracyVsEnemyBase * accuracyPenalties["accuracyPenalty" .. distances[1] .. "m"])) * hitChanceMod) -- Check for flag and at least 100% hit chance at minimum distance
+			local exceedsHitChance = skillModList:Flag(cfg, "Condition:HitChanceCanExceed100") and calcs.hitChance(enemyEvasion, (m_floor(accuracyVsEnemyBase * accuracyPenalties["accuracyPenalty" .. distances[1] .. "m"])) * hitChanceMod) -- Check for flag and at least 100% hit chance at minimum distance
 			output.AccuracyHitChanceUncapped = exceedsHitChance and m_max(calcs.hitChance(enemyEvasion, accuracyVsEnemy, true) * calcLib.mod(skillModList, cfg, "HitChance"), output.AccuracyHitChance) -- keep higher chance in case of "CannotBeEvaded"
 			local handCondition = (pass.label == "Off Hand") and "OffHandAttack" or "MainHandAttack"
 			if exceedsHitChance and output.AccuracyHitChanceUncapped - 100 > 0 then


### PR DESCRIPTION
Fixes #2010 

### Description of the problem being solved:
We fixed a typo in 0.16 in the ModParser:2715 for the flag in Amazon's Critical Strike that changed the flag from a global/modDB flag to a skillType/skillModList flag, but in CalcOffence where we pull that flag we aren't passing in the skill config so it never catches it.

### Link to a build that showcases this PR:
<pre>https://pobb.in/zR53CdqLtKa4</pre>

### After screenshot:
<img width="776" height="262" alt="image" src="https://github.com/user-attachments/assets/fb4869ea-6cc8-436d-9fd3-5ca73376d541" />
<img width="981" height="288" alt="image" src="https://github.com/user-attachments/assets/aa057bbf-277c-405e-8002-f4194200c41a" />
