### PR TITLE
Fix Jewel mod sorting not working

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2136,7 +2136,7 @@ local function checkLineForAllocates(line, nodes)
 end
 
 function ItemsTabClass:AddModComparisonTooltip(tooltip, mod)
-	local slotName = self.displayItem:GetPrimarySlot()
+	local slotName = self:GetComparisonSlotNameForItem(self.displayItem)
 	local newItem = new("Item", self.displayItem:BuildRaw())
 
 	for _, subMod in ipairs(mod) do
@@ -2166,6 +2166,21 @@ function ItemsTabClass:GetEquippedSlotForItem(item)
 			end
 		end
 	end
+end
+
+function ItemsTabClass:GetComparisonSlotNameForItem(item)
+	local equippedSlot = self:GetEquippedSlotForItem(item)
+	if equippedSlot then
+		return equippedSlot.slotName
+	end
+	if item.type == "Jewel" then
+		for _, slot in ipairs(self.orderedSlots) do
+			if not slot.inactive and slot.selItemId == 0 and slot:IsShown() and self:IsItemValidForSlot(item, slot.slotName) then
+				return slot.slotName
+			end
+		end
+	end
+	return item:GetPrimarySlot()
 end
 
 -- Check if the given item could be equipped in the given slot, taking into account possible conflicts with currently equipped items
@@ -2685,7 +2700,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 	end
 	local function sortEnchantList(stat)
 		if stat then
-			local slotName = self.displayItem:GetPrimarySlot()
+			local slotName = self:GetComparisonSlotNameForItem(self.displayItem)
 			local calcFunc = self.build.calcsTab:GetMiscCalculator()
 			local useFullDPS = stat == "FullDPS"
 			sortModList(enchantList[currentModType], stat, function(listMod)
@@ -2913,7 +2928,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		end
 		local selected = not selectFirst and modList[controls.modSelect.selIndex] or nil
 		if stat then
-			local slotName = self.displayItem:GetPrimarySlot()
+			local slotName = self:GetComparisonSlotNameForItem(self.displayItem)
 			local calcFunc = self.build.calcsTab:GetMiscCalculator()
 			local useFullDPS = stat == "FullDPS"
 			sortModList(modList, stat, function(listMod)


### PR DESCRIPTION
### Description of the problem being solved:
The sorting of mods on jewels wasn't working, as we were using the wrong slot name.
The logic now chooses an empty slot, then an active slot if it exists so

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/dva7k306

### Before screenshot:
<img width="933" height="214" alt="image" src="https://github.com/user-attachments/assets/737a1b23-95e4-4395-94c0-f53a86b60a8c" />

### After screenshot:
<img width="1012" height="233" alt="image" src="https://github.com/user-attachments/assets/9a5d9d3c-cde9-45bc-b6e0-9bdeaa4b3fb2" />
