### PR TITLE
Fix Comet not showing DPS values

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -3697,6 +3697,10 @@ skills["CometPlayer"] = {
 			incrementalEffectiveness = 0.12999999523163,
 			damageIncrementalEffectiveness = 0.0096000004559755,
 			statDescriptionScope = "comet",
+			statMap = {
+				["base_skill_show_average_damage_instead_of_dps"] = {
+				},
+			},
 			baseFlags = {
 				area = true,
 				spell = true,
@@ -3767,6 +3771,10 @@ skills["CometPlayer"] = {
 			incrementalEffectiveness = 0.12999999523163,
 			damageIncrementalEffectiveness = 0.0096000004559755,
 			statDescriptionScope = "comet",
+			statMap = {
+				["base_skill_show_average_damage_instead_of_dps"] = {
+				},
+			},
 			baseFlags = {
 				area = true,
 				spell = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -267,9 +267,17 @@ statMap = {
 #skill CometPlayer
 #set CometPlayer
 #flags area spell
+statMap = {
+	["base_skill_show_average_damage_instead_of_dps"] = {
+	},
+},
 #mods
 #set CometFireInfusionPlayer
 #flags area spell
+statMap = {
+	["base_skill_show_average_damage_instead_of_dps"] = {
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:
The skill has the only show average damage flag on it so I gave it a blank stat map to stop it from hiding the DPS calcs

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/k06x0d0y

### Before screenshot:
<img width="305" height="263" alt="image" src="https://github.com/user-attachments/assets/812a0173-d59c-41d8-87a3-4f8664eb889f" />

### After screenshot:
<img width="308" height="278" alt="image" src="https://github.com/user-attachments/assets/0d2cddae-e338-46f6-96ad-55d8d3487f94" />
