### PR TITLE
Disable right click to paste in the notes tab

### DIFF
--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -520,7 +520,7 @@ function EditClass:OnKeyDown(key, doubleClick)
 				self:ReplaceSel("")
 			end
 		end
-	elseif key == "v" and ctrl or key == "RIGHTBUTTON" and self.Object:IsMouseOver() then
+	elseif key == "v" and ctrl or key == "RIGHTBUTTON" and self.Object:IsMouseOver() and not self.disableRightClickPaste then
 		local text = Paste()
 		if text then
 			if self.pasteFilter then

--- a/src/Classes/NotesTab.lua
+++ b/src/Classes/NotesTab.lua
@@ -32,6 +32,7 @@ Below are some common color codes PoB uses:	]]
 	self.controls.default = new("ButtonControl", {"TOPLEFT",self.controls.intelligence,"TOPLEFT"}, {120, 0, 100, 18}, "^7DEFAULT", function() self:SetColor("^7") end)
 
 	self.controls.edit = new("EditControl", {"TOPLEFT",self.controls.fire,"TOPLEFT"}, {0, 48, 0, 0}, "", nil, "^%C\t\n", nil, nil, 16, true)
+	self.controls.edit.disableRightClickPaste = true
 	self.controls.edit.width = function()
 		return self.width - 16
 	end


### PR DESCRIPTION
Fixes #2082

### Description of the problem being solved:
Right clicking pastes text into any of the input boxes but feels like it shouldn't exist in the notes tab