### PR TITLE
Fix false positive on "Cannot be used manually"

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4947,7 +4947,8 @@ c["Cannot be Light Stunned if you haven't been Hit Recently"]={{[1]={[1]={neg=tr
 c["Cannot be Poisoned"]={{[1]={flags=0,keywordFlags=0,name="PoisonImmune",type="FLAG",value=true}},nil}
 c["Cannot be Shocked"]={{[1]={flags=0,keywordFlags=0,name="ShockImmune",type="FLAG",value=true}},nil}
 c["Cannot be Stunned"]={{[1]={flags=0,keywordFlags=0,name="StunImmune",type="FLAG",value=true}},nil}
-c["Cannot be Used manually"]={{[1]={flags=0,keywordFlags=0,name="UsedManuallyImmune",type="FLAG",value=true}},nil}
+c["Cannot be Used manually"]={{},"Used manually "}
+c["Cannot be Used manually Used when you release a skill with Perfect Timing"]={{},"Used manually Used when you release a skill with Perfect Timing "}
 c["Cannot collide with targets"]={nil,"Cannot collide with targets "}
 c["Cannot gain Spirit from Equipment"]={{[1]={flags=0,keywordFlags=0,name="CannotGainSpiritFromEquipment",type="FLAG",value=true}},nil}
 c["Cannot have Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="CannotHaveES",type="FLAG",value=true}},nil}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6721,13 +6721,17 @@ local function parseMod(line, order)
 		modType = type(modValue) == "table" and modValue.type or "FLAG"
 		modValue = type(modValue) == "table" and modValue.value or true
 	elseif modForm == "IMMUNE" then
-		local effectLine = line:gsub("%s+$","") -- remove trailing spaces
+		local effectLine = line:gsub("%s+$",""):lower() -- remove trailing spaces and lower case
 		local _, numWords = effectLine:gsub("%S+", "")
 		local multiEffect = effectLine:find(" and ")
 
 		local function getEffectFromStatus(statusString)
 			return statusToEffectMap[statusString:lower()] or statusString
 		end
+		-- list of known false positives that should be excluded as they don't provide "immunity"
+		local effectBlacklist = {
+			["used manually"] = true, -- "Cannot be used manually" from "Opportunity, Ultimate Life Flask"
+		}
 
 		-- Check number of words, as 99% of effects consist of only one or two words
 		-- NOTE: needs exception for wordings like "freeze and chill"
@@ -6742,6 +6746,8 @@ local function parseMod(line, order)
 			end
 		elseif (numWords < 1) or (numWords > 2) then
 			return { }, line -- no words or more than 2 unlikely for single effect
+		elseif effectBlacklist[effectLine] then
+				return { }, line
 		end
 
 		-- Process effect strings to valid mod names


### PR DESCRIPTION
### Description of the problem being solved:
"Cannot be used manually" on the "Opportunity, Ultimate Life Flask" unique flask was falsely parsed as "UsedManuallyImmune" due to #2142 

Added an `effectBlacklist` to exclude this case and any others in future

### Steps taken to verify a working solution:
- Checked ModCache before and after. Only that mod was affected and is now no longer parsed (which is correct)