### PR TITLE
Add support for Eye of Winter ground damage buffs

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -6847,6 +6847,13 @@ skills["EyeOfWinterPlayer"] = {
 			incrementalEffectiveness = 0.12999999523163,
 			damageIncrementalEffectiveness = 0.0074000000022352,
 			statDescriptionScope = "eye_of_winter_new",
+			statMap = {
+				["eye_of_winter_damage_%_to_gain_as_element_per_ground_effect_type"] = {
+					mod("SkillDamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterCold"}),
+					mod("SkillDamageGainAsFire", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterFire"}),
+					mod("SkillDamageGainAsLightning", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterLightning"}),
+				},
+			},
 			baseFlags = {
 				spell = true,
 				projectile = true,
@@ -8115,6 +8122,8 @@ skills["FlameWallPlayer"] = {
 			damageIncrementalEffectiveness = 0.0096000004559755,
 			statDescriptionScope = "flame_wall",
 			baseFlags = {
+				spell = true,
+				area = true,
 			},
 			constantStats = {
 				{ "number_of_allowed_firewalls", 3 },

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -466,6 +466,13 @@ statMap = {
 #skill EyeOfWinterPlayer
 #set EyeOfWinterPlayer
 #flags spell projectile
+statMap = {
+	["eye_of_winter_damage_%_to_gain_as_element_per_ground_effect_type"] = {
+		mod("SkillDamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterCold"}),
+		mod("SkillDamageGainAsFire", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterFire"}),
+		mod("SkillDamageGainAsLightning", "BASE", nil, 0, 0, { type = "Condition", var = "EyeOfWinterLightning"}),
+	},
+},
 #mods
 #skillEnd
 
@@ -562,7 +569,7 @@ statMap = {
 
 #skill FlameWallPlayer
 #set FlameWallPlayer
-#flags
+#flags spell area
 #mods
 #set FlameWallProjectileBuffPlayer
 #flags

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -357,6 +357,16 @@ local configSettings = {
 	{ var = "embraceMadnessActive", type = "check", label = "Is Embrace Madness active?", ifSkill = "Embrace Madness", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AffectedByGloriousMadness", "FLAG", true, "Config")
 	end },
+	{ label = "Eye of Winter:", ifSkill = "Eye of Winter" },
+	{ var = "eyeOfWinterCold", type = "check", label = "Eye of Winter gained ^x3F6DB3Cold^7 Damage:", ifSkill = "Eye of Winter", tooltip = "Eye of Winter has passed over ^x3F6DB3Cold^7 Ground Effect or Orb.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:EyeOfWinterCold", "FLAG", true, "Config")
+	end },
+	{ var = "eyeOfWinterFire", type = "check", label = "Eye of Winter gained ^xB97123Fire^7 Damage:", ifSkill = "Eye of Winter", tooltip = "Eye of Winter has passed over ^xB97123Fire^7 Ground Effect or Orb.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:EyeOfWinterFire", "FLAG", true, "Config")
+	end },
+	{ var = "eyeOfWinterLightning", type = "check", label = "Eye of Winter gained ^xADAA47Lightning^7 Damage:", ifSkill = "Eye of Winter", tooltip = "Eye of Winter has passed over ^xADAA47Lightning^7 Ground Effect or Orb.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:EyeOfWinterLightning", "FLAG", true, "Config")
+	end },
 	{ var = "touchedDebuffsCount", type = "countAllowZero", label = "Glorious Madness Stacks", ifOption = "embraceMadnessActive", defaultState = 10, tooltip = "Glorious Madness Stacks grants:\n\tEroding Touch: 6% inc Damage Taken per stack\n\tParalysing Touch: 6% reduced Action Speed per stack\n\tDiluting Touch: 9% reduced Flask charges gained and 9% reduced Flask Effect per stack\n\tWasting Touch: 9% reduced ^xE05030Life ^7and ^x88FFFFEnergy Shield ^7recovery rate per stack", apply = function(val, modList, enemyModList)
 		val = m_min(val, 10)
 		modList:NewMod("DamageTaken", "INC", val * 6, val.." Eroding Touch Stacks", { type = "GlobalEffect", effectType = "Debuff" }, { type = "Condition", var = "AffectedByGloriousMadness" })


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for the damage gain mods granted by the eye going over different ground types
Also adds flags for flame wall damage

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/3u8vne0y
### Before screenshot:
<img width="307" height="291" alt="image" src="https://github.com/user-attachments/assets/39af3a65-eb15-4706-a341-7e99f02766f3" />

### After screenshot:
<img width="369" height="182" alt="image" src="https://github.com/user-attachments/assets/4a14fd27-c76d-4f49-8856-4b671860502d" />
<img width="628" height="362" alt="image" src="https://github.com/user-attachments/assets/f76d6f6d-7082-4a4f-8bf3-0214bd74b437" />
