### PR TITLE
Fix crash when importing a character that uses Facebreaker gloves

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -956,10 +956,10 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 
 		-- This could be done better with the character melee skills data at some point.
 		if typeLine:match("Mace Strike") then
-			local weapon1Sel = self.build.itemsTab.activeItemSet["Weapon 1"].selItemId or 0
-			local weapon2Sel = self.build.itemsTab.activeItemSet["Weapon 2"].selItemId or 0
+			local weapon1Sel = self.build.itemsTab.activeItemSet["Weapon 1"] and self.build.itemsTab.activeItemSet["Weapon 1"].selItemId or 0
+			local weapon2Sel = self.build.itemsTab.activeItemSet["Weapon 2"] and self.build.itemsTab.activeItemSet["Weapon 2"].selItemId or 0
 			if weapon2Sel == 0 then
-				if self.build.itemsTab.items[weapon1Sel].base.type == "One Hand Mace" then
+				if weapon1Sel == 0 or self.build.itemsTab.items[weapon1Sel].base.type == "One Hand Mace" then -- Facebreaker uses single handed mace strike
 					gemId = "Metadata/Items/Gems/SkillGemPlayerDefault1HMace"
 				elseif self.build.itemsTab.items[weapon1Sel].base.type == "Two Hand Mace" then
 					gemId = "Metadata/Items/Gems/SkillGemPlayerDefault2HMace"


### PR DESCRIPTION
### Description of the problem being solved:
When using Facebreakers, the character acts as if it is using a 1 hand mace so it gets the single handed mace strike skill. We assumed that the player had to have a weapon equipped if this skill was in the character list so it would crash when referring to an invalid index

### Before screenshot:
<img width="567" height="347" alt="image" src="https://github.com/user-attachments/assets/233fc5d5-b86c-46a6-bc42-f2dcee622444" />

### After screenshot:
<img width="386" height="256" alt="image" src="https://github.com/user-attachments/assets/b7c1ce10-2f70-44bf-856b-dcb7a4e1a6cf" />
