### PR TITLE
Fix Hollow Form support effects being switched

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -8896,10 +8896,10 @@ skills["SupportHollowFormPlayer"] = {
 			statDescriptionScope = "meta_gem_stat_descriptions",
 			statMap = {
 				["mantra_of_illusions_triggered_skill_attack_speed_+%_final"] = {
-					mod("Damage", "MORE", nil),
+					mod("Speed", "MORE", nil, ModFlag.Attack),
 				},
 				["mantra_of_illusions_triggered_skill_damage_+%_final"] = {
-					mod("Speed", "MORE", nil, ModFlag.Attack),
+					mod("Damage", "MORE", nil),
 				},
 			},
 			baseFlags = {

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -576,10 +576,10 @@ statMap = {
 #set SupportHollowFormPlayer
 statMap = {
 	["mantra_of_illusions_triggered_skill_attack_speed_+%_final"] = {
-		mod("Damage", "MORE", nil),
+		mod("Speed", "MORE", nil, ModFlag.Attack),
 	},
 	["mantra_of_illusions_triggered_skill_damage_+%_final"] = {
-		mod("Speed", "MORE", nil, ModFlag.Attack),
+		mod("Damage", "MORE", nil),
 	},
 },
 #mods


### PR DESCRIPTION
Fixes #2092

### Description of the problem being solved:
I accidently swapped the stats in the export so the less damage multi was applying to attack speed

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/rmc3kh0y

### Before screenshot:
<img width="431" height="39" alt="image" src="https://github.com/user-attachments/assets/e892994b-33e3-4b87-9cd6-7b26eb53cb08" />

### After screenshot:
<img width="428" height="38" alt="image" src="https://github.com/user-attachments/assets/362a0d84-73eb-4aea-941e-66dbfbf09d6f" />
