### PR TITLE
Implement parsing for remnant effect mods

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6205,13 +6205,9 @@ c["Remnants can be collected from 50% further away All Flames of Chayula that yo
 c["Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Purple"]={nil,"Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Purple "}
 c["Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Red"]={nil,"Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Red "}
 c["Remnants can be collected from 50% further away Remnants you create reappear once, 3 seconds after being collected"]={nil,"Remnants can be collected from 50% further away Remnants you create reappear once, 3 seconds after being collected "}
-c["Remnants you create have 10% increased effect"]={nil,"Remnants you create have 10% increased effect "}
+c["Remnants you create have 10% increased effect"]={{[1]={flags=0,keywordFlags=0,name="RemnantEffect",type="INC",value=10}},nil}
 c["Remnants you create have 2% increased effect per 10 Tribute"]={nil,"Remnants you create have 2% increased effect per 10 Tribute "}
-c["Remnants you create have 50% increased effect"]={nil,"Remnants you create have 50% increased effect "}
-c["Remnants you create have 50% increased effect Remnants can be collected from 50% further away"]={nil,"Remnants you create have 50% increased effect Remnants can be collected from 50% further away "}
-c["Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Blue"]={nil,"Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Blue "}
-c["Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Purple"]={nil,"Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Purple "}
-c["Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Red"]={nil,"Remnants you create have 50% increased effect Remnants can be collected from 50% further away All Flames of Chayula that you manifest are Red "}
+c["Remnants you create have 50% increased effect"]={{[1]={flags=0,keywordFlags=0,name="RemnantEffect",type="INC",value=50}},nil}
 c["Remnants you create reappear once, 3 seconds after being collected"]={nil,"Remnants you create reappear once, 3 seconds after being collected "}
 c["Remove Ignite when you Warcry"]={nil,"Remove Ignite when you Warcry "}
 c["Remove a Curse after Channelling for 2 seconds"]={nil,"Remove a Curse after Channelling for 2 seconds "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5489,6 +5489,8 @@ local specialModList = {
 	["magic utility flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("MagicUtilityFlaskEffect", "INC", num, { type = "ActorCondition", actor = "player"}) } end,
 	["flasks applied to you have (%d+)%% reduced effect"] = function(num) return { mod("FlaskEffect", "INC", -num, { type = "ActorCondition", actor = "player"}) } end,
 	["remnants have (%d+)%% increased effect"] = function(num) return { mod("RemnantEffect", "INC", num) } end,
+	["remnants you create have (%d+)%% increased effect"]                                                                                                                                                                                                                                                                                                                                                                       = function(
+		num) return { mod("RemnantEffect", "INC", num) } end,
 	["(%d+)%% increased charm cooldown recovery rate"] = function(num) return { mod("CharmCooldownRecovery", "INC", num) } end,
 	["adds (%d+) passive skills"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelNodeCount", value = num }) } end,
 	["1 added passive skill is a jewel socket"] = { mod("JewelData", "LIST", { key = "clusterJewelSocketCount", value = 1 }) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5489,8 +5489,7 @@ local specialModList = {
 	["magic utility flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("MagicUtilityFlaskEffect", "INC", num, { type = "ActorCondition", actor = "player"}) } end,
 	["flasks applied to you have (%d+)%% reduced effect"] = function(num) return { mod("FlaskEffect", "INC", -num, { type = "ActorCondition", actor = "player"}) } end,
 	["remnants have (%d+)%% increased effect"] = function(num) return { mod("RemnantEffect", "INC", num) } end,
-	["remnants you create have (%d+)%% increased effect"]                                                                                                                                                                                                                                                                                                                                                                       = function(
-		num) return { mod("RemnantEffect", "INC", num) } end,
+	["remnants you create have (%d+)%% increased effect"] = function(num) return { mod("RemnantEffect", "INC", num) } end,
 	["(%d+)%% increased charm cooldown recovery rate"] = function(num) return { mod("CharmCooldownRecovery", "INC", num) } end,
 	["adds (%d+) passive skills"] = function(num) return { mod("JewelData", "LIST", { key = "clusterJewelNodeCount", value = num }) } end,
 	["1 added passive skill is a jewel socket"] = { mod("JewelData", "LIST", { key = "clusterJewelSocketCount", value = 1 }) },


### PR DESCRIPTION
Fixes #2030  .

### Description of the problem being solved:

Some remnant mods were not parsed previously.

### Steps taken to verify a working solution:
- Allocate the `Remnants you create have #% increased Effect` nodes on the tree
- Add `Mana Remnants`
- Verify in the calc tab that the nodes apply

### Before screenshot:

<img width="872" height="318" alt="image" src="https://github.com/user-attachments/assets/e461db51-bc1c-4f05-927e-8daf8bb4b111" />

### After screenshot:

<img width="596" height="320" alt="image" src="https://github.com/user-attachments/assets/8366e4d2-0350-47af-9ce0-9df9712dcd5f" />
<img width="593" height="368" alt="image" src="https://github.com/user-attachments/assets/6489424d-0b5e-4145-9eb0-f21f71ba4ea6" />
