### PR TITLE
Fix Fist of Stone more ES/Evasion mod on gloves

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -244,6 +244,7 @@ local modNameList = {
 	["evasion rating and armour"] = "ArmourAndEvasion",
 	["armour and energy shield"] = "ArmourAndEnergyShield",
 	["evasion rating and energy shield"] = "EvasionAndEnergyShield",
+	["global evasion rating and energy shield"] = { "Evasion", "EnergyShield" },
 	["evasion and energy shield"] = "EvasionAndEnergyShield",
 	["armour, evasion and energy shield"] = "Defences",
 	["defences"] = "Defences",


### PR DESCRIPTION
Fixes #2110

### Description of the problem being solved:
The more mod was being parsed as the local es/evasion mod instead of the individual global ones