### PR TITLE
Fix Deflect chance not being capped at 95%

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -50,7 +50,7 @@ function calcs.deflectChance(deflection, accuracy)
 		return 0
 	end
 	local chanceToNotDeflect = accuracy / ( accuracy + deflection * 0.12 ) * 150 - 50
-	return 100 - m_max(m_min(round(chanceToNotDeflect), data.misc.DeflectionChanceCap), 0)
+	return m_max(m_min(100 - round(chanceToNotDeflect), data.misc.DeflectionChanceCap), 0)
 end
 -- Calculate damage reduction from armour, float
 function calcs.armourReductionF(armour, raw)


### PR DESCRIPTION
Fixes #2088

### Description of the problem being solved:
The formula was not correct and was not capping the final value

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/65c3l10y

### Before screenshot:
<img width="246" height="86" alt="image" src="https://github.com/user-attachments/assets/8a64615a-2568-4fe2-a375-6bbee5e0418d" />

### After screenshot:
<img width="261" height="85" alt="image" src="https://github.com/user-attachments/assets/a41e2a42-6670-46a9-a667-7cc052934f06" />
