### PR TITLE
Fix Virtuous Barrier not factoring the base 3 of each type of mote

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1389,7 +1389,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	-- Merge Granted Skills Tables
 	env.grantedSkills = tableConcat(env.grantedSkillsNodes, env.grantedSkillsItems)
 
-	local virtuousMoteSkillCount = accelerate.skills and env.virtuousMoteSkillCount or { Str = 0, Dex = 0, Int = 0 }
+	local virtuousMoteSkillCount = accelerate.skills and env.virtuousMoteSkillCount or { Str = 3, Dex = 3, Int = 3 }
 	local virtuousMoteSkillCounted = { }
 
 	if not accelerate.skills then


### PR DESCRIPTION
Fixes #2101

### Description of the problem being solved:
I forgot that it had a base of 3 for each mote

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/r5clsi0y

### Before screenshot:
<img width="650" height="128" alt="image" src="https://github.com/user-attachments/assets/f75e051c-b771-435a-84ae-9f41dc6875e3" />

### After screenshot:
<img width="652" height="128" alt="image" src="https://github.com/user-attachments/assets/d7652df1-19e3-4df8-97e8-8c83fbd0b3ce" />
