### PR TITLE
Fix Shrine sceptre Auras not making linked buffs have no Spirit cost

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -94,6 +94,13 @@ describe("TestSkills", function()
 		assert.True(build.calcsTab.mainOutput.SpiritReservedPercent > oneCurseReservation)
 	end)
 
+	it("applies active skill reservation multiplier to linked buff spirit reservation", function()
+		build.skillsTab:PasteSocketGroup("Purity of Fire 20/0  1\nVitality II 1/0  1\n")
+		runCallback("OnFrame")
+
+		assert.are.equals(0, build.calcsTab.mainOutput.SpiritReserved)
+	end)
+
 	it("Keeps Virtuous armour scaling during Full DPS loop", function()
 		build.itemsTab:CreateDisplayItemFromRaw("New Item\nRazor Quarterstaff\nQuality: 0")
 		build.itemsTab:AddDisplayItem()

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -751,6 +751,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 
 	-- Add extra modifiers from granted effect level
 	local level = activeEffect.grantedEffectLevel
+	if level.reservationMultiplier then
+		skillModList:NewMod("ReservationMultiplier", "MORE", level.reservationMultiplier, activeGrantedEffect.modSource)
+	end
 	activeSkill.skillData.CritChance = level.critChance
 	if level.damageMultiplier then
 		skillModList:NewMod("Damage", "MORE", level.damageMultiplier, activeEffect.grantedEffect.modSource, ModFlag.Attack)


### PR DESCRIPTION
Fixes #2066

### Description of the problem being solved:
The purity auras granted by the Shrine sceptre bases all have a reservation multiplier of -100 so the buffs linked to them have no spirit cost

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/nb9qnr0y

### Before screenshot:
<img width="702" height="152" alt="image" src="https://github.com/user-attachments/assets/075dd5fe-dc16-473e-94e3-f6d4509cee38" />

### After screenshot:
<img width="697" height="154" alt="image" src="https://github.com/user-attachments/assets/f7d5e55a-ff6c-4896-b9aa-a6ac04fe6e8c" />
