### PR TITLE
Fix some bonded Rune affects applying without Wisdom of the Maji

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -460,6 +460,22 @@ describe("TestItemParse", function()
 		end
 	end)
 
+	it("keeps bonded rune stats separate from normal rune stats", function()
+		local item = new("Item", [[
+			Rarity: Rare
+			Test Body
+			Rusted Cuirass
+		]])
+		item.itemSocketCount = 1
+		item.runes = { "Lesser Body Rune" }
+		item:UpdateRunes()
+
+		assert.are.equals(3, #item.runeModLines)
+		assert.are.equals("+30 to maximum Life", item.runeModLines[1].line)
+		assert.are.equals("Bonded: +20 to maximum Life", item.runeModLines[2].line)
+		assert.are.equals("Bonded: +20 to maximum Mana", item.runeModLines[3].line)
+	end)
+
 	it("multi-line rune mod", function()
 		-- Thruldana is Bow-only as well
 		local item = new("Item", [[

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1519,10 +1519,11 @@ function ItemClass:UpdateRunes()
 			for _, mod in ipairs(gatheredMods) do
 				for i, modLine in ipairs(mod) do
 					local order = mod.statOrder[i]
-					if statOrder[order] then
+					local orderKey = modLine:match("^Bonded:") and "Bonded:"..order or order
+					if statOrder[orderKey] then
 						-- Combine stats
 						local start = 1
-						statOrder[order].line = statOrder[order].line:gsub("(%d%.?%d*)", function(num)
+						statOrder[orderKey].line = statOrder[orderKey].line:gsub("(%d%.?%d*)", function(num)
 							local s, e, other = mod[i]:find("(%d%.?%d*)", start)
 							start = e + 1
 							return tonumber(num) + tonumber(other)
@@ -1535,7 +1536,7 @@ function ItemClass:UpdateRunes()
 								break
 							end
 						end
-						statOrder[order] = modLine
+						statOrder[orderKey] = modLine
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #2051

### Description of the problem being solved:
The logic for combining Rune stats on gear wasn't check to see if a mod was bonded before merging the stat
We now use a separate key so they no longer merge with each other but will merge correctly with other rune mods of the same type

### Before screenshot:
<img width="362" height="308" alt="image" src="https://github.com/user-attachments/assets/ae9221ec-2168-4d6a-8d4a-648c1074e8e4" />

### After screenshot:
<img width="357" height="354" alt="image" src="https://github.com/user-attachments/assets/c188707d-452e-4a9d-bfb5-26b417709b00" />
