### PR TITLE
Fix Crafted mods not importing from items

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -329,6 +329,18 @@ describe("TestItemParse", function()
 		assert.truthy(item.explicitModLines[1].custom)
 	end)
 
+	it("crafted", function()
+		local item = new("Item", raw("{crafted}+8 to Strength"))
+		assert.truthy(item.explicitModLines[1].crafted)
+	end)
+
+	it("preserves crafted mod lines when rebuilding raw text", function()
+		local item = new("Item", raw("+8 to Strength"))
+		item.explicitModLines[1].crafted = true
+		item:BuildAndParseRaw()
+		assert.truthy(item.explicitModLines[1].crafted)
+	end)
+
 	it("enchant", function()
 		local item = new("Item", raw("+8 to Strength (enchant)"))
 		assert.are.equals(1, #item.enchantModLines)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1240,6 +1240,14 @@ function ImportTabClass:ImportItem(itemData, slotName)
 			end
 		end
 	end
+	if itemData.craftedMods then
+		for _, line in ipairs(itemData.craftedMods) do
+			for line in line:gmatch("[^\n]+") do
+				local modList, extra = modLib.parseMod(line)
+				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, crafted = true })
+			end
+		end
+	end
 
 	if itemData.grantedSkills then
 		for _, grantedSkillInfo in ipairs(itemData.grantedSkills) do

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -64,7 +64,7 @@ local ItemClass = newClass("Item", function(self, raw, rarity, highQuality)
 end)
 
 local lineFlags = {
-	["custom"] = true, ["fractured"] = true, ["desecrated"] = true, ["mutated"] = true, ["enchant"] = true, ["implicit"] = true, ["rune"] = true, ["unscalable"] = true
+	["custom"] = true, ["crafted"] = true, ["fractured"] = true, ["desecrated"] = true, ["mutated"] = true, ["enchant"] = true, ["implicit"] = true, ["rune"] = true, ["unscalable"] = true
 }
 
 local function baseHasImplicitLine(base, line)
@@ -1362,6 +1362,9 @@ function ItemClass:BuildRaw()
 		end
 		if modLine.mutated then
 			line = "{mutated}" .. line
+		end
+		if modLine.crafted then
+			line = "{crafted}" .. line
 		end
 		if modLine.unscalable then
 			line = "{unscalable}" .. line

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -14,6 +14,7 @@ colorCodes = {
 	GEMINFO = "^x6F9A98",
 	PROPHECY = "^xB54BFF",
 	CURRENCY = "^xAA9E82",
+	CRAFTED = "^xB8DAF1",
 	ENCHANTED = "^xB8DAF1",
 	CUSTOM = "^x5CF0BB",
 	SOURCE = "^x88FFFF",

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -335,7 +335,7 @@ function itemLib.formatModLine(modLine, dbMode)
 			line = line .. "   ^1'" .. modLine.extra .. "'"
 		end
 	else
-		colorCode = (modLine.enchant and colorCodes.ENCHANTED) or (modLine.fractured and colorCodes.FRACTURED) or (modLine.mutated and colorCodes.MUTATED) or (modLine.custom and (not modLine.desecrated and colorCodes.CUSTOM)) or colorCodes.MAGIC
+		colorCode = (modLine.crafted and colorCodes.CRAFTED) or (modLine.enchant and colorCodes.ENCHANTED) or (modLine.fractured and colorCodes.FRACTURED) or (modLine.mutated and colorCodes.MUTATED) or (modLine.custom and (not modLine.desecrated and colorCodes.CUSTOM)) or colorCodes.MAGIC
 	end
 	return colorCode..line
 end


### PR DESCRIPTION
### Description of the problem being solved:
Add the crafted mod import section to the import tab
For some reason we removed the parsing of crafted mods from some of the item mod logic so I added it back along with the colour for crafted mods

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldur/character/Ghazzy-0404/GhazzyTV_Zoomancer?i=1&search=class%3DSpirit%2BWalker%26name%3Dghaz

### Before screenshot:
<img width="506" height="424" alt="image" src="https://github.com/user-attachments/assets/dacbfd3f-5d5d-4bf9-a489-5cdedec1f830" />

### After screenshot:
<img width="509" height="356" alt="image" src="https://github.com/user-attachments/assets/15c2ab1a-e7f0-410a-ac02-b05ddd04fc38" />
