### PR TITLE
Fix Full DPS breakdown and gem dropdowns showing the wrong name for Companion / Spectre skills

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -377,6 +377,27 @@ describe("TestSkills", function()
 		end
 	end)
 
+	it("uses selected companion names in skill displays", function()
+		build.skillsTab:PasteSocketGroup("Companion: Lightless Abomination 20/0  1")
+		build.skillsTab:PasteSocketGroup("Companion: Lightless Moray 20/0  1")
+		build.skillsTab.socketGroupList[1].includeInFullDPS = true
+		build.skillsTab.socketGroupList[2].includeInFullDPS = true
+		runCallback("OnFrame")
+
+		local skillNames = { }
+		for _, skill in ipairs(build.calcsTab.mainOutput.SkillDPS) do
+			skillNames[skill.name] = true
+		end
+		assert.is_true(skillNames["Companion: Lightless Abomination"])
+		assert.is_true(skillNames["Companion: Lightless Moray"])
+
+		build:RefreshSkillSelectControls(build.controls, 1, "")
+		assert.are.equals("Companion: Lightless Abomination", build.controls.mainSkill.list[1].label)
+
+		build:RefreshSkillSelectControls(build.controls, 2, "")
+		assert.are.equals("Companion: Lightless Moray", build.controls.mainSkill.list[1].label)
+	end)
+
 	it("Inspiring Ally only mirrors companion damage, not generic minion damage", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 			New Item

--- a/src/Classes/CompareEntry.lua
+++ b/src/Classes/CompareEntry.lua
@@ -326,7 +326,7 @@ function CompareEntryClass:RefreshSkillSelectControls(controls, mainGroup, suffi
 		local explodeSource = activeSkill.activeEffect.srcInstance.explodeSource
 		local explodeSourceName = explodeSource and (explodeSource.name or explodeSource.dn)
 		local colourCoded = explodeSourceName and ("From "..colorCodes[explodeSource.rarity or "NORMAL"]..explodeSourceName)
-		t_insert(controls.mainSkill.list, { val = i, label = colourCoded or activeSkill.activeEffect.grantedEffect.name })
+		t_insert(controls.mainSkill.list, { val = i, label = colourCoded or self.calcsTab.calcs.getActiveSkillDisplayName(activeSkill) })
 	end
 	controls.mainSkill.enabled = #displaySkillList > 1
 	controls.mainSkill.selIndex = mainActiveSkill

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1955,7 +1955,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 			local explodeSource = activeSkill.activeEffect.srcInstance.explodeSource
 			local explodeSourceName = explodeSource and (explodeSource.name or explodeSource.dn)
 			local colourCoded = explodeSourceName and ("From "..colorCodes[explodeSource.rarity or "NORMAL"]..explodeSourceName)
-			t_insert(controls.mainSkill.list, { val = i, label = colourCoded or activeSkill.activeEffect.grantedEffect.name })
+			t_insert(controls.mainSkill.list, { val = i, label = colourCoded or self.calcsTab.calcs.getActiveSkillDisplayName(activeSkill) })
 		end
 		controls.mainSkill.enabled = #displaySkillList > 1
 		controls.mainSkill.selIndex = mainActiveSkill

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -230,6 +230,19 @@ function calcs.createActiveSkill(activeEffect, supportList, env, actor, socketGr
 	return activeSkill
 end
 
+function calcs.getActiveSkillDisplayName(activeSkill)
+	local skillName = activeSkill.activeEffect.grantedEffect.name
+	local skillMinion = activeSkill.minion
+	if skillMinion and skillMinion.minionData then
+		if skillName:match("^Companion:") then
+			return "Companion: "..skillMinion.minionData.name
+		elseif skillName:match("^Spectre:") then
+			return "Spectre: "..skillMinion.minionData.name
+		end
+	end
+	return skillName
+end
+
 -- Copy an Active Skill
 function calcs.copyActiveSkill(env, mode, skill)
 	local activeEffect = {

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -183,24 +183,35 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 				fullEnv.player.mainSkill = activeSkill
 				calcs.perform(fullEnv, true)
 				usedEnv = fullEnv
+				-- Companion/Spectre gems all share a single granted effect ("Companion: {0}"/"Spectre: {0}"),
+				-- whose name is mutated globally for display, so derive the entry name from this skill's own minion
+				local skillName = activeSkill.activeEffect.grantedEffect.name
+				local skillMinion = activeSkill.minion or usedEnv.minion
+				if skillMinion and skillMinion.minionData then
+					if skillName:match("^Companion:") then
+						skillName = "Companion: "..skillMinion.minionData.name
+					elseif skillName:match("^Spectre:") then
+						skillName = "Spectre: "..skillMinion.minionData.name
+					end
+				end
 				local minionName = nil
 				if activeSkill.minion or usedEnv.minion then
 					if usedEnv.minion.output.TotalDPS and usedEnv.minion.output.TotalDPS > 0 then
 						minionName = (activeSkill.minion and activeSkill.minion.minionData.name..": ") or (usedEnv.minion and usedEnv.minion.minionData.name..": ") or ""
-						t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.minion.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName..activeSkill.skillPartName })
+						t_insert(fullDPS.skills, { name = skillName, dps = usedEnv.minion.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName..activeSkill.skillPartName })
 						fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.minion.output.TotalDPS * activeSkillCount
 					end
 					if usedEnv.minion.output.BleedDPS and usedEnv.minion.output.BleedDPS > fullDPS.bleedDPS then
 						fullDPS.bleedDPS = usedEnv.minion.output.BleedDPS
-						bleedSource = activeSkill.activeEffect.grantedEffect.name
+						bleedSource = skillName
 					end
 					if usedEnv.minion.output.IgniteDPS and usedEnv.minion.output.IgniteDPS > fullDPS.igniteDPS then
 						fullDPS.igniteDPS = usedEnv.minion.output.IgniteDPS
-						igniteSource = activeSkill.activeEffect.grantedEffect.name
+						igniteSource = skillName
 					end
 					if usedEnv.minion.output.PoisonDPS and usedEnv.minion.output.PoisonDPS > fullDPS.poisonDPS then
 						fullDPS.poisonDPS = usedEnv.minion.output.PoisonDPS
-						poisonSource = activeSkill.activeEffect.grantedEffect.name
+						poisonSource = skillName
 					end
 					if usedEnv.minion.output.ImpaleDPS and usedEnv.minion.output.ImpaleDPS > 0 then
 						fullDPS.impaleDPS = fullDPS.impaleDPS + usedEnv.minion.output.ImpaleDPS * activeSkillCount
@@ -263,32 +274,32 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 				end
 
 				if usedEnv.player.output.TotalDPS and usedEnv.player.output.TotalDPS > 0 then
-					t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.player.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName and activeSkill.infoMessage2 or activeSkill.skillPartName })
+					t_insert(fullDPS.skills, { name = skillName, dps = usedEnv.player.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName and activeSkill.infoMessage2 or activeSkill.skillPartName })
 					fullDPS.combinedDPS = fullDPS.combinedDPS + usedEnv.player.output.TotalDPS * activeSkillCount
 				end
 				if usedEnv.player.output.BleedDPS and usedEnv.player.output.BleedDPS > fullDPS.bleedDPS then
 					fullDPS.bleedDPS = usedEnv.player.output.BleedDPS
-					bleedSource = activeSkill.activeEffect.grantedEffect.name
+					bleedSource = skillName
 				end
 				if usedEnv.player.output.CorruptingBloodDPS and usedEnv.player.output.CorruptingBloodDPS > fullDPS.corruptingBloodDPS then
 					fullDPS.corruptingBloodDPS = usedEnv.player.output.CorruptingBloodDPS
-					corruptingBloodSource = activeSkill.activeEffect.grantedEffect.name
+					corruptingBloodSource = skillName
 				end
 				if usedEnv.player.output.IgniteDPS and usedEnv.player.output.IgniteDPS > fullDPS.igniteDPS then
 					fullDPS.igniteDPS = usedEnv.player.output.IgniteDPS
-					igniteSource = activeSkill.activeEffect.grantedEffect.name
+					igniteSource = skillName
 				end
 				if usedEnv.player.output.BurningGroundDPS and usedEnv.player.output.BurningGroundDPS > fullDPS.burningGroundDPS then
 					fullDPS.burningGroundDPS = usedEnv.player.output.BurningGroundDPS
-					burningGroundSource = activeSkill.activeEffect.grantedEffect.name
+					burningGroundSource = skillName
 				end
 				if usedEnv.player.output.PoisonDPS and usedEnv.player.output.PoisonDPS > fullDPS.poisonDPS then
 					fullDPS.poisonDPS = usedEnv.player.output.PoisonDPS
-					poisonSource = activeSkill.activeEffect.grantedEffect.name
+					poisonSource = skillName
 				end
 				if usedEnv.player.output.CausticGroundDPS and usedEnv.player.output.CausticGroundDPS > fullDPS.causticGroundDPS then
 					fullDPS.causticGroundDPS = usedEnv.player.output.CausticGroundDPS
-					causticGroundSource = activeSkill.activeEffect.grantedEffect.name
+					causticGroundSource = skillName
 				end
 				if usedEnv.player.output.ImpaleDPS and usedEnv.player.output.ImpaleDPS > 0 then
 					fullDPS.impaleDPS = fullDPS.impaleDPS + usedEnv.player.output.ImpaleDPS * activeSkillCount

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -183,17 +183,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 				fullEnv.player.mainSkill = activeSkill
 				calcs.perform(fullEnv, true)
 				usedEnv = fullEnv
-				-- Companion/Spectre gems all share a single granted effect ("Companion: {0}"/"Spectre: {0}"),
-				-- whose name is mutated globally for display, so derive the entry name from this skill's own minion
-				local skillName = activeSkill.activeEffect.grantedEffect.name
-				local skillMinion = activeSkill.minion or usedEnv.minion
-				if skillMinion and skillMinion.minionData then
-					if skillName:match("^Companion:") then
-						skillName = "Companion: "..skillMinion.minionData.name
-					elseif skillName:match("^Spectre:") then
-						skillName = "Spectre: "..skillMinion.minionData.name
-					end
-				end
+				local skillName = calcs.getActiveSkillDisplayName(activeSkill)
 				local minionName = nil
 				if activeSkill.minion or usedEnv.minion then
 					if usedEnv.minion.output.TotalDPS and usedEnv.minion.output.TotalDPS > 0 then


### PR DESCRIPTION
Companion and Spectre gems share a single granted effect ("Companion: {0}" / "Spectre: {0}") whose name is mutated globally for reservation display, so every entry in the Full DPS breakdown showed the same minion name. Derive each entry's name from the skill's own minion instead.

### Link to a build that showcases this PR:
https://pobb.in/-TeCx6SJiuWv

### Before screenshot:
<img width="292" height="90" alt="image" src="https://github.com/user-attachments/assets/5f1bfa6a-1199-4620-9d60-f1f93ce472a0" />

### After screenshot:
<img width="301" height="82" alt="image" src="https://github.com/user-attachments/assets/33b5fb95-d54d-44bd-8a3a-02a9309ce5d6" />
