### PR TITLE
Fix crash on trying to use Trarthan Cannon

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -271,10 +271,13 @@ local function checkAsThoughWeaponTypes(weaponData, weaponTypes)
 end
 
 -- Get weapon flags and info for given weapon
-local function getWeaponFlags(env, weaponData, weaponTypes)
+local function getWeaponFlags(env, weaponData, weaponTypes, gemTags)
 	local info = env.data.weaponTypeInfo[weaponData.type]
 	if not info then
 		return
+	end
+	if weaponData.cannotUseGemTag and gemTags and gemTags[weaponData.cannotUseGemTag] then
+		return nil, info
 	end
 	if weaponTypes then
 		for _, types in ipairs(weaponTypes) do
@@ -379,6 +382,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	local skillTypes = activeSkill.skillTypes
 	local activeEffect = activeSkill.activeEffect
 	local activeGrantedEffect = activeEffect.grantedEffect
+	local gemTags = activeEffect.gemData and activeEffect.gemData.tags
 	local activeStatSet, skillFlags
 	if env.mode == "CALCS" then
 		activeStatSet = activeEffect.statSetCalcs.statSet
@@ -461,7 +465,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				t_insert(weaponTypes, skillEffect.grantedEffect.weaponTypes)
 			end
 		end
-		local weapon1Flags, weapon1Info = getWeaponFlags(env, activeSkill.actor.weaponData1, weaponTypes)
+		local weapon1Flags, weapon1Info = getWeaponFlags(env, activeSkill.actor.weaponData1, weaponTypes, gemTags)
 		if not weapon1Flags and activeSkill.summonSkill then
 			-- Minion skills seem to ignore weapon types
 			weapon1Flags, weapon1Info = ModFlag[env.data.weaponTypeInfo["None"].flag], env.data.weaponTypeInfo["None"]
@@ -483,7 +487,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			activeSkill.disableReason = "Main Hand weapon is not usable with this skill"
 		end
 		if not skillTypes[SkillType.MainHandOnly] and not skillFlags.forceMainHand then
-			local weapon2Flags, weapon2Info = getWeaponFlags(env, activeSkill.actor.weaponData2, weaponTypes)
+			local weapon2Flags, weapon2Info = getWeaponFlags(env, activeSkill.actor.weaponData2, weaponTypes, gemTags)
 			if weapon2Flags then
 				if skillTypes[SkillType.DualWieldRequiresDifferentTypes] and (activeSkill.actor.weaponData1.type == activeSkill.actor.weaponData2.type) then
 					-- Skill requires a different compatible off hand weapon to main hand weapon

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -282,6 +282,9 @@ end
 ---@return number
 local function calcCrossbowReloadTime(weaponData, boltSkill)
 	local baseReloadTime = weaponData.ReloadTime
+	if not baseReloadTime then
+		return
+	end
 
 	local reloadTimeMulti = calcLib.mod(boltSkill.skillModList, boltSkill.skillCfg, "ReloadSpeed", "Speed" )
 	return baseReloadTime / reloadTimeMulti
@@ -2861,7 +2864,7 @@ function calcs.offence(env, actor, activeSkill)
 				output.Speed = m_min(output.Speed, data.misc.ServerTickRate * output.Repeats)
 			end
 			-- Crossbows: Adjust attack speed values for Crossbow skills that need to reload
-			if skillData.reloadTime then
+			if skillData.reloadTime and skillData.reloadTime > 0 then
 				output.FiringRate = output.Speed
 				output.BoltCount = skillData.boltCount
 				output.EffectiveBoltCount = output.BoltCount
@@ -2907,7 +2910,7 @@ function calcs.offence(env, actor, activeSkill)
 				-- Crossbows: adjust breakdown to account for effect of reload time, bolt count, etc.
 				-- note: if we are ever allowed to dual wield crossbows, this will need to be adjusted
 				-- TODO: properly reflect effects of "SkillAttackTime" mods in the breakdown. (This is also not currently done in the standard breakdown.Speed calculation)
-				if output.ReloadTime then
+				if output.ReloadTime and source.ReloadTime then
 					globalBreakdown.FiringRate = { }
 					breakdown.multiChain(globalBreakdown.FiringRate, {
 						base = { "%.2f ^8(base)", 1 / baseTime },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3416,6 +3416,7 @@ local specialModList = {
 	} end,
 	["has (%d+) sockets?"] = function(num) return { mod("SocketCount", "BASE", num) } end,
 	["no physical damage"] = { mod("WeaponData", "LIST", { key = "PhysicalMin" }), mod("WeaponData", "LIST", { key = "PhysicalMax" }), mod("WeaponData", "LIST", { key = "PhysicalDPS" }) },
+	["cannot load or fire ammunition"] = { mod("WeaponData", "LIST", { key = "cannotUseGemTag", value = "ammunition" }) },
 	["has (%d+)%% increased elemental damage"] = function(num) return { mod("LocalElementalDamage", "INC", num) } end,
 	["all attacks with this weapon are critical hits"] = { mod("WeaponData", "LIST", { key = "CritChance", value = 100 }) },
 	["this weapon's critical hit chance is (%d+)%%"] = function(num) return { mod("WeaponData", "LIST", { key = "CritChance", value = num }) } end,


### PR DESCRIPTION
Fixes #2047

### Description of the problem being solved:
We assumed that all crossbows would have the reload time stats but this new base type doesn't have it
Added checks to CalcOffence to make sure that value exists now
Also add proper support for the weapon implicit so all ammo skills can't be used with it

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/wh71yh0y

### Before screenshot:
<img width="908" height="357" alt="image" src="https://github.com/user-attachments/assets/23ed6cfd-4fa1-4977-a0cd-d3be4aa4c5bc" />

### After screenshot:
<img width="716" height="147" alt="image" src="https://github.com/user-attachments/assets/a278d272-ea88-42a3-b9e7-d2c0f143ffb8" />
