### PR TITLE
Change tests to run in parallel + cache cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,33 @@ jobs:
   run_tests:
     runs-on: ubuntu-latest
     container: ghcr.io/pathofbuildingcommunity/pathofbuilding-tests:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run tests
-        run: busted --lua=luajit
+        run: |
+          set -eu
+          shard_count=3
+          shard="${{ matrix.shard }}"
+          index=0
+          found=0
+          for spec in $(find spec/System -name '*_spec.lua' | sort); do
+            if [ $((index % shard_count)) -eq "$shard" ]; then
+              found=1
+              echo "::group::$spec"
+              if ! busted --lua=luajit "../$spec"; then
+                echo "::endgroup::"
+                exit 1
+              fi
+              echo "::endgroup::"
+            fi
+            index=$((index + 1))
+          done
+          [ "$found" -eq 1 ]
   check_modcache:
     runs-on: ubuntu-latest
     container: ghcr.io/pathofbuildingcommunity/pathofbuilding-tests:latest

--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -205,6 +205,9 @@ build = mainObject.main.modes["BUILD"]
 
 -- Here's some helpful helper functions to help you get started
 function newBuild()
+	if GlobalCache and GlobalCache.cachedData then
+		wipeGlobalCache()
+	end
 	mainObject.main:SetMode("BUILD", false, "Help, I'm stuck in Path of Building!")
 	runCallback("OnFrame")
 end


### PR DESCRIPTION
The tests before ran in one run without a global cache cleanup
This change cuts the peak memory usage from 1.23GB to 940MB which hopefully is enough for the tests to stop failing
