### PR TITLE
Add missing genesis tree exclusive mods to Rings and Belts

### DIFF
--- a/src/Data/Bases/belt.lua
+++ b/src/Data/Bases/belt.lua
@@ -5,7 +5,7 @@ local itemBases = ...
 itemBases["Golden Obi"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, demigods = true, not_for_sale = true, },
+	tags = { belt = true, default = true, demigods = true, genesis_tree_caster = true, genesis_tree_minion = true, not_for_sale = true, },
 	implicit = "(20-30)% increased Rarity of Items found\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "drop" }, },
 	req = { },
@@ -13,7 +13,7 @@ itemBases["Golden Obi"] = {
 itemBases["Rawhide Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(20-30)% increased Life Recovery from Flasks\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "flask", "resource", "life" }, },
 	req = { },
@@ -21,7 +21,7 @@ itemBases["Rawhide Belt"] = {
 itemBases["Linen Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(20-30)% increased Mana Recovery from Flasks\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "flask", "resource", "mana" }, },
 	req = { },
@@ -29,7 +29,7 @@ itemBases["Linen Belt"] = {
 itemBases["Wide Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(20-30)% increased Flask Charges gained\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "flask" }, },
 	req = { level = 14, },
@@ -37,7 +37,7 @@ itemBases["Wide Belt"] = {
 itemBases["Long Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(15-20)% increased Charm Effect Duration\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, },
 	req = { level = 20, },
@@ -45,7 +45,7 @@ itemBases["Long Belt"] = {
 itemBases["Plate Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "+(140-180) to Armour\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "defences", "armour" }, },
 	req = { level = 24, },
@@ -53,7 +53,7 @@ itemBases["Plate Belt"] = {
 itemBases["Ornate Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(10-15)% reduced Charm Charges used\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, },
 	req = { level = 31, },
@@ -61,7 +61,7 @@ itemBases["Ornate Belt"] = {
 itemBases["Mail Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(10-15)% reduced Flask Charges used\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "flask" }, },
 	req = { level = 40, },
@@ -69,7 +69,7 @@ itemBases["Mail Belt"] = {
 itemBases["Double Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(20-30)% increased Charm Charges gained\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, },
 	req = { level = 44, },
@@ -77,7 +77,7 @@ itemBases["Double Belt"] = {
 itemBases["Heavy Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "(20-30)% increased Stun Threshold\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, },
 	req = { level = 50, },
@@ -86,7 +86,7 @@ itemBases["Runemastered Heavy Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
 	hidden = true,
-	tags = { belt = true, default = true, runeforged = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, runeforged = true, },
 	implicit = "(20-30)% increased Stun Threshold\n(15-25)% Life Recovery from Flasks also applies to Runic Ward\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, {  }, },
 	req = { level = 50, },
@@ -95,7 +95,7 @@ itemBases["Runemastered Heavy Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
 	hidden = true,
-	tags = { belt = true, default = true, runeforged = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, runeforged = true, },
 	implicit = "(20-30)% increased Stun Threshold\n(20-40)% increased Runic Ward Regeneration Rate\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, { "runic_ward" }, },
 	req = { level = 50, },
@@ -104,7 +104,7 @@ itemBases["Runemastered Heavy Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
 	hidden = true,
-	tags = { belt = true, default = true, runeforged = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, runeforged = true, },
 	implicit = "(20-30)% increased Stun Threshold\nRunic Ward recovery can can Overflow maximum Runic Ward\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, {  }, },
 	req = { level = 50, },
@@ -113,7 +113,7 @@ itemBases["Runemastered Heavy Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
 	hidden = true,
-	tags = { belt = true, default = true, runeforged = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, runeforged = true, },
 	implicit = "(20-30)% increased Stun Threshold\nFlasks gain (0.5-1) charges per Second\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, {  }, },
 	req = { level = 50, },
@@ -121,7 +121,7 @@ itemBases["Runemastered Heavy Belt"] = {
 itemBases["Utility Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "20% of Flask Recovery applied Instantly\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, },
 	req = { level = 55, },
@@ -129,7 +129,7 @@ itemBases["Utility Belt"] = {
 itemBases["Fine Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "Flasks gain 0.17 charges per Second\nHas (1-3) Charm Slots",
 	implicitModTypes = { {  }, },
 	req = { level = 62, },
@@ -137,7 +137,7 @@ itemBases["Fine Belt"] = {
 itemBases["Stalking Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "Has 1 Charm Slot\nThis item gains bonuses from Socketed Items as though it was Boots\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, {  }, },
 	req = { level = 40, },
@@ -145,7 +145,7 @@ itemBases["Stalking Belt"] = {
 itemBases["Invoking Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "Has 1 Charm Slot\n(8-12)% increased Cast Speed\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, { "caster_speed", "caster", "speed" }, },
 	req = { level = 32, },
@@ -153,7 +153,7 @@ itemBases["Invoking Belt"] = {
 itemBases["Sinew Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "Has 1 Charm Slot\n+(15-20) to Strength\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, { "attribute" }, },
 	req = { level = 32, },
@@ -161,7 +161,7 @@ itemBases["Sinew Belt"] = {
 itemBases["Forking Belt"] = {
 	type = "Belt",
 	charmLimit = 0,
-	tags = { belt = true, default = true, },
+	tags = { belt = true, default = true, genesis_tree_caster = true, genesis_tree_minion = true, },
 	implicit = "Has 1 Charm Slot\nAdds 1 to (20-30) Lightning damage to Attacks\nHas (1-3) Charm Slots",
 	implicitModTypes = { { "charm" }, { "elemental_damage", "damage", "elemental", "lightning", "attack" }, },
 	req = { level = 32, },

--- a/src/Data/Bases/ring.lua
+++ b/src/Data/Bases/ring.lua
@@ -4,202 +4,202 @@ local itemBases = ...
 
 itemBases["Golden Hoop"] = {
 	type = "Ring",
-	tags = { default = true, demigods = true, not_for_sale = true, ring = true, },
+	tags = { default = true, demigods = true, genesis_tree_caster = true, genesis_tree_minion = true, not_for_sale = true, ring = true, },
 	implicit = "+(8-12) to all Attributes",
 	implicitModTypes = { { "attribute" }, },
 	req = { level = 12, },
 }
 itemBases["Iron Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "Adds 1 to 4 Physical Damage to Attacks",
 	implicitModTypes = { { "physical_damage", "damage", "physical", "attack" }, },
 	req = { },
 }
 itemBases["Lazuli Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(20-30) to maximum Mana",
 	implicitModTypes = { { "resource", "mana" }, },
 	req = { },
 }
 itemBases["Ruby Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(20-30)% to Fire Resistance",
 	implicitModTypes = { { "elemental_resistance", "fire_resistance", "elemental", "fire", "resistance" }, },
 	req = { level = 8, },
 }
 itemBases["Sapphire Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(20-30)% to Cold Resistance",
 	implicitModTypes = { { "cold_resistance", "elemental_resistance", "elemental", "cold", "resistance" }, },
 	req = { level = 12, },
 }
 itemBases["Topaz Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(20-30)% to Lightning Resistance",
 	implicitModTypes = { { "elemental_resistance", "lightning_resistance", "elemental", "lightning", "resistance" }, },
 	req = { level = 16, },
 }
 itemBases["Amethyst Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(7-13)% to Chaos Resistance",
 	implicitModTypes = { { "chaos_resistance", "chaos", "resistance" }, },
 	req = { level = 20, },
 }
 itemBases["Emerald Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(120-160) to Accuracy Rating",
 	implicitModTypes = { { "attack" }, },
 	req = { level = 26, },
 }
 itemBases["Pearl Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "(7-10)% increased Cast Speed",
 	implicitModTypes = { { "caster_speed", "caster", "speed" }, },
 	req = { level = 32, },
 }
 itemBases["Prismatic Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(7-10)% to all Elemental Resistances",
 	implicitModTypes = { { "cold_resistance", "elemental_resistance", "fire_resistance", "lightning_resistance", "elemental", "fire", "cold", "lightning", "resistance" }, },
 	req = { level = 35, },
 }
 itemBases["Gold Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "(6-15)% increased Rarity of Items found",
 	implicitModTypes = { { "drop" }, },
 	req = { level = 40, },
 }
 itemBases["Unset Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "Grants 1 additional Skill Slot",
 	implicitModTypes = { {  }, },
 	req = { level = 44, },
 }
 itemBases["Abyssal Signet"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "Inflict Abyssal Wasting on Hit",
 	implicitModTypes = { {  }, },
 	req = { },
 }
 itemBases["Two-Stone Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(12-16)% to Fire and Cold Resistances",
 	implicitModTypes = { { "cold_resistance", "elemental_resistance", "fire_resistance", "elemental", "fire", "cold", "resistance" }, },
 	req = { },
 }
 itemBases["Two-Stone Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(12-16)% to Fire and Lightning Resistances",
 	implicitModTypes = { { "elemental_resistance", "fire_resistance", "lightning_resistance", "elemental", "fire", "lightning", "resistance" }, },
 	req = { },
 }
 itemBases["Two-Stone Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+(12-16)% to Cold and Lightning Resistances",
 	implicitModTypes = { { "cold_resistance", "elemental_resistance", "lightning_resistance", "elemental", "cold", "lightning", "resistance" }, },
 	req = { },
 }
 itemBases["Biostatic Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+1% to all maximum Resistances",
 	implicitModTypes = { { "resistance" }, },
 	req = { level = 52, },
 }
 itemBases["Vitalic Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "(4-6)% increased maximum Life",
 	implicitModTypes = { { "resource", "life" }, },
 	req = { level = 40, },
 }
 itemBases["Mnemonic Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "(4-6)% increased maximum Mana",
 	implicitModTypes = { { "resource", "mana" }, },
 	req = { level = 40, },
 }
 itemBases["Kinetic Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "Adds (6-9) to (11-15) Physical Damage to Attacks",
 	implicitModTypes = { { "physical_damage", "damage", "physical", "attack" }, },
 	req = { level = 40, },
 }
 itemBases["Oneiric Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "(11-23)% increased Chaos Damage",
 	implicitModTypes = { { "chaos_damage", "damage", "chaos" }, },
 	req = { level = 47, },
 }
 itemBases["Grasping Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "This item gains bonuses from Socketed Items as though it was Gloves",
 	implicitModTypes = { {  }, },
 	req = { level = 40, },
 }
 itemBases["Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicitModTypes = { },
 	req = { },
 }
 itemBases["Dusk Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+1 Prefix Modifier allowed\n-1 Suffix Modifier allowed",
 	implicitModTypes = { {  }, {  }, },
 	req = { },
 }
 itemBases["Gloam Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "-1 Prefix Modifier allowed\n+1 Suffix Modifier allowed",
 	implicitModTypes = { {  }, {  }, },
 	req = { },
 }
 itemBases["Penumbra Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+2 Prefix Modifiers allowed\n-2 Suffix Modifiers allowed",
 	implicitModTypes = { {  }, {  }, },
 	req = { },
 }
 itemBases["Tenebrous Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "-2 Prefix Modifiers allowed\n+2 Suffix Modifiers allowed",
 	implicitModTypes = { {  }, {  }, },
 	req = { },
 }
 itemBases["Breach Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+20% to Maximum Quality",
 	implicitModTypes = { {  }, },
 	req = { level = 40, },
 }
 itemBases["Refined Breach Ring"] = {
 	type = "Ring",
-	tags = { default = true, ring = true, },
+	tags = { default = true, genesis_tree_caster = true, genesis_tree_minion = true, ring = true, },
 	implicit = "+25% to Maximum Quality",
 	implicitModTypes = { {  }, },
 	req = { level = 40, },

--- a/src/Export/Scripts/bases.lua
+++ b/src/Export/Scripts/bases.lua
@@ -124,6 +124,13 @@ directiveTable.base = function(state, args, out)
 	for _, tag in ipairs(baseItemType.Tags) do
 		combinedTags[tag.Id] = true
 	end
+	-- Genesis Tree tags are granted at runtime and omitted from BaseItemTypes,
+	-- so the genesis_tree_* mods (belt/ring caster and minion affixes) match nothing.
+	-- Re-add them; each mod's own belt/ring exclusion routes it to the correct slot.
+	if combinedTags.belt or combinedTags.ring then
+		combinedTags.genesis_tree_minion = true
+		combinedTags.genesis_tree_caster = true
+	end
 	local combinedTagList = { }
 	for tag in pairsSortByKey(combinedTags) do
 		table.insert(combinedTagList, tag)


### PR DESCRIPTION
…elt and ring bases

These mods only spawn on the genesis_tree_* tags, which GGG grants at runtime and omits from base data, so they matched no item. Adding the tags to belt/ring bases during export lets the existing spawn-weight logic route them to the right slot.

### Description of the problem being solved:

Couldn't add minion/caster mods to rings and belts

### Steps taken to verify a working solution:

Check the existence of mods when crafting belts and rings. 

### Before screenshot:


<img width="477" height="532" alt="image" src="https://github.com/user-attachments/assets/c6cbf13d-0ff9-4c3f-a543-3048e8872295" />

### After screenshot:

<img width="513" height="736" alt="image" src="https://github.com/user-attachments/assets/d1ef78f8-d5ec-489b-9601-4f9641bf0b36" />


