### PR TITLE
Fix crash when clicking on empty rune list

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1954,6 +1954,7 @@ function ItemsTabClass:UpdateRuneControls()
 	local item = self.displayItem
 	-- Build rune selection for item
 	local runes = self:GetValidRunesForItem(item)
+	local runesUpdated = false
 
 	for i = 1, item.itemSocketCount do
 		self.controls["displayItemRune"..i].list = runes
@@ -1967,10 +1968,15 @@ function ItemsTabClass:UpdateRuneControls()
 			end
 			if not found then
 				self.controls["displayItemRune"..i].selIndex = 1
+				item.runes[i] = "None"
+				runesUpdated = true
 			end
 		else
 			self.controls["displayItemRune"..i].selIndex = 1
 		end
+	end
+	if runesUpdated then
+		item:UpdateRunes()
 	end
 end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1737,7 +1737,6 @@ function ItemsTabClass:CopyAnointsAndAugments(newItem, copyAugments, overwrite, 
 				for i = 1, #newItem.sockets do
 					newItem.runes[i] = "None"
 					if currentRunes[i] then
-						local found = false
 						for _, rune in ipairs(validRunes) do
 							-- we only copy runes which fit the new item type
 							if rune.name == currentRunes[i] then

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1939,10 +1939,16 @@ function ItemsTabClass:UpdateRuneControls()
 	for i = 1, item.itemSocketCount do
 		self.controls["displayItemRune"..i].list = runes
 		if item.runes[i] then
+			local found = false
 			for j, modLine in ipairs(self.controls["displayItemRune"..i].list) do
 				if item.runes[i] == modLine.name then
 					self.controls["displayItemRune"..i].selIndex = j
+					found = true
 				end
+			end
+			-- ensure that outdated rune selections from previous display items get reset
+			if not found then
+				self.controls["displayItemRune"..i].selIndex = 1
 			end
 		else
 			self.controls["displayItemRune"..i].selIndex = 1

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1729,10 +1729,23 @@ function ItemsTabClass:CopyAnointsAndAugments(newItem, copyAugments, overwrite, 
 				newItem.itemSocketCount = #newItem.sockets
 				newItem:UpdateRunes()
 			end
+
+			local validRunes = self:GetValidRunesForItem(newItem)
+
 			-- replace runes with current ones, or set to none
 			if shouldChangeAugments then
 				for i = 1, #newItem.sockets do
-					newItem.runes[i] = currentRunes[i] or "None"
+					newItem.runes[i] = "None"
+					if currentRunes[i] then
+						local found = false
+						for _, rune in ipairs(validRunes) do
+							-- we only copy runes which fit the new item type
+							if rune.name == currentRunes[i] then
+								newItem.runes[i] = currentRunes[i]
+								break
+							end
+						end
+					end
 				end
 				newItem:UpdateRunes()
 			end
@@ -1900,10 +1913,8 @@ table.sort(runeModLines, function(a, b)
 		return a.group < b.group
 	end
 end)
--- Update rune selection controls
-function ItemsTabClass:UpdateRuneControls()
-	local item = self.displayItem
-	-- Build rune selection for item
+
+function ItemsTabClass:GetValidRunesForItem(item)
 	local runes = { }
 	for _, rune in pairs(runeModLines) do
 		local subType = item.base.subType and item.base.subType:lower()
@@ -1935,6 +1946,14 @@ function ItemsTabClass:UpdateRuneControls()
 				end
 		end
 	end
+	return runes
+end
+
+-- Update rune selection controls
+function ItemsTabClass:UpdateRuneControls()
+	local item = self.displayItem
+	-- Build rune selection for item
+	local runes = self:GetValidRunesForItem(item)
 
 	for i = 1, item.itemSocketCount do
 		self.controls["displayItemRune"..i].list = runes
@@ -1946,7 +1965,6 @@ function ItemsTabClass:UpdateRuneControls()
 					found = true
 				end
 			end
-			-- ensure that outdated rune selections from previous display items get reset
 			if not found then
 				self.controls["displayItemRune"..i].selIndex = 1
 			end


### PR DESCRIPTION
Fixes #2089 .

### Description of the problem being solved:

Dropdowns weren't being updated if no matching rune was found

### Steps taken to verify a working solution:
- tested listed example

### Link to a build that showcases this PR:
Wand spell damage penetrates 25% of enemy elemental resistances and then double click a sceptre
### Before screenshot:
<img width="553" height="136" alt="image" src="https://github.com/user-attachments/assets/96e11b52-b66c-48aa-bb4a-f124c678e3d1" />

### After screenshot:
<img width="537" height="115" alt="image" src="https://github.com/user-attachments/assets/fe6cac7a-6a98-42a0-8e59-36a3957d9156" />
