### PR TITLE
Add missing tamable beasts and their skills

### DIFF
--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -8281,3 +8281,2281 @@ skills["GAIcyQuadrillaBossRectSlam"] = {
 		},
 	}
 }
+
+skills["MeleeMudBurrowerLeftCleave"] = {
+	name = "Left Cleave",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/iconbasicattack.dds",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Left Cleave",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", 40 },
+			},
+			stats = {
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MeleeMudBurrowerRightCleave"] = {
+	name = "Right Cleave",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/iconbasicattack.dds",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Right Cleave",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", 40 },
+			},
+			stats = {
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MeleeMudBurrowerBite"] = {
+	name = "Bite",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/iconbasicattack.dds",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Bite",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", 80 },
+			},
+			stats = {
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPAMudBurrowerBloodProj"] = {
+	name = "Blood Spit",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.25, levelRequirement = 0, },
+		[2] = { baseMultiplier = 1.25, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1115 },
+				{ "projectile_ballistic_gravity_override", 3000 },
+				{ "projectile_spread_radius", 7 },
+				{ "attack_maximum_action_distance_+", 11 },
+			},
+			stats = {
+				"number_of_additional_projectiles",
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"maintain_projectile_direction_when_using_contact_position",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"projectile_ballistic_angle_from_target_distance",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+				[2] = { 2, statInterpolation = { 1, }, actorLevel = 50, },
+			},
+		},
+	}
+}
+skills["GAMudBurrowerBloodProj"] = {
+	name = "Blood Spit Impact",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Blood Spit Impact",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", 50 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPAMudBurrowerSprayProj"] = {
+	name = "Blood Spray",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 16, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1118 },
+				{ "projectile_ballistic_gravity_override", 0 },
+				{ "projectile_spread_radius", 8 },
+			},
+			stats = {
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"projectile_uses_contact_direction",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"projectile_ballistic_angle_from_target_distance",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAMudBurrowerSpraySmallImpact"] = {
+	name = "Blood Spray Impact",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Blood Spray Impact",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "base_poison_duration_+%", 50 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"global_poison_on_hit",
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPAMudBurrowerGoopSmallBall"] = {
+	name = "Goop Ball",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1116 },
+				{ "projectile_ballistic_gravity_override", 0 },
+				{ "projectile_spread_radius", 10 },
+			},
+			stats = {
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"maintain_projectile_direction_when_using_contact_position",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"projectile_ballistic_angle_from_target_distance",
+				"projectile_uses_contact_direction",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAMudBurrowerGoopSmallImpact"] = {
+	name = "Goop Ball Impact",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.35, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Goop Ball Impact",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"global_poison_on_hit",
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPAMudBurrowerGoopBigBall"] = {
+	name = "Large Goop Ball",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1117 },
+				{ "projectile_ballistic_gravity_override", 0 },
+				{ "projectile_spread_radius", 3 },
+			},
+			stats = {
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"maintain_projectile_direction_when_using_contact_position",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"projectile_ballistic_angle_from_target_distance",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MudBurrowerGoopExplode"] = {
+	name = "Goop Explosion",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.6, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Goop Explosion",
+			baseEffectiveness = 8,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+			},
+			stats = {
+				"is_area_damage",
+				"global_poison_on_hit",
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAMudBurrowerHeadSlam"] = {
+	name = "Head Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 4, cooldown = 12, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", 80 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"global_poison_on_hit",
+				"base_skill_cannot_be_avoided_by_dodge_roll_or_blocked",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAMudBurrowerDivePush"] = {
+	name = "Dive",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Dive",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "knockback_distance_+%", 20 },
+				{ "base_knockback_speed_+%", 50 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"base_skill_cannot_be_avoided_by_dodge_roll_or_evaded_or_blocked",
+				"base_cannot_be_blocked",
+				"global_always_hit",
+				"global_knockback",
+				"disable_visual_hit_effect",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["CGEMudBurrowerVomit"] = {
+	name = "Vomit Ground",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Vomit Ground",
+			baseEffectiveness = 15,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+				duration = true,
+			},
+			constantStats = {
+				{ "active_skill_base_area_of_effect_radius", 15 },
+				{ "base_skill_effect_duration", 10000 },
+				{ "ground_caustic_art_variation", 1000 },
+			},
+			stats = {
+				"base_chaos_damage_to_deal_per_minute",
+			},
+			levels = {
+				[1] = { 16.666667039196, statInterpolation = { 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPAMudBurrowerVomitProj"] = {
+	name = "Vomit",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.8, critChance = 5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1118 },
+			},
+			stats = {
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"projectile_uses_contact_direction",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_deal_no_damage",
+				"projectile_ballistic_angle_from_reference_event",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MudBurrowerMaggotSummon"] = {
+	name = "Summon Maggots",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Summon Maggots",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+			},
+			constantStats = {
+				{ "number_of_monsters_to_summon", 4 },
+				{ "alternate_minion", 1003 },
+			},
+			stats = {
+				"summoned_monsters_are_minions",
+				"summoned_monsters_no_drops_or_experience",
+				"minion_dies_when_parent_dies",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GPAPorcupineAntSpikeNova"] = {
+	name = "Spike Nova",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Spike Nova",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "projectile_speed_variation_+%", 30 },
+				{ "projectile_spread_radius", 20 },
+				{ "base_skill_area_of_effect_+%", -60 },
+			},
+			stats = {
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MMAPorcupineAntSpikeball"] = {
+	name = "Spike Mortar",
+	hidden = true,
+	icon = "",
+	description = "Generic monster mortar skill. Like Monster Projectile but has an impact effect.",
+	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1.2,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Mortar",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "number_of_projectiles_override", 1 },
+				{ "melee_range_+", 60 },
+				{ "projectile_spread_radius", 5 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectiles_not_offset",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GPAPorcupineAntSpikeNovaSanctum"] = {
+	name = "Spike Nova",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Spike Nova",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "projectile_speed_variation_+%", 30 },
+				{ "projectile_spread_radius", 20 },
+				{ "base_skill_area_of_effect_+%", -60 },
+				{ "base_chance_to_poison_on_hit_%", 100 },
+			},
+			stats = {
+				"base_is_projectile",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MMAPorcupineAntSpikeballSanctum"] = {
+	name = "Spike Mortar",
+	hidden = true,
+	icon = "",
+	description = "Generic monster mortar skill. Like Monster Projectile but has an impact effect.",
+	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1.2,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Spike Mortar",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "number_of_projectiles_override", 1 },
+				{ "melee_range_+", 60 },
+				{ "projectile_spread_radius", 5 },
+				{ "base_chance_to_poison_on_hit_%", 100 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectiles_not_offset",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["MPWBlackStriderWebProjectile"] = {
+	name = "Web Projectile",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Web Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1150 },
+				{ "projectile_ballistic_gravity_override", 1500 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_ballistic_angle_from_target_distance",
+				"projectile_uses_contact_direction",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"base_deal_no_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GABlackStriderWebMortarImpact"] = {
+	name = "Web Impact",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.45, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Web Impact",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "base_skill_effect_duration", 3000 },
+			},
+			stats = {
+				"is_area_damage",
+				"base_is_projectile",
+				"base_skill_can_be_blocked",
+				"base_skill_can_be_avoided_by_dodge_roll",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["BlackStriderMassMortar"] = {
+	name = "Mass Mortar",
+	hidden = true,
+	icon = "",
+	description = "Generic monster mortar skill. Like Monster Projectile but has an impact effect.",
+	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.92, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Mass Mortar",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "projectile_minimum_range", 5 },
+				{ "number_of_projectiles_override", 1 },
+			},
+			stats = {
+				"is_area_damage",
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"base_deal_no_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPWBlackStriderWebProjectileSanctum"] = {
+	name = "Web Projectile",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 6.5, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Web Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1151 },
+				{ "projectile_ballistic_gravity_override", 1300 },
+				{ "number_of_additional_projectiles", 3 },
+				{ "projectile_spread_radius", 20 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_ballistic_angle_from_target_distance",
+				"projectile_uses_contact_direction",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"distribute_projectiles_over_contact_points",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["CGESanctumBlackStriderWeb"] = {
+	name = "Web Ground",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Web Ground",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+				duration = true,
+			},
+			constantStats = {
+				{ "ground_web_art_variation", 1000 },
+				{ "base_movement_velocity_+%", -30 },
+				{ "base_skill_effect_duration", 6000 },
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["QuillCrabSpikeShrapnel"] = {
+	name = "Spike Shrapnel",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.2, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Spike Shrapnel",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1003 },
+				{ "projectile_angle_variance", 0 },
+				{ "monster_reverse_point_blank_damage_-%_at_minimum_range", 20 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_fire", 40 },
+				{ "projectile_spread_radius", 18 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"projectiles_not_offset",
+				"projectile_ballistic_angle_from_reference_event",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["QuillCrabSpikeShrapnelPoison"] = {
+	name = "Spike Shrapnel",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.2, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Spike Shrapnel",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1005 },
+				{ "projectile_angle_variance", 0 },
+				{ "monster_reverse_point_blank_damage_-%_at_minimum_range", 20 },
+				{ "projectile_spread_radius", 0 },
+			},
+			stats = {
+				"base_is_projectile",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"projectiles_not_offset",
+				"global_poison_on_hit",
+				"projectile_ballistic_angle_from_reference_event",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["CGEQuillCrabFireGround"] = {
+	name = "Burning Ground",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Burning Ground",
+			baseEffectiveness = 10,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+				duration = true,
+			},
+			constantStats = {
+				{ "active_skill_area_of_effect_radius_+%_final", -40 },
+				{ "base_skill_effect_duration", 4000 },
+			},
+			stats = {
+				"base_fire_damage_to_deal_per_minute",
+				"is_area_damage",
+			},
+			notMinionStat = {
+				"base_fire_damage_to_deal_per_minute",
+			},
+			levels = {
+				[1] = { 16.666667039196, statInterpolation = { 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["CGEQuillCrabCausticGround"] = {
+	name = "Caustic Ground",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Caustic Ground",
+			baseEffectiveness = 10,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+				duration = true,
+			},
+			constantStats = {
+				{ "active_skill_area_of_effect_radius_+%_final", -50 },
+				{ "base_skill_effect_duration", 4000 },
+				{ "ground_caustic_art_variation", 1000 },
+			},
+			stats = {
+				"base_chaos_damage_to_deal_per_minute",
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { 16.666667039196, statInterpolation = { 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GSBeetleLightningNova"] = {
+	name = "Lightning Nova",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { critChance = 6, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Lightning Nova",
+			baseEffectiveness = 3,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+			},
+			stats = {
+				"spell_minimum_base_lightning_damage",
+				"spell_maximum_base_lightning_damage",
+				"is_area_damage",
+			},
+			notMinionStat = {
+				"spell_minimum_base_lightning_damage",
+				"spell_maximum_base_lightning_damage",
+			},
+			levels = {
+				[1] = { 0.5, 1.5, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GSCaveDwellerSonicPulse"] = {
+	name = "Sonic Pulse",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 2.266,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 12, critChance = 5, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Sonic Pulse",
+			baseEffectiveness = 0.80000001192093,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "base_skill_effect_duration", 3000 },
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"is_area_damage",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GSCaveDwellerSuperProjectile"] = {
+	name = "Sonic Projectile",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { critChance = 5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Sonic Projectile",
+			baseEffectiveness = 6.25,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				projectile = true,
+				triggerable = true,
+			},
+			stats = {
+				"spell_minimum_base_fire_damage",
+				"spell_maximum_base_fire_damage",
+				"is_area_damage",
+				"always_ignite",
+				"base_is_projectile",
+			},
+			notMinionStat = {
+				"spell_minimum_base_fire_damage",
+				"spell_maximum_base_fire_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GPSCaveDwellerSuperProjectileSanctum"] = {
+	name = "Sonic Projectile",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 2,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Sonic Projectile",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "spell_maximum_action_distance_+%", -50 },
+			},
+			stats = {
+				"spell_minimum_base_fire_damage",
+				"spell_maximum_base_fire_damage",
+				"use_scaled_contact_offset",
+				"projectile_uses_contact_position",
+				"base_is_projectile",
+				"base_deal_no_damage",
+				"cannot_pierce",
+			},
+			notMinionStat = {
+				"spell_minimum_base_fire_damage",
+				"spell_maximum_base_fire_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GSPlagueNymphLaser"] = {
+	name = "Laser",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { critChance = 5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Laser",
+			baseEffectiveness = 4.25,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				triggerable = true,
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_is_projectile",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPSPlagueNymphRailGun"] = {
+	name = "Rail Gun",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/passives/MaceNotable2.dds",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { critChance = 5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			baseEffectiveness = 4.25,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				projectile = true,
+				triggerable = true,
+				hit = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1125 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 60 },
+				{ "spell_maximum_action_distance_+%", -50 },
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", -60 },
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"action_attack_or_cast_time_uses_animation_length",
+				"always_pierce",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GSTwilightOrderPlagueNymphLaser"] = {
+	name = "Laser",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { critChance = 5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Laser",
+			baseEffectiveness = 4.25,
+			incrementalEffectiveness = 0.21999999880791,
+			damageIncrementalEffectiveness = 0.013000000268221,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				triggerable = true,
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_is_projectile",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MPSTwilightOrderPlagueNymphRailGun"] = {
+	name = "Rail Gun",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/passives/MaceNotable2.dds",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 8, critChance = 5, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			baseEffectiveness = 4.25,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				projectile = true,
+				triggerable = true,
+				hit = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1125 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 60 },
+				{ "spell_maximum_action_distance_+%", -50 },
+				{ "monster_penalty_against_minions_damage_+%_final_vs_player_minions", -60 },
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"action_attack_or_cast_time_uses_animation_length",
+				"always_pierce",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GSSerpentClanAcidSpit"] = {
+	name = "Acid Spit",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { cooldown = 1.5, critChance = 5, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Acid Spit",
+			baseEffectiveness = 1.75,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "geometry_spell",
+			baseFlags = {
+				spell = true,
+				triggerable = true,
+			},
+			stats = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+				"is_area_damage",
+				"global_poison_on_hit",
+			},
+			notMinionStat = {
+				"spell_minimum_base_physical_damage",
+				"spell_maximum_base_physical_damage",
+			},
+			levels = {
+				[1] = { 0.80000001192093, 1.2000000476837, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["HyenaCentaurSpearThrowCliff"] = {
+	name = "Spear Throw",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Projectile",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "monster_projectile_variation", 1084 },
+				{ "spell_maximum_action_distance_+%", 0 },
+				{ "projectile_spread_radius", 10 },
+				{ "main_hand_local_maim_on_hit_%", 30 },
+			},
+			stats = {
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_ballistic_angle_from_target_distance",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["MeleeAtAnimationSpeed2"] = {
+	name = "Basic Attack",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/iconbasicattack.dds",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Basic Attack",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			stats = {
+				"skill_can_fire_arrows",
+				"skill_can_fire_wand_projectiles",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["MAASBaronEndgameBasic"] = {
+	name = "Basic Attack",
+	hidden = true,
+	icon = "Art/2DArt/SkillIcons/iconbasicattack.dds",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Basic Attack",
+			baseEffectiveness = 0,
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "maim_on_hit_%", 30 },
+				{ "bleed_on_hit_with_attacks_%", 50 },
+			},
+			stats = {
+				"skill_can_fire_arrows",
+				"skill_can_fire_wand_projectiles",
+				"action_attack_or_cast_time_uses_animation_length",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["GAArenaBeastSlam"] = {
+	name = "Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.35, cooldown = 6, levelRequirement = 0, storedUses = 1, },
+	},
+	statSets = {
+		[1] = {
+			label = "Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "base_skill_area_of_effect_+%", 35 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastSlamEmpowered"] = {
+	name = "Empowered Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Empowered Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAGoblinArenaBeastHeadbutt"] = {
+	name = "Headbutt",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Headbutt",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "hit_damage_stun_multiplier_+%", 100 },
+			},
+			stats = {
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAGoblinArenaBeastHeadbuttEmpowered"] = {
+	name = "Empowered Headbutt",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Empowered Headbutt",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAGoblinArenaBeastGroundSlash"] = {
+	name = "Ground Slash",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.6, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Ground Slash",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 25 },
+			},
+			stats = {
+				"is_area_damage",
+				"base_skill_can_be_blocked",
+				"base_skill_can_be_avoided_by_dodge_roll",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAGoblinArenaBeastGroundSlashLightning"] = {
+	name = "Lightning Ground Slash",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Lightning Ground Slash",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 50 },
+			},
+			stats = {
+				"is_area_damage",
+				"base_skill_can_be_blocked",
+				"base_skill_can_be_avoided_by_dodge_roll",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossBigSlam"] = {
+	name = "Big Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.75, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Big Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+				{ "base_skill_area_of_effect_+%", 15 },
+			},
+			stats = {
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossShockwave"] = {
+	name = "Shockwave",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Shockwave",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			stats = {
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossPunchLeft"] = {
+	name = "Punch",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Punch",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "base_skill_area_of_effect_+%", 35 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_skill_cannot_be_avoided_by_dodge_roll_or_blocked",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossPunchLeftEmpowered"] = {
+	name = "Empowered Punch",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Empowered Punch",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossPunchRight"] = {
+	name = "Punch",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Punch",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			constantStats = {
+				{ "base_skill_area_of_effect_+%", 35 },
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+				"base_skill_cannot_be_avoided_by_dodge_roll_or_blocked",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossPunchRightEmpowered"] = {
+	name = "Empowered Punch",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Empowered Punch",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossFissureDamage"] = {
+	name = "Fissure",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.65, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Fissure",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 40 },
+			},
+			stats = {
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastBossFissureExplosion"] = {
+	name = "Fissure Explosion",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 0.65, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Fissure Explosion",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				area = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 40 },
+			},
+			stats = {
+				"is_area_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["CGEArenaBeastBossSulpurGas"] = {
+	name = "Sulphur Gas",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Sulphur Gas",
+			baseEffectiveness = 22,
+			incrementalEffectiveness = 0.10000000149012,
+			damageIncrementalEffectiveness = 0.017500000074506,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				spell = true,
+				area = true,
+				triggerable = true,
+				duration = true,
+			},
+			constantStats = {
+				{ "active_skill_area_of_effect_radius_+%_final", -80 },
+				{ "base_skill_effect_duration", 10000 },
+				{ "ground_sulphite_art_variation", 1 },
+			},
+			stats = {
+				"base_lightning_damage_to_deal_per_minute",
+				"base_physical_damage_to_deal_per_minute",
+			},
+			levels = {
+				[1] = { 8.3333335195979, 8.3333335195979, statInterpolation = { 3, 3, }, actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastLeapSlam"] = {
+	name = "Leap Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Leap Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastLeapSlamEnraged"] = {
+	name = "Enraged Leap Slam",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Enraged Leap Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["GAArenaBeastLeapSlamEnragedKick"] = {
+	name = "Enraged Kick",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Enraged Kick",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				melee = true,
+				area = true,
+			},
+			constantStats = {
+				{ "active_skill_base_physical_damage_%_to_convert_to_lightning", 30 },
+			},
+			stats = {
+				"is_area_damage",
+				"action_attack_or_cast_time_uses_animation_length",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+
+skills["DTTParasiteSwarmLeap"] = {
+	name = "Leap",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Movement] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Leap Slam",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+			},
+			constantStats = {
+				{ "walk_emerge_extra_distance", 20 },
+				{ "leap_slam_minimum_distance", 40 },
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["DTTParasiteSwarmLeapAttach"] = {
+	name = "Leap Attach",
+	hidden = true,
+	icon = "",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Movement] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 0.5,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Leap Attach",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}
+skills["BlackStriderWebProjectile"] = {
+	name = "Web Projectile",
+	hidden = true,
+	icon = "",
+	description = "Generic monster mortar skill. Like Monster Projectile but has an impact effect.",
+	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
+	castTime = 1,
+	qualityStats = {
+	},
+	levels = {
+		[1] = { levelRequirement = 0, },
+	},
+	statSets = {
+		[1] = {
+			label = "Web Projectile",
+			incrementalEffectiveness = 0.054999999701977,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				attack = true,
+				projectile = true,
+				triggerable = true,
+			},
+			constantStats = {
+				{ "projectile_minimum_range", 15 },
+				{ "number_of_projectiles_override", 1 },
+			},
+			stats = {
+				"is_area_damage",
+				"base_is_projectile",
+				"projectile_uses_contact_position",
+				"use_scaled_contact_offset",
+				"base_deal_no_damage",
+			},
+			levels = {
+				[1] = { actorLevel = 1, },
+			},
+		},
+	}
+}

--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -8345,6 +8345,84 @@ minions["Metadata/Monsters/PorcupineAnt/PorcupineAntSmall"] = {
 	},
 }
 
+minions["Metadata/Monsters/PorcupineAnt/PorcupineAntMedium"] = {
+	name = "Rasp Scavenger",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "melee", "MonsterStab_onhit_audio", "not_dex", "not_int", "physical_affinity", "ranged", "slow_movement", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.35,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 26,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Confluence (Map)",
+		"Deshar (Act 2)",
+		"The Dreadnought's Wake (Act 2)",
+		"The Khari Crossing (Act 6)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GPAPorcupineAntSpikeNova",
+		"MMAPorcupineAntSpikeball",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.6, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2600]
+	},
+}
+
+minions["Metadata/Monsters/PorcupineAnt/PorcupineAntLarge"] = {
+	name = "Rasp Scavenger",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "medium_movement", "melee", "MonsterStab_onhit_audio", "not_dex", "not_int", "physical_affinity", "ranged", },
+	life = 1.2,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.4,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.2,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 14,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 34,
+	spectreReservation = 57,
+	companionReservation = 32.7,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Confluence (Map)",
+		"Deshar (Act 2)",
+		"The Dreadnought's Wake (Act 2)",
+		"The Khari Crossing (Act 6)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GPAPorcupineAntSpikeNova",
+		"MMAPorcupineAntSpikeball",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.6, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2600]
+	},
+}
+
 minions["Metadata/Monsters/CaveDweller/CaveDweller"] = {
 	name = "Tombshrieker",
 	monsterTags = { "allows_inc_aoe", "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "melee", "not_dex", "not_int", "physical_affinity", "red_blood", },
@@ -20584,7 +20662,7 @@ minions["Metadata/Monsters/LeagueIncursionNew/Thaumaturge/VaalThaumaturgeSpear"]
 
 minions["Metadata/Monsters/LeagueIncursionNew/MiniBosses/SoulCoreQuadrillaBoss/SoulCoreQuadrillaMinion"] = {
 	name = "Quadrilla Sergeant",
-	monsterTags = { "2HBluntStone_onhit_audio", "beast", "fast_movement", "humanoid", "incursion_unique_quadrilla", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "2HBluntStone_onhit_audio", "beast", "fast_movement", "humanoid", "incursion_unique_quadrilla", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	life = 2.5,
 	baseDamageIgnoresAttackSpeed = true,
 	armour = 0.66,
@@ -20626,7 +20704,7 @@ minions["Metadata/Monsters/LeagueIncursionNew/MiniBosses/SoulCoreQuadrillaBoss/S
 
 minions["Metadata/Monsters/LeagueIncursionNew/MiniBosses/IncursionChainedBeastBoss/ChainedBeastBossMinion_"] = {
 	name = "Unchained Beast",
-	monsterTags = { "beast", "Claw_onhit_audio", "incursion_unique_chained_beast", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "Claw_onhit_audio", "incursion_unique_chained_beast", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", "boss", },
 	life = 2.5,
 	baseDamageIgnoresAttackSpeed = true,
 	armour = 0.66,
@@ -20740,7 +20818,7 @@ minions["Metadata/Monsters/LeagueExpeditionNew/Expedition2/HumanoidFaction/VaalF
 
 minions["Metadata/Monsters/CrowBell/CrowBellBossMinion1"] = {
 	name = "The Crowbell",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "red_blood", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -20815,7 +20893,7 @@ minions["Metadata/Monsters/CrowBell/CrowBellBossMinion1"] = {
 
 minions["Metadata/Monsters/CrowBell/CrowBellBossMinion2"] = {
 	name = "The Black Crow",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "red_blood", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -20890,7 +20968,7 @@ minions["Metadata/Monsters/CrowBell/CrowBellBossMinion2"] = {
 
 minions["Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion1"] = {
 	name = "The Devourer",
-	monsterTags = { "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -20953,7 +21031,7 @@ minions["Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion1"] = {
 
 minions["Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2"] = {
 	name = "Gorian, the Moving Earth",
-	monsterTags = { "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21016,7 +21094,7 @@ minions["Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2"] = {
 
 minions["Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion1"] = {
 	name = "Xyclucian, the Chimera",
-	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21086,7 +21164,7 @@ minions["Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion1"] = {
 
 minions["Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion2"] = {
 	name = "Xilozoma, the Maw-Beast",
-	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21156,7 +21234,7 @@ minions["Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion2"] = {
 
 minions["Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion1"] = {
 	name = "Uxmal, the Beastlord",
-	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21220,7 +21298,7 @@ minions["Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion1"] = {
 
 minions["Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion2"] = {
 	name = "Gressor-Kul, the Apex",
-	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Claw_onhit_audio", "flying", "mammal_beast", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21284,7 +21362,7 @@ minions["Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion2"] = {
 
 minions["Metadata/Monsters/Bird2/MutantBird2Minion1"] = {
 	name = "Scourge of the Skies",
-	monsterTags = { "beast", "Beast_onhit_audio", "flying", "red_blood", "very_slow_movement", },
+	monsterTags = { "beast", "Beast_onhit_audio", "flying", "red_blood", "very_slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21368,7 +21446,7 @@ minions["Metadata/Monsters/Bird2/MutantBird2Minion1"] = {
 
 minions["Metadata/Monsters/Bird2/MutantBird2Minion2"] = {
 	name = "Chetza, the Feathered Plague",
-	monsterTags = { "beast", "Beast_onhit_audio", "flying", "red_blood", "very_slow_movement", },
+	monsterTags = { "beast", "Beast_onhit_audio", "flying", "red_blood", "very_slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21452,7 +21530,7 @@ minions["Metadata/Monsters/Bird2/MutantBird2Minion2"] = {
 
 minions["Metadata/Monsters/HyenaMonster/RathbreakerBossMinion1"] = {
 	name = "Rathbreaker",
-	monsterTags = { "2HSharpMetal_onhit_audio", "beast", "fast_movement", "mammal_beast", "melee", "physical_affinity", "red_blood", },
+	monsterTags = { "2HSharpMetal_onhit_audio", "beast", "fast_movement", "mammal_beast", "melee", "physical_affinity", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21501,7 +21579,7 @@ minions["Metadata/Monsters/HyenaMonster/RathbreakerBossMinion1"] = {
 
 minions["Metadata/Monsters/HyenaMonster/RathbreakerBossMinion2"] = {
 	name = "Caedron, the Hyena Lord",
-	monsterTags = { "2HSharpMetal_onhit_audio", "beast", "fast_movement", "mammal_beast", "melee", "physical_affinity", "red_blood", },
+	monsterTags = { "2HSharpMetal_onhit_audio", "beast", "fast_movement", "mammal_beast", "melee", "physical_affinity", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21550,7 +21628,7 @@ minions["Metadata/Monsters/HyenaMonster/RathbreakerBossMinion2"] = {
 
 minions["Metadata/Monsters/Quadrilla/QuadrillaBossMinion1"] = {
 	name = "Mighty Silverfist",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21595,7 +21673,7 @@ minions["Metadata/Monsters/Quadrilla/QuadrillaBossMinion1"] = {
 
 minions["Metadata/Monsters/Quadrilla/QuadrillaBossMinion2"] = {
 	name = "Zekoa, the Headcrusher",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21640,7 +21718,7 @@ minions["Metadata/Monsters/Quadrilla/QuadrillaBossMinion2"] = {
 
 minions["Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion1"] = {
 	name = "The Abominable Yeti",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21692,7 +21770,7 @@ minions["Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion1"] = {
 
 minions["Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion2"] = {
 	name = "The Frostborn Fiend",
-	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "mammal_beast", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21744,7 +21822,7 @@ minions["Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion2"] = {
 
 minions["Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion1"] = {
 	name = "Great White One",
-	monsterTags = { "beast", "fast_movement", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "fast_movement", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21818,7 +21896,7 @@ minions["Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion1"] = {
 
 minions["Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion2"] = {
 	name = "The Sandstrider",
-	monsterTags = { "beast", "fast_movement", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "fast_movement", "MonsterBlunt_onhit_audio", "not_dex", "not_int", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21892,7 +21970,7 @@ minions["Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion2"] = {
 
 minions["Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_"] = {
 	name = "The Ravenous Fang",
-	monsterTags = { "beast", "Claw_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", },
+	monsterTags = { "beast", "Claw_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -21961,7 +22039,7 @@ minions["Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_"] = {
 
 minions["Metadata/Monsters/ChaosGodOwlBoss/ChaosGodOwlBossMinion"] = {
 	name = "Bahlak, the Sky Seer",
-	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22025,7 +22103,7 @@ minions["Metadata/Monsters/ChaosGodOwlBoss/ChaosGodOwlBossMinion"] = {
 
 minions["Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion1"] = {
 	name = "Rakkar, the Frozen Talon",
-	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22088,7 +22166,7 @@ minions["Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion1"] = {
 
 minions["Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion2"] = {
 	name = "Thraeven, Wing of Winter",
-	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", },
+	monsterTags = { "beast", "Beast_onhit_audio", "flying", "not_str", "red_blood", "slow_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22151,7 +22229,7 @@ minions["Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion2"] = {
 
 minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion1_"] = {
 	name = "Ashar, the Sand Mother",
-	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "sanctum_monster", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "sanctum_monster", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22203,7 +22281,7 @@ minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion1_"] =
 
 minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion2"] = {
 	name = "Karash, The Dune Dweller",
-	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "sanctum_monster", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "sanctum_monster", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22255,7 +22333,7 @@ minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion2"] = 
 
 minions["Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion1"] = {
 	name = "Vornas, the Fell Flame",
-	monsterTags = { "beast", "Claw_onhit_audio", "fast_movement", "fire", "mammal_beast", "not_dex", "not_int", },
+	monsterTags = { "beast", "Claw_onhit_audio", "fast_movement", "fire", "mammal_beast", "not_dex", "not_int", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22314,7 +22392,7 @@ minions["Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion1"] = 
 
 minions["Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion2"] = {
 	name = "Morvak, the Infernal",
-	monsterTags = { "beast", "Claw_onhit_audio", "fast_movement", "fire", "mammal_beast", "not_dex", "not_int", },
+	monsterTags = { "beast", "Claw_onhit_audio", "fast_movement", "fire", "mammal_beast", "not_dex", "not_int", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22373,7 +22451,7 @@ minions["Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion2"] = 
 
 minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion"] = {
 	name = "Akthi, the Final Sting",
-	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", },
+	monsterTags = { "beast", "fast_movement", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "red_blood", "very_fast_movement", "boss", },
 	extraFlags = {
 		recommendedBeast = true,
 	},
@@ -22413,6 +22491,954 @@ minions["Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion"] 
 		-- TamedMonsterImpale [cannot_consume_impale = 1]
 		mod("ImpaleChance", "BASE", 50, 0, 0), -- TamedMonsterImpale [impale_on_hit_%_chance = 50]
 		-- TamedMonsterImpale [impale_magnitude_+% = 50]
+		-- MonsterUniqueT2Boss [monster_slain_experience_+% = 0]
+		-- MonsterUniqueT2Boss [monster_dropped_item_quantity_+% = 0]
+		-- MonsterUniqueT2Boss [monster_dropped_item_rarity_+% = 1600]
+		-- MonsterUniqueT2Boss [i_am_boss_of_tier = 2]
+		-- set_corpse_cannot_be_destroyed [set_corpse_cannot_be_destroyed = 1]
+		mod("StunDuration", "OVERRIDE", 4, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 4000]
+		-- set_use_boss_incremental_stats [set_use_boss_incremental_stats = 1]
+	},
+}
+minions["Metadata/Monsters/Monkeys/MonkeyJungleTamed"] = {
+	name = "Feral Primate",
+	monsterTags = { "animal_claw_weapon", "beast", "flesh_armour", "is_unarmed", "mammal_beast", "medium_movement", "melee", "not_int", "not_str", "physical_affinity", "primate_beast", "red_blood", "small_height", "Unarmed_onhit_audio", },
+	life = 0.65,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.3,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.65,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 7,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 33,
+	spectreReservation = 36,
+	companionReservation = 24,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Jungle Ruins (Act 3)",
+		"Kriar Peaks (Act 6)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeedComboTEMP",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.733, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2733]
+	},
+}
+
+minions["Metadata/Monsters/QuillCrab/QuillCrabBigElite"] = {
+	name = "Porcupine Crab",
+	monsterTags = { "allows_additional_projectiles", "beast", "fire_affinity", "insect", "MonsterStab_onhit_audio", "not_dex", "not_int", "ranged", "red_blood", "slow_movement", },
+	life = 0.85,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.25,
+	fireResist = 30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.85,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 50,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 27,
+	spectreReservation = 44,
+	companionReservation = 27.6,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"The Riverbank (Act 1)",
+		"Found in Maps",
+	},
+	skillList = {
+		"QuillCrabSpikeBurstEmptyAction",
+		"QuillCrabSpikeBurst",
+		"QuillCrabSpikeShrapnelAudio",
+		"QuillCrabSpikeShrapnel",
+		"CGEQuillCrabFireGround",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 3, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 3000]
+	},
+}
+
+minions["Metadata/Monsters/QuillCrab/QuillCrabBigPoisonElite"] = {
+	name = "Venomous Crab Matriarch",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "monster_applies_poison", "MonsterStab_onhit_audio", "not_dex", "not_int", "physical_affinity", "ranged", "red_blood", "slow_movement", },
+	life = 0.85,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.25,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.85,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 50,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 27,
+	spectreReservation = 44,
+	companionReservation = 27.6,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Hunting Grounds (Act 1)",
+		"Sandspit (Map)",
+		"Found in Maps",
+	},
+	skillList = {
+		"QuillCrabSpikeBurstEmptyAction",
+		"QuillCrabSpikeBurstPoison",
+		"QuillCrabSpikeShrapnelAudioPoison",
+		"QuillCrabSpikeShrapnelPoison",
+		"CGEQuillCrabCausticGround",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 3, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 3000]
+	},
+}
+
+minions["Metadata/Monsters/HuhuGrub/HuhuGrubLarvaeRanged1Spectre"] = {
+	name = "Flesh Larva",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "cannot_be_monolith", "insect", "medium_movement", "melee", "monster_applies_poison", "monster_barely_moves", "monster_summons_adds", "physical_affinity", "ranged", "red_blood", "Stab_onhit_audio", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.8,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 33,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Abyssal Depths (Act 2)",
+		"Dark Domain",
+		"Lightless Passage (Act 2)",
+		"Lightless Void",
+		"Mud Burrow (Act 1)",
+		"Pools of Khatal (Act 6)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"HuhuGrubLarvaeMortar",
+		"HuhuGrubRangedStanceChange",
+	},
+	modList = {
+	},
+}
+
+minions["Metadata/Monsters/DemonSpiders/BlackStrider"] = {
+	name = "Black Strider",
+	monsterTags = { "allows_inc_aoe", "beast", "fast_movement", "melee", "physical_affinity", "spider", "Stab_onhit_audio", },
+	life = 2,
+	baseDamageIgnoresAttackSpeed = true,
+	fireResist = -30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 2,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 28,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 43,
+	spectreReservation = 84,
+	companionReservation = 42.3,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Ancient Gateway (Map)",
+		"Ashen Forest (Act 6)",
+		"Eastern Gateway (Map)",
+		"Spider Woods (Map)",
+		"The Matriarch Halls (Map)",
+		"The Patriarch Halls (Map)",
+		"The Titan Grotto (Act 2)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Western Gateway (Map)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeedComboTEMP",
+		"BlackStriderMassMortar",
+		"GTBlackStriderMassMortar",
+		"GABlackStriderWebMortarImpact",
+		"BlackStriderWebProjectile",
+		"MPWBlackStriderWebProjectile",
+	},
+	modList = {
+		-- MonsterIgnoreActorScaleFromStats [ignore_actor_scale_from_stats = 1]
+		mod("StunDuration", "OVERRIDE", 2.5, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2500]
+	},
+}
+
+minions["Metadata/Monsters/DemonSpiders/BlackStriderSanctumTrial"] = {
+	name = "Black Strider",
+	monsterTags = { "allows_inc_aoe", "beast", "fast_movement", "melee", "physical_affinity", "sanctum_monster", "spider", "Stab_onhit_audio", },
+	life = 2,
+	baseDamageIgnoresAttackSpeed = true,
+	fireResist = -30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 2,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 28,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 43,
+	spectreReservation = 84,
+	companionReservation = 42.3,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Ancient Gateway (Map)",
+		"Ashen Forest (Act 6)",
+		"Eastern Gateway (Map)",
+		"Spider Woods (Map)",
+		"The Matriarch Halls (Map)",
+		"The Patriarch Halls (Map)",
+		"The Titan Grotto (Act 2)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Western Gateway (Map)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeedComboTEMP",
+		"CGESanctumBlackStriderWeb",
+		"MPWBlackStriderWebProjectileSanctum",
+	},
+	modList = {
+		-- MonsterIgnoreActorScaleFromStats [ignore_actor_scale_from_stats = 1]
+		mod("StunDuration", "OVERRIDE", 2.5, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2500]
+	},
+}
+
+minions["Metadata/Monsters/EtchedBeetles/SmallEtchedBeetleArmouredDullSanctumScorpionBoss"] = {
+	name = "Tarnished Beetle",
+	monsterTags = { "allows_inc_aoe", "beast", "Claw_onhit_audio", "insect", "lightning_affinity", "medium_movement", "melee", "not_dex", "not_int", "sanctum_monster", },
+	life = 0.85,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.5,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.85,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 6,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 31,
+	spectreReservation = 44,
+	companionReservation = 27.6,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Keth (Act 2)",
+		"The Galai Gates (Act 6)",
+		"The Khari Crossing (Act 6)",
+		"The Lost City (Act 2)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GSBeetleLightningNova",
+		"EABeetleNovaCharge",
+	},
+	modList = {
+		-- MonsterNoDropsOrExperience [monster_no_drops_or_experience = 1]
+	},
+}
+
+minions["Metadata/Monsters/EtchedBeetles/MediumEtchedBeetleArmouredTuskWideSanctumTrial"] = {
+	name = "Adorned Scarab",
+	monsterTags = { "2HSharpMetal_onhit_audio", "allows_inc_aoe", "beast", "fast_movement", "insect", "lightning_affinity", "melee", "not_dex", "not_int", "sanctum_monster", },
+	life = 1.5,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.7,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.5,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 11,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 47,
+	spectreReservation = 67,
+	companionReservation = 36.6,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Spring (Map)",
+		"The Galai Gates (Act 6)",
+		"The Lost City (Act 2)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 2)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GAMediumBeetleChargedSunder",
+		"GAMediumBeetleSunder",
+		"WalkEmergeSanctumPortal",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.466, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2466]
+	},
+}
+
+minions["Metadata/Monsters/EtchedBeetles/LargeEtchedBeetleBossMinion"] = {
+	name = "Adorned Beetle",
+	monsterTags = { "allows_inc_aoe", "beast", "Claw_onhit_audio", "fast_movement", "insect", "lightning_affinity", "melee", "not_dex", "not_int", },
+	life = 0.85,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.5,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.85,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 6,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 47,
+	spectreReservation = 44,
+	companionReservation = 27.6,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Spring (Map)",
+		"The Galai Gates (Act 6)",
+		"The Lost City (Act 2)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 2)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+	},
+	modList = {
+	},
+}
+
+minions["Metadata/Monsters/HyenaMonster/HyenaMonsterHighAggro"] = {
+	name = "Hyena Demon",
+	monsterTags = { "beast", "Beast_onhit_audio", "fast_movement", "mammal_beast", "melee", "not_int", "not_str", "physical_affinity", "red_blood", "very_fast_movement", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.3,
+	fireResist = 0,
+	coldResist = 30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 9,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 50,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Mesa (Map)",
+		"Precursor Tower (Map)",
+		"Qimah (Act 6)",
+		"Savannah (Map)",
+		"The Bone Pits (Act 2)",
+		"Found in Maps",
+		"Vastiri Outskirts (Act 2)",
+		"Wetlands (Map)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2000]
+	},
+}
+
+minions["Metadata/Monsters/HyenaMonster/HyenaCentaurSpearBossMinion_"] = {
+	name = "Sun Clan Scavenger",
+	monsterTags = { "allows_additional_projectiles", "beast", "fast_movement", "mammal_beast", "melee", "physical_affinity", "red_blood", "SpearMetal_onhit_audio", },
+	life = 2,
+	baseDamageIgnoresAttackSpeed = true,
+	fireResist = 0,
+	coldResist = 30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 2,
+	damageSpread = 0.2,
+	attackTime = 1.11,
+	attackRange = 8,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 39,
+	spectreReservation = 84,
+	companionReservation = 42.3,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Mesa (Map)",
+		"Precursor Tower (Map)",
+		"Qimah (Act 6)",
+		"Savannah (Map)",
+		"The Bone Pits (Act 2)",
+		"Found in Maps",
+		"Vastiri Outskirts (Act 2)",
+		"Wetlands (Map)",
+	},
+	skillList = {
+		"HyenaCentaurMeleeStab",
+		"HyenaCentaurMeleeSwipe",
+		"HyenaCentaurSpearThrow",
+		"EGHyenaDogpile",
+		"EGHyenaDogpileBig",
+		"HyenaCentaurSpearThrowCliff",
+		"DTTHyenaCentaurCliffJump",
+		"EASHyenaCliffJump",
+		"EASHyenaCliffFlee",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 3.033, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 3033]
+	},
+}
+
+minions["Metadata/Monsters/PorcupineAnt/PorcupineAntMediumSanctumTrial"] = {
+	name = "Rasp Scavenger",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "melee", "MonsterStab_onhit_audio", "not_dex", "not_int", "physical_affinity", "ranged", "sanctum_monster", "slow_movement", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.35,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 26,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Confluence (Map)",
+		"Deshar (Act 2)",
+		"The Dreadnought's Wake (Act 2)",
+		"The Khari Crossing (Act 6)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GPAPorcupineAntSpikeNovaSanctum",
+		"MMAPorcupineAntSpikeballSanctum",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.6, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2600]
+	},
+}
+
+minions["Metadata/Monsters/PorcupineAnt/PorcupineAntLargeSanctumTrial"] = {
+	name = "Rasp Scavenger",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "medium_movement", "melee", "MonsterStab_onhit_audio", "not_dex", "not_int", "physical_affinity", "ranged", "sanctum_monster", },
+	life = 1.2,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.4,
+	fireResist = 0,
+	coldResist = -30,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.2,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 14,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 34,
+	spectreReservation = 57,
+	companionReservation = 32.7,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Confluence (Map)",
+		"Deshar (Act 2)",
+		"The Dreadnought's Wake (Act 2)",
+		"The Khari Crossing (Act 6)",
+		"Found in Maps",
+		"Trial of the Sekhemas (Floor 1)",
+		"Trial of the Sekhemas (Floor 3)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GPAPorcupineAntSpikeNovaSanctum",
+		"MMAPorcupineAntSpikeballSanctum",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 2.6, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2600]
+	},
+}
+
+minions["Metadata/Monsters/CaveDweller/CaveDwellerSanctumTrial__"] = {
+	name = "Tombshrieker",
+	monsterTags = { "allows_inc_aoe", "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "melee", "not_dex", "not_int", "physical_affinity", "red_blood", "sanctum_monster", },
+	life = 1.35,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.1,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 30,
+	chaosResist = 0,
+	damage = 1.35,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 11,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 33,
+	spectreReservation = 62,
+	companionReservation = 34.8,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Ancient Gateway (Map)",
+		"Eastern Gateway (Map)",
+		"Qimah Reservoir (Act 6)",
+		"Skull of the Titan (Act 2)",
+		"The Matriarch Halls (Map)",
+		"The Patriarch Halls (Map)",
+		"Found in Maps",
+		"Traitor's Passage (Act 2)",
+		"Trial of the Sekhemas (Floor 1)",
+		"Western Gateway (Map)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GSCaveDwellerSonicPulse",
+		"GPSCaveDwellerSuperProjectileSanctum",
+		"GSCaveDwellerSuperProjectile",
+	},
+	modList = {
+		mod("StunDuration", "OVERRIDE", 3, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 3000]
+	},
+}
+
+minions["Metadata/Monsters/PlagueNymph/PlagueNymphFoundry"] = {
+	name = "Plague Nymph",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "insect", "melee", "MonsterStab_onhit_audio", "not_int", "not_str", "physical_affinity", "ranged", "red_blood", "slow_movement", },
+	life = 1.25,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.2,
+	fireResist = -30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.25,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 11,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 25,
+	spectreReservation = 59,
+	companionReservation = 33.3,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Hive (Map)",
+		"Howling Caves (Act 6)",
+		"Mawdun Mine (Act 2)",
+		"Pools of Khatal (Act 6)",
+		"The Dreadnought's Wake (Act 2)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"GSPlagueNymphLaser",
+		"MPSPlagueNymphRailGun",
+	},
+	modList = {
+		-- MonsterMaimOnHitChance [maim_on_hit_% = 25]
+		mod("StunDuration", "OVERRIDE", 1.5, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 1500]
+	},
+}
+
+minions["Metadata/Monsters/ChawMongrel/ChawMongrelLeashBoss"] = {
+	name = "Chaw Mongrel",
+	monsterTags = { "beast", "Beast_onhit_audio", "fast_movement", "melee", "not_int", "physical_affinity", "red_blood", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.2,
+	evasion = 0.4,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 0.99,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 48,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"The Azak Bog (Act 3)",
+		"The Matlan Waterways (Act 3)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"DoLiterallyNothing",
+	},
+	modList = {
+		-- MonsterMaimOnHit [global_maim_on_hit = 1]
+	},
+}
+
+minions["Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion2"] = {
+	name = "The Ravenous Fang",
+	monsterTags = { "beast", "Claw_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "red_blood", "boss", },
+	life = 3,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.25,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 75,
+	chaosResist = 0,
+	damage = 2.5,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 28,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 30,
+	spectreReservation = 99,
+	companionReservation = 47.4,
+	monsterCategory = "Beast",
+	spawnLocation = {
+	},
+	skillList = {
+		"MeleeAtAnimationSpeedBoss",
+		"GAArenaBeastSlam",
+		"GAArenaBeastSlamEmpowered",
+		"EASGoblinArenaBeastCombo",
+		"GAGoblinArenaBeastHeadbutt",
+		"GAGoblinArenaBeastHeadbuttEmpowered",
+		"GAGoblinArenaBeastGroundSlash",
+		"EASArenaBeastBossFissureSlams",
+		"WalkEmergeArenaBeastBoss",
+		"GTArenaBeastBossShockwave",
+		"EGArenaBeastBossShockwaveDetonation",
+		"GAArenaBeastBossBigSlam",
+		"GAArenaBeastBossShockwave",
+		"GAArenaBeastBossPunchLeft",
+		"GAArenaBeastBossPunchLeftEmpowered",
+		"GAArenaBeastBossPunchRight",
+		"GAArenaBeastBossPunchRightEmpowered",
+		"GAArenaBeastBossFissureDamage",
+		"GAArenaBeastBossFissureExplosion",
+		"CGEArenaBeastBossSulpurGas",
+		"EASBlindBeastEnrage",
+		"GAGoblinArenaBeastGroundSlashLightning",
+		"GAGoblinArenaBeastLightningInfuse",
+		"EAABlindBeastDash",
+		"GAArenaBeastLeapSlam",
+		"GAArenaBeastLeapSlamEnraged",
+		"GAArenaBeastLeapSlamEnragedKick",
+	},
+	modList = {
+		mod("PhysicalCanShock", "FLAG", 1, 0, 0), -- TamedMonsterAllDamageShocksAndEffect [all_damage_can_shock = 1]
+		mod("EnemyShockMagnitude", "INC", 100, 0, 0), -- TamedMonsterAllDamageShocksAndEffect [shock_effect_+% = 100]
+		-- MonsterUniqueT2Boss [monster_slain_experience_+% = 0]
+		-- MonsterUniqueT2Boss [monster_dropped_item_quantity_+% = 0]
+		-- MonsterUniqueT2Boss [monster_dropped_item_rarity_+% = 1600]
+		-- MonsterUniqueT2Boss [i_am_boss_of_tier = 2]
+		-- set_corpse_cannot_be_destroyed [set_corpse_cannot_be_destroyed = 1]
+		mod("StunDuration", "OVERRIDE", 4, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 4000]
+		-- set_use_boss_incremental_stats [set_use_boss_incremental_stats = 1]
+		mod("StunDuration", "OVERRIDE", 3.6, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 3600]
+		-- set_monster_delay_item_drops_millis [set_monster_delay_item_drops_millis = 1600]
+	},
+}
+
+minions["Metadata/Monsters/ParasiteMonsters/ParasiteMonster01"] = {
+	name = "Armoured Parasite",
+	monsterTags = { "beast", "insect", "MonsterStab_onhit_audio", "red_blood", "very_slow_movement", },
+	life = 0.8,
+	baseDamageIgnoresAttackSpeed = true,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.8,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 5,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 12,
+	spectreReservation = 42,
+	companionReservation = 26.7,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Isle of Decay (Act 4)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"EGParasiteRevive",
+		"DTTParasiteSwarmLeap",
+		"DTTParasiteSwarmLeapAttach",
+	},
+	modList = {
+	},
+}
+
+minions["Metadata/Monsters/ParasiteMonsters/ParasiteMonster02"] = {
+	name = "Kreth Parasite",
+	monsterTags = { "beast", "medium_movement", "MonsterStab_onhit_audio", "not_int", "not_str", "red_blood", },
+	life = 0.7,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.5,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.7,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 8,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 32,
+	spectreReservation = 38,
+	companionReservation = 24.9,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Isle of Decay (Act 4)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"EGParasiteRevive",
+		"DTTParasiteSwarmLeap",
+		"DTTParasiteSwarmLeapAttach",
+	},
+	modList = {
+	},
+}
+
+minions["Metadata/Monsters/MorayClanMonster/MorayClan"] = {
+	name = "Moray Clan",
+	monsterTags = { "beast", "fast_movement", "not_int", "not_str", "Unarmed_onhit_audio", },
+	life = 1,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.25,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 46,
+	spectreReservation = 50,
+	companionReservation = 30,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Isle of Decay (Act 4)",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"SerpentClanTailWhip",
+		"GSSerpentClanAcidSpit",
+	},
+	modList = {
+	},
+}
+
+minions["Metadata/Monsters/Baron/BaronWerewolfProwlerSummon"] = {
+	name = "Tendril Prowler",
+	monsterTags = { "beast", "Beast_onhit_audio", "mammal_beast", "medium_movement", "not_int", "not_str", "red_blood", },
+	life = 1.4,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.4,
+	fireResist = -30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.54,
+	damageSpread = 0.2,
+	attackTime = 2.25,
+	attackRange = 12,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 37,
+	spectreReservation = 64,
+	companionReservation = 35.4,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Holten Estate (Act 6)",
+		"Ogham Manor (Act 1)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"MeleeAtAnimationSpeed2",
+		"MAASBaronEndgameBasic",
+	},
+	modList = {
+		-- MonsterNoDropsOrExperience [monster_no_drops_or_experience = 1]
+		-- BossMinionFlaskChargeIncrease300 [monster_slain_flask_charges_granted_+% = 300]
+		mod("StunDuration", "OVERRIDE", 2.25, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2250]
+	},
+}
+
+minions["Metadata/Monsters/RabidFeralDogMonster/RabidDogLargeFarmlandsNoName"] = {
+	name = "Rabid Dog",
+	monsterTags = { "beast", "mammal_beast", "melee", "not_int", "not_str", "physical_affinity", "quest_null_monster_mods", "red_blood", "Snap_onhit_audio", "very_slow_movement", },
+	life = 1.15,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.4,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.5,
+	damageSpread = 0.2,
+	attackTime = 1.5,
+	attackRange = 6,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 11,
+	spectreReservation = 55,
+	companionReservation = 32.1,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Ogham Farmlands (Act 1)",
+		"Riverhold (Map)",
+		"Scorched Farmlands (Act 6)",
+		"Found in Maps",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+	},
+	modList = {
+		-- has_quadruped_head_control_while_turning [has_quadruped_head_control_while_turning = 1]
+		-- quadruped_head_turn_duration_ms [quadruped_head_turn_duration_ms = 100]
+		mod("StunDuration", "OVERRIDE", 2.2, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 2200]
+	},
+}
+
+minions["Metadata/Monsters/PlagueNymph/TwilightOrderPlagueNymph"] = {
+	name = "Nymph Wasp",
+	monsterTags = { "allows_additional_projectiles", "allows_inc_aoe", "beast", "caster", "insect", "melee", "MonsterStab_onhit_audio", "not_int", "not_str", "physical_affinity", "ranged", "red_blood", "slow_movement", },
+	life = 1.25,
+	baseDamageIgnoresAttackSpeed = true,
+	evasion = 0.2,
+	fireResist = -30,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.25,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 11,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 25,
+	spectreReservation = 59,
+	companionReservation = 33.3,
+	monsterCategory = "Beast",
+	spawnLocation = {
+		"Arastas (Act 4)",
+		"Ashen Forest (Act 6)",
+		"Mournful Cliffside",
+	},
+	skillList = {
+		"MeleeAtAnimationSpeed",
+		"MPSTwilightOrderPlagueNymphRailGun",
+		"GSTwilightOrderPlagueNymphLaser",
+	},
+	modList = {
+		-- MonsterMaimOnHitChance [maim_on_hit_% = 25]
+		mod("StunDuration", "OVERRIDE", 1.5, 0, 0), -- set_base_heavy_stun_duration_ms [set_base_heavy_stun_duration_ms = 1500]
+	},
+}
+
+minions["Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion"] = {
+	name = "Anundr, the Sandworm",
+	monsterTags = { "beast", "Claw_onhit_audio", "mammal_beast", "medium_movement", "not_dex", "not_int", "boss", },
+	life = 2,
+	baseDamageIgnoresAttackSpeed = true,
+	armour = 0.35,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 30,
+	chaosResist = 0,
+	damage = 2.5,
+	damageSpread = 0.2,
+	attackTime = 2.01,
+	attackRange = 37,
+	accuracy = 1,
+	critChance = 5,
+	baseMovementSpeed = 30,
+	spectreReservation = 99,
+	companionReservation = 47.4,
+	monsterCategory = "Beast",
+	spawnLocation = {
+	},
+	skillList = {
+		"MeleeMudBurrowerLeftCleave",
+		"MeleeMudBurrowerRightCleave",
+		"MeleeMudBurrowerBite",
+		"MPAMudBurrowerBloodProj",
+		"MudBurrowerBurrowSpam",
+		"MudBurrowerEpicBurrowNoRetarget",
+		"MudBurrowerGoopGT",
+		"MPAMudBurrowerSprayProj",
+		"GAMudBurrowerBloodProj",
+		"MudBurrowerEpicBurrowTriggerGA",
+		"MudBurrowerMaggotSummon",
+		"MudBurrowerGoopTriggerEG",
+		"MudBurrowerGoopTriggerKnockbackGA",
+		"MPAMudBurrowerGoopSmallBall",
+		"GAMudBurrowerGoopSmallImpact",
+		"MPAMudBurrowerGoopBigBall",
+		"MudBurrowerGoopExplode",
+		"GAMudBurrowerSpraySmallImpact",
+		"GAMudBurrowerDivePush",
+		"GAMudBurrowerHeadSlam",
+		"CGEMudBurrowerVomit",
+		"MPAMudBurrowerVomitProj",
+	},
+	modList = {
+		mod("AilmentMagnitude", "MORE", 200, 0, 2097152), -- TamedMonsterPoisonMagnitude [active_skill_poison_effect_+%_final = 200]
 		-- MonsterUniqueT2Boss [monster_slain_experience_+% = 0]
 		-- MonsterUniqueT2Boss [monster_dropped_item_quantity_+% = 0]
 		-- MonsterUniqueT2Boss [monster_dropped_item_rarity_+% = 1600]

--- a/src/Export/Minions/SpectreList.txt
+++ b/src/Export/Minions/SpectreList.txt
@@ -30,6 +30,7 @@ Metadata/Monsters/TheCountsEliteGuardCorrupted/Ranged/CorruptedEliteRanger_     
 Metadata/Monsters/TheCountsEliteGuardCorrupted/MeleeVariantB/CorruptedEliteBloater        		----		Iron Enforcer
 Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion1                                  		----		The Devourer
 Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2                                  		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadTrap                                         		----		The Devourer
 Metadata/Monsters/MudBurrower/MudBurrowerTailBoss_                                        		----		The Devourer
 Metadata/Monsters/FungusZombie/FungusZombieMedium                                         		----		Fungal Zombie
 Metadata/Monsters/FungusZombie/FungusZombieLarge                                          		----		Fungal Zombie
@@ -43,6 +44,7 @@ Metadata/Monsters/BitterGuy/BitterGuyWifeSurge                                  
 Metadata/Monsters/BitterGuy/BitterGuyChild1Surge_                                         		----		Calum, Weeping Child
 Metadata/Monsters/BitterGuy/BitterGuyChild2Surge                                          		----		Torcall, Sobbing Child
 Metadata/Monsters/QuillCrab/QuillCrab                                                     		----		Porcupine Crab
+Metadata/Monsters/QuillCrab/QuillCrabBig                                                  		----		Porcupine Crab
 Metadata/Monsters/QuillCrab/QuillCrabBigElite                                             		----		Porcupine Crab
 Metadata/Monsters/QuillCrab/QuillCrabPoison                                               		----		Venomous Crab
 Metadata/Monsters/QuillCrab/QuillCrabBigPoison_                                           		----		Venomous Crab Matriarch
@@ -216,6 +218,7 @@ Metadata/Monsters/MarakethGuards/MarakethHeroGuard01___                         
 Metadata/Monsters/MarakethGuards/MarakethHeroGuard02                                      		----		Tanim
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptre                           		----		Terracotta Soldier
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreStatue                     		----		Terracotta Soldier
+Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreStatueBridge               		----		Terracotta Soldier
 Metadata/Monsters/BoneCultists/BoneCultists_Savage/BoneCultists_Savage__                  		----		Lost-men Subjugator
 Metadata/Monsters/BoneCultists/BoneCultists_Beast/BoneCultistBeast                        		----		Drudge Osseodon
 Metadata/Monsters/BoneCultists/BoneCultists_Beast/Runemarked/BoneCultistBeastRunemarked   		----		Drudge Osseodon
@@ -230,7 +233,10 @@ Metadata/Monsters/Skeletons/TitanGrotto/SkeletonTitanGrottoUnarmed_             
 Metadata/Monsters/Skeletons/TitanGrotto/SkeletonTitanGrottoSword_                         		----		Sandflesh Warrior
 Metadata/Monsters/Skeletons/TitanGrotto/SkeletonTitanGrottoCaster                         		----		Sandflesh Mage
 Metadata/Monsters/PorcupineAnt/PorcupineAntSmall                                          		----		Rasp Scavenger
+Metadata/Monsters/PorcupineAnt/PorcupineAntMedium                                         		----		Rasp Scavenger
 Metadata/Monsters/PorcupineAnt/PorcupineAntMediumSanctumTrial                             		----		Rasp Scavenger
+Metadata/Monsters/PorcupineAnt/PorcupineAntLarge                                          		----		Rasp Scavenger
+Metadata/Monsters/PorcupineAnt/PorcupineAntLargeSanctumTrial                              		----		Rasp Scavenger
 Metadata/Monsters/CaveDweller/CaveDweller                                                 		----		Tombshrieker
 Metadata/Monsters/CaveDweller/CaveDwellerSanctumTrial__                                   		----		Tombshrieker
 Metadata/Monsters/MineBat/MineBatDesertCaveNoEmerge                                       		----		Vesper Bat
@@ -321,6 +327,8 @@ Metadata/Monsters/CrazedCannibalPicts/PictFemaleStaff                           
 Metadata/Monsters/CrazedCannibalPicts/Runemarked/PictFemaleStaffRunemarked                		----		Cultist Witch
 Metadata/Monsters/CrazedCannibalPicts/PictMaleAxe                                         		----		Cultist Warrior
 Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeAxe                                      		----		Cultist Warrior
+Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeDagger                                   		----		Cultist Warrior
+Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeShield                                   		----		Cultist Warrior
 Metadata/Monsters/CrazedCannibalPicts/PictBigMale                                         		----		Cultist Brute
 Metadata/Monsters/PitifulFabrications/Canopy/PitifulFabrication02                         		----		Ribrattle
 Metadata/Monsters/WereCat/TigerChimeral                                                   		----		Prowling Chimeral
@@ -397,6 +405,7 @@ Metadata/Monsters/Procession/ProcessionDagger                                   
 Metadata/Monsters/Procession/ProcessionBow                                                		----		Vaal Embalmed Archer
 Metadata/Monsters/Procession/ProcessionBannerSpectre                                      		----		Vaal Embalmed Bearer
 Metadata/Monsters/GoldenOnes/GoldenOnesTwoHandSword                                       		----		Gold-Melted Shambler
+Metadata/Monsters/GoldenOnes/GoldenOnesOneHandMace                                        		----		Gold-Melted Shambler
 Metadata/Monsters/DrownedCrew/DrownedCrewSword_                                           		----		Drowned Explorer
 Metadata/Monsters/DrownedCrew/DrownedCrewGhost                                            		----		Drowned Spectre
 Metadata/Monsters/DrownedCrew/DrownedCrewFigurehead                                       		----		Drowned Bearer
@@ -447,6 +456,8 @@ Metadata/Monsters/NecromancerRemakeBook/SpinedNecromancer                       
 Metadata/Monsters/NecromancerRemakeBook/SpinedNecromancer                                 		----		Forael, the Soulkeeper
 Metadata/Monsters/SkeletonProwler/SkeletonProwler_                                        		----		Prowling Skeleton
 Metadata/Monsters/RatMonster/RatMonsterPrison                                             		----		Eaten Rat
+Metadata/Monsters/RatMonster/RatMonsterPrisonMedium                                       		----		Eaten Rat
+Metadata/Monsters/RatMonster/RatMonsterPrisonSmall                                        		----		Eaten Rat
 Metadata/Monsters/Skeletons/Basic/PrisonSkeletonUnarmed                                   		----		Risen Rattler
 Metadata/Monsters/Zombies/UpperPrison/PrisonZombieUnarmed_                                		----		Eternal Prisoner
 Metadata/Monsters/PaleWalker/PaleWalkerWave                                               		----		Pale Tidecrasher
@@ -474,7 +485,8 @@ Metadata/Monsters/Goblins/GoblinTusker/GoblinTusker                             
 Metadata/Monsters/Goblins/GoblinShaman/GoblinShaman                                       		----		Shaman Kin
 Metadata/Monsters/Goblins/GoblinShaman/Runemarked/GoblinShamanRunemarked                  		----		Shaman Kin
 Metadata/Monsters/HarpyMonster/MagmaHarpy/MagmaHarpy                                      		----		Molten Imp
-Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_                                    		----		The Ravenous Fang
+Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_                                    		----		The Blind Beast
+Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion2                                     		----		The Ravenous Fang
 Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion3                                     		----		The Blind Brute
 Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion4                                     		----		The Blind Mauler
 Metadata/Monsters/Goblins/GoblinMiner/GoblinMinerMining                                   		----		Prospector Kin
@@ -545,6 +557,7 @@ Metadata/Monsters/FallenGods/FallenGodMinibossClubHandMinion                    
 Metadata/Monsters/FallenGods/FallenGodMinibossCrawlerMinion                               		----		Forgotten Crawler
 Metadata/Monsters/FallenGods/FallenGodMinibossStagMinion                                  		----		Forgotten Stag
 Metadata/Monsters/RabidFeralDogMonster/RabidDog                                           		----		Rabid Dog
+Metadata/Monsters/RabidFeralDogMonster/RabidDogLargeFarmlandsNoName                       		----		Rabid Dog
 Metadata/Monsters/KaruiBoar/ExplosivePig                                                  		----		Volatile Boar
 Metadata/Monsters/Ghouls/FarudinCrawler                                                   		----		Faridun Crawler
 Metadata/Monsters/FarudinMiniboss/Runemarked/FarudinCorpseStriderRunemarked               		----		Faridun Corpse Strider
@@ -666,6 +679,8 @@ Metadata/Monsters/Sanctified/Floppy/SanctifiedFloppy                            
 Metadata/Monsters/PrecursorDungeon/PrecursorCentipede                                     		----		Precursor Centipede
 Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion1                        		----		Vornas, the Fell Flame
 Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion2                        		----		Morvak, the Infernal
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion                       		----		Anundr, the Sandworm
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoTailMAP_                         		----		Anundr, the Sandworm
 Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion                      		----		Akthi, the Final Sting
 Metadata/Monsters/LeagueAbyss/Blackblood/CollectorSpectre                                 		----		Blackblooded Proboscite
 Metadata/Monsters/LeagueAbyss/Blackblood/CretinSpectre                                    		----		Blackblooded Cretin
@@ -690,6 +705,7 @@ Metadata/Monsters/LeagueAbyss/Pit/CorpseStrider/CorpseStriderAbyssSpectre       
 Metadata/Monsters/LeagueAbyss/Fodder/PaleWalker2/KulemaksGraspSpectre                     		----		Abyssal Shambler
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster3AbyssSpectre                          		----		Primordium of the Pit
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2Spectre                               		----		Hound of the Pit
+Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2LargeSpectre                          		----		Hound of the Pit
 Metadata/Monsters/LeagueAncestral/StandaloneTawhoa/Boar/TawhoaBoarStandalone              		----		Tawhoa's Boar
 Metadata/Monsters/LeagueAncestral/StandaloneTawhoa/Tuatata/TawhoaTuataraStandalone        		----		Tawhoa's Tuatara
 Metadata/Monsters/LeagueAncestral/StandaloneTawhoa/MedicineWoman/TawhoaMedicineWomanStandalone__		----		Tawhoa Mystic
@@ -757,11 +773,11 @@ Metadata/Monsters/PrecursorCentipedeTrain/PrecursorCentipedeTrainHead           
 -- Spectres Not Yet Imported --
 -- These spectres are not in PoB yet. Could be false spectres or disabled server-side. --
 
-Metadata/Monsters/Monkeys/MonkeyJungleTamed                                               		----		Feral Primate
 Metadata/Monsters/MudBurrower/Runemarked/BurrowerRunemarked                               		----		Bramble Burrower
 Metadata/Monsters/Wraith/WraithSpookyColdSanctumTrialTime                                 		----		Frost Wraith
 Metadata/Monsters/Wraith/Runemarked/WraithSpookyRunemarked                                		----		Tempest Wraith
 Metadata/Monsters/TheCountsGuardEliteCorruptedMageLessCorrupted/Runemarked/CorruptedEliteGuardRunemarked		----		Iron Thaumaturgist
+Metadata/Monsters/MudBurrower/MudBurrowerHeadTrap                                         		----		The Devourer
 Metadata/Monsters/MudBurrower/MudBurrowerTailBoss_                                        		----		The Devourer
 Metadata/Monsters/FungusZombie/FungusZombieLarge                                          		----		Fungal Zombie
 Metadata/Monsters/FungusZombie/Runemarked/FungusZombieFungalmancerRunemarked              		----		Fungal Proliferator
@@ -770,10 +786,7 @@ Metadata/Monsters/BitterGuy/BitterGuyWifeGhost                                  
 Metadata/Monsters/BitterGuy/BitterGuyWifeSurge                                            		----		Isabel, Mourning Wife
 Metadata/Monsters/BitterGuy/BitterGuyChild1Surge_                                         		----		Calum, Weeping Child
 Metadata/Monsters/BitterGuy/BitterGuyChild2Surge                                          		----		Torcall, Sobbing Child
-Metadata/Monsters/QuillCrab/QuillCrabBigElite                                             		----		Porcupine Crab
-Metadata/Monsters/QuillCrab/QuillCrabBigPoisonElite                                       		----		Venomous Crab Matriarch
 Metadata/Monsters/Urchins/MeleeUrchin1                                                    		----		Vile Imp
-Metadata/Monsters/HuhuGrub/HuhuGrubLarvaeRanged1Spectre                                   		----		Flesh Larva
 Metadata/Monsters/Werewolves/Runemarked/WerewolfProwlerRunemarked                         		----		Werewolf Prowler
 Metadata/Monsters/Gargoyle/Runemarked/GargoyleGolemRunemarked                             		----		Gargoyle Demon
 Metadata/Monsters/Mercenary/Infected/InfectedMercenaryCrossbow                            		----		Decrepit Mercenary
@@ -802,18 +815,10 @@ Metadata/Monsters/Mutewind/MutewindGirlCorroded_                                
 Metadata/Monsters/Mutewind/MutewindManDualSwordGrim                                       		----		Faridun Swordsman
 Metadata/Monsters/Mutewind/MutewindMan2HSpearGrim                                         		----		Faridun Spearman
 Metadata/Monsters/Mutewind/MutewindWomanDualDaggerGrim                                    		----		Faridun Wind-slicer
-Metadata/Monsters/DemonSpiders/BlackStrider                                               		----		Black Strider
-Metadata/Monsters/DemonSpiders/BlackStriderSanctumTrial                                   		----		Black Strider
-Metadata/Monsters/DemonSpiders/BlackStrider                                               		----		Ashen Arachnid
 Metadata/Monsters/DemonSpiders/BlackStrider/Runemarked/BlackStriderRunemarked             		----		Black Strider
-Metadata/Monsters/EtchedBeetles/SmallEtchedBeetleArmouredDullSanctumScorpionBoss          		----		Tarnished Beetle
-Metadata/Monsters/EtchedBeetles/MediumEtchedBeetleArmouredTuskWideSanctumTrial            		----		Adorned Scarab
-Metadata/Monsters/EtchedBeetles/LargeEtchedBeetleBossMinion                               		----		Adorned Beetle
 Metadata/Monsters/SerpentClanMonster/SerpentClan1SanctumTrial                             		----		Serpent Clan
 Metadata/Monsters/SaltGolem/SaltGolemNoEmerge_                                            		----		Quake Golem
 Metadata/Monsters/SaltGolem/SaltGolemNoEmergeSanctumTrial                                 		----		Quake Golem
-Metadata/Monsters/HyenaMonster/HyenaMonsterHighAggro                                      		----		Hyena Demon
-Metadata/Monsters/HyenaMonster/HyenaCentaurSpearBossMinion_                               		----		Sun Clan Scavenger
 Metadata/Monsters/HyenaMonster/Runemarked/HyenaCentaurRunemarked                          		----		Sun Clan Scavenger
 Metadata/Monsters/SandGolemancer/SandGolemancerSanctumTrial                               		----		Desiccated Lich
 Metadata/Monsters/SandGolemancer/Runemarked/SandGolemancerRunemarked                      		----		Desiccated Lich
@@ -825,25 +830,24 @@ Metadata/Monsters/BoneCultists/BoneCultist_Zealots/Runemarked/BoneCultistZealotR
 Metadata/Monsters/MarakethGuards/MarakethHeroGuard01___                                   		----		Emal
 Metadata/Monsters/MarakethGuards/MarakethHeroGuard02                                      		----		Tanim
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreStatue                     		----		Terracotta Soldier
+Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreStatueBridge               		----		Terracotta Soldier
 Metadata/Monsters/BoneCultists/BoneCultists_Beast/Runemarked/BoneCultistBeastRunemarked   		----		Drudge Osseodon
 Metadata/Monsters/SerpentClanMonster/SerpentClanCasterSanctumTrial                        		----		Serpent Shaman
 Metadata/Monsters/SerpentClanMonster/Runemarked/SerpentClanCasterRunemarked               		----		Serpent Shaman
-Metadata/Monsters/PorcupineAnt/PorcupineAntMediumSanctumTrial                             		----		Rasp Scavenger
-Metadata/Monsters/CaveDweller/CaveDwellerSanctumTrial__                                   		----		Tombshrieker
 Metadata/Monsters/VultureZombie/Runemarked/VultureDemonRunemarked                         		----		Vile Vulture
-Metadata/Monsters/PlagueNymph/PlagueNymphFoundry                                          		----		Plague Nymph
 Metadata/Monsters/TwilightOrderExcavationOverseer/Runemarked/TwilightOrderOverseerRunemarked		----		Twilight Overseer
 Metadata/Monsters/WingedCreature/Runemarked/WingedCreatureRunemarked                      		----		Winged Horror
 Metadata/Monsters/VaalSavage/VaalSavageShamanWaterways                                    		----		Azak Shaman
 Metadata/Monsters/VaalSavage/Runemarked/VaalSavageGiantRunemarked                         		----		Azak Mauler
 Metadata/Monsters/BloodClan/BloodClanDagger                                               		----		Sea-tribe Daggerbearer
 Metadata/Monsters/Anchorite/Runemarked/AnchoriteMotherRunemarked                          		----		Pyromushroom Cultivator
-Metadata/Monsters/ChawMongrel/ChawMongrelLeashBoss                                        		----		Chaw Mongrel
 Metadata/Monsters/ZombieTreasureHunters/IllFatedExplorer2                                 		----		Ill-fated Explorer
 Metadata/Monsters/ZombieTreasureHunters/IllFatedExplorerNoSpores1                         		----		Ill-fated Explorer
 Metadata/Monsters/NettleAnt/NettleAnt__                                                   		----		Nettle Ant
 Metadata/Monsters/CrazedCannibalPicts/Runemarked/PictFemaleStaffRunemarked                		----		Cultist Witch
 Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeAxe                                      		----		Cultist Warrior
+Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeDagger                                   		----		Cultist Warrior
+Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeShield                                   		----		Cultist Warrior
 Metadata/Monsters/VaalConstructs/Golem/Runemarked/VaalConstructGolemRunemarked            		----		Shockblade Construct
 Metadata/Monsters/VaalConstructs/Skitterbot/VaalConstructSkitterbotAncient_               		----		Crawler Sentinel
 Metadata/Monsters/VaalMonsters/Machinarium/Wraith/Runemarked/ProwlingShadeRunemarked      		----		Prowling Shade
@@ -864,6 +868,7 @@ Metadata/Monsters/VaalMonsters/Living/VaalGuardSpearLiving                      
 Metadata/Monsters/VaalMonsters/Living/VaalGuardBowLiving                                  		----		Vaal Guard
 Metadata/Monsters/VaalMonsters/Living/VaalGoliathLivingCrystalThrower                     		----		Vaal Goliath
 Metadata/Monsters/VaalMonsters/Living/BloodPriests/Runemarked/VaalBloodPriestFemaleRunemarked		----		Blood Priestess
+Metadata/Monsters/GoldenOnes/GoldenOnesOneHandMace                                        		----		Gold-Melted Shambler
 Metadata/Monsters/VaalForgeMan/Runemarked/VaalForgeManRunemarked                          		----		Gold-melted Blacksmith
 Metadata/Monsters/BloodBathers/BloodBatherMace/BloodBatherMace                            		----		Bloodrite Guard
 Metadata/Monsters/BloodBathers/BloodBatherFlail/BloodBatherFlail                          		----		Bloodrite Guard
@@ -871,19 +876,17 @@ Metadata/Monsters/BloodBathers/BloodBatherSpear/BloodBatherSpear                
 Metadata/Monsters/BloodBathers/VaalApparition/Runemarked/SunVaalApparitionRunemarked      		----		Priest of the Sun
 Metadata/Monsters/Pirates/CaptainRothBossCannon                                           		----		Ghost Cannon
 Metadata/Monsters/VaalHumanoids/VaalHumanoidCannon/VaalHumanoidCannonLightningSkitterMine_		----		Skitter Mine
+Metadata/Monsters/RatMonster/RatMonsterPrisonMedium                                       		----		Eaten Rat
+Metadata/Monsters/RatMonster/RatMonsterPrisonSmall                                        		----		Eaten Rat
 Metadata/Monsters/Skeletons/Basic/PrisonSkeletonUnarmed                                   		----		Risen Rattler
 Metadata/Monsters/PaleWalker/PaleWalkerMirageClone                                        		----		Pale Brinesplitter
 Metadata/Monsters/Goblins/GoblinShaman/Runemarked/GoblinShamanRunemarked                  		----		Shaman Kin
 Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion3                                     		----		The Blind Brute
 Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion4                                     		----		The Blind Mauler
 Metadata/Monsters/KaruiSoulCaster/KaruiSpiritSummon                                       		----		Ancestral Mask
-Metadata/Monsters/ParasiteMonsters/ParasiteMonster01                                      		----		Armoured Parasite
-Metadata/Monsters/ParasiteMonsters/ParasiteMonster02                                      		----		Kreth Parasite
-Metadata/Monsters/MorayClanMonster/MorayClan                                              		----		Moray Clan
 Metadata/Monsters/RootedGuys/RootedGuy01/RootedGuy1____                                   		----		Blightstalker
 Metadata/Monsters/RootedGuys/RootedGuy03/RootedGuy3                                       		----		Sporebearer
 Metadata/Monsters/RootedGuys/RootedGuy04/RootedGuy4                                       		----		Fungal Reaver
-Metadata/Monsters/Baron/BaronWerewolfProwlerSummon                                        		----		Tendril Prowler
 Metadata/Monsters/ScarecrowBeast/Runemarked/ScarecrowBeastRunemarked                      		----		Scarecrow Beast
 Metadata/Monsters/RootedGuys/Cocoons2/Cocoons2__                                          		----		Infested Cadaver
 Metadata/Monsters/SummonedPhantasm/HusbandWifeSpirits                                     		----		Captured Soul
@@ -916,20 +919,30 @@ Metadata/Monsters/Skeletons/Essence/EssenceSkeletonCasterFire                   
 Metadata/Monsters/Skeletons/Essence/EssenceSkeletonCasterCold                             		----		Risen Rattler
 Metadata/Monsters/Skeletons/Essence/EssenceSkeletonCasterLightning                        		----		Risen Rattler
 Metadata/Monsters/TormentedSpirits/Stag/SpiritStag                                        		----		Stag Spirit
-Metadata/Monsters/PlagueNymph/TwilightOrderPlagueNymph                                    		----		Nymph Wasp
 Metadata/Monsters/PrecursorDungeon/PrecursorCentipede                                     		----		Precursor Centipede
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoTailMAP_                         		----		Anundr, the Sandworm
 
 -- Duplicate Spectre Names --
 -- Same name but different skill sets (should likely be separate imports). --
 
 Metadata/Monsters/Monkeys/MonkeyJunglePale                                                		----		Feral Primate
 Metadata/Monsters/Monkeys/MonkeyJungleTamedBossSpectator                                  		----		Feral Primate
+Metadata/Monsters/CrowBell/CrowBellBossMinion2                                            		----		The Black Crow
+Metadata/Monsters/CrowBell/CrowBellBossMinion2                                            		----		The Black Crow
+Metadata/Monsters/CrowBell/CrowBellBossMinion1                                            		----		The Crowbell
+Metadata/Monsters/CrowBell/CrowBellBossMinion2                                            		----		The Black Crow
 Metadata/Monsters/Wraith/WraithSpookyColdSpectre                                          		----		Frost Wraith
 Metadata/Monsters/Wraith/WraithSpookyLightningSpectre                                     		----		Lightning Wraith
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2                                  		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2                                  		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2                                  		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossTAMED                                    		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion1                                  		----		The Devourer
+Metadata/Monsters/MudBurrower/MudBurrowerHeadBossMinion2                                  		----		Gorian, the Moving Earth
+Metadata/Monsters/MudBurrower/MudBurrowerHeadTrap2                                        		----		The Devourer
 Metadata/Monsters/MudGolem/MudGolemWet1                                                   		----		Mud Simulacrum
 Metadata/Monsters/MudGolem/MudGolemWetEmerge1                                             		----		Mud Simulacrum
 Metadata/Monsters/MudGolem/MudGolemWetEncased1                                            		----		Mud Simulacrum
-Metadata/Monsters/QuillCrab/QuillCrabBig                                                  		----		Porcupine Crab
 Metadata/Monsters/Zombies/Lumberjack/LumberingDrownedUnarmedPhysics                       		----		Drowned
 Metadata/Monsters/Zombies/Lumberjack/LumberingDrownedOneHandAxe                           		----		Drowned
 Metadata/Monsters/Zombies/Lumberjack/LumberingDrownedOneHandAxePhysics                    		----		Drowned
@@ -965,7 +978,17 @@ Metadata/Monsters/Mercenary/Infected/InfectedMercenaryCrossbowExecutionerMinionS
 Metadata/Monsters/Mercenary/Infected/InfectedMercenaryAxeShieldExecutionerMinion_STANDALONE		----		Decrepit Mercenary
 Metadata/Monsters/Mercenary/Infected/InfectedMercenaryAxeAxeExecutionerMinion             		----		Decrepit Mercenary
 Metadata/Monsters/Mercenary/Infected/InfectedMercenaryAxeAxeExecutionerMinionSTANDALONE   		----		Decrepit Mercenary
+Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion2                          		----		Xilozoma, the Maw-Beast
+Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion1                          		----		Xyclucian, the Chimera
+Metadata/Monsters/ChimeraWetlandsBoss/ChimeraWetlandsBossMinion2                          		----		Xilozoma, the Maw-Beast
+Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion2                                   		----		Gressor-Kul, the Apex
+Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion1                                   		----		Uxmal, the Beastlord
+Metadata/Monsters/Ultimatum/ChimeraUltimatumBossMinion2                                   		----		Gressor-Kul, the Apex
 Metadata/Monsters/Bird2/MutantBird2Minion1                                                		----		Scourge of the Skies
+Metadata/Monsters/Bird2/MutantBird2Minion2                                                		----		Chetza, the Feathered Plague
+Metadata/Monsters/Bird2/MutantBird2Minion2                                                		----		Chetza, the Feathered Plague
+Metadata/Monsters/Bird2/MutantBird2Minion1                                                		----		Scourge of the Skies
+Metadata/Monsters/Bird2/MutantBird2Minion2                                                		----		Chetza, the Feathered Plague
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonOneHandAxeNoArmour_                  		----		Risen Maraketh
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonOneHandAxeClothArmour                		----		Risen Maraketh
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonOneHandAxeMediumArmour               		----		Risen Maraketh
@@ -1040,6 +1063,9 @@ Metadata/Monsters/SaltGolem/SaltGolemNoEmergeSanctumTrial                       
 Metadata/Monsters/SaltGolem/SaltGolemBlackNoEmerge                                        		----		Quake Golem
 Metadata/Monsters/SaltGolem/SaltGolemBlackNoEmerge                                        		----		Quake Golem
 Metadata/Monsters/HyenaMonster/HyenaMonsterBossMinion                                     		----		Hyena Demon
+Metadata/Monsters/HyenaMonster/RathbreakerBossMinion2                                     		----		Caedron, the Hyena Lord
+Metadata/Monsters/HyenaMonster/RathbreakerBossMinion1                                     		----		Rathbreaker
+Metadata/Monsters/HyenaMonster/RathbreakerBossMinion2                                     		----		Caedron, the Hyena Lord
 Metadata/Monsters/ShellMonster/ShellMonsterSmall                                          		----		Brimstone Crab
 Metadata/Monsters/ShellMonster/ShellMonsterPoisonSmall                                    		----		Caustic Crab
 Metadata/Monsters/ShellMonster/ShellMonsterPoison_                                        		----		Caustic Crab
@@ -1058,7 +1084,6 @@ Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSickleShieldSanctumTrial
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreSanctumTrialNoEmerge       		----		Terracotta Soldier
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSickleShieldSanctumTrialNoEmerge  		----		Terracotta Soldier
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreFormation                  		----		Terracotta Soldier
-Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptreStatueBridge               		----		Terracotta Soldier
 Metadata/Monsters/TerracottaGuardians/TerracottaGuardianSceptre                           		----		Terracotta Soldier
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonOneHandSwordNoArmour                 		----		Risen Maraketh
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonUnarmed                              		----		Risen Maraketh
@@ -1069,9 +1094,6 @@ Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonCrossbow                   
 Metadata/Monsters/Skeletons/Maraketh/MarakethSkeletonCrossbowSanctumTrial_                		----		Risen Maraketh
 Metadata/Monsters/Skeletons/TitanGrotto/SkeletonTitanGrottoSwordShield                    		----		Sandflesh Warrior
 Metadata/Monsters/Skeletons/TitanGrotto/SkeletonTitanGrottoCasterSanctumTrial             		----		Sandflesh Mage
-Metadata/Monsters/PorcupineAnt/PorcupineAntMedium                                         		----		Rasp Scavenger
-Metadata/Monsters/PorcupineAnt/PorcupineAntLarge                                          		----		Rasp Scavenger
-Metadata/Monsters/PorcupineAnt/PorcupineAntLargeSanctumTrial                              		----		Rasp Scavenger
 Metadata/Monsters/MineBat/MineBatDesertCaveNoEmerge                                       		----		Vesper Bat
 Metadata/Monsters/MineBat/MineBatDesertCaveSanctumTrial_NoEmerge                          		----		Vesper Bat
 Metadata/Monsters/MineBat/MineBatDesertCaveSanctumTrial_NoEmerge                          		----		Vesper Bat
@@ -1107,12 +1129,17 @@ Metadata/Monsters/ZombieTreasureHunters/IllFatedExplorerNoSporesOrange2         
 Metadata/Monsters/ZombieTreasureHunters/IllFatedExplorerNoSporesOrange3                   		----		Ill-fated Explorer
 Metadata/Monsters/ZombieTreasureHunters/IllFatedExplorerNoSporesOrange4                   		----		Ill-fated Explorer
 Metadata/Monsters/Quadrilla/Runemarked/QuadrillaRunemarked                                		----		Quadrilla
+Metadata/Monsters/Quadrilla/QuadrillaBossMinion2                                          		----		Zekoa, the Headcrusher
+Metadata/Monsters/Quadrilla/QuadrillaBossMinion2                                          		----		Zekoa, the Headcrusher
+Metadata/Monsters/Quadrilla/QuadrillaBossMinion1                                          		----		Mighty Silverfist
+Metadata/Monsters/Quadrilla/QuadrillaBossMinion2                                          		----		Zekoa, the Headcrusher
+Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion2                                       		----		The Frostborn Fiend
+Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion1                                       		----		The Abominable Yeti
+Metadata/Monsters/Quadrilla/IcyQuadrillaBossMinion2                                       		----		The Frostborn Fiend
 Metadata/Monsters/NettleAnt/NettleAntSummoned                                             		----		Nettle Ant
 Metadata/Monsters/SnakeHulk/Runemarked/SnakeHulkRunemarked                                		----		Entwined Hulk
 Metadata/Monsters/SpiderMonkey/SpiderMonkeyTropical                                       		----		Scorpion Monkey
 Metadata/Monsters/GoreCharger/Runemarked/GoreChargerRunemarked                            		----		Diretusk Boar
-Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeDagger                                   		----		Cultist Warrior
-Metadata/Monsters/CrazedCannibalPicts/PictMaleAxeShield                                   		----		Cultist Warrior
 Metadata/Monsters/PitifulFabrications/Canopy/PitifulFabrication01                         		----		Skullslinger
 Metadata/Monsters/PitifulFabrications/Canopy/PitifulFabrication03_                        		----		Spinesnatcher
 Metadata/Monsters/Taniwha/RiverTaniwhaNoJank                                              		----		River Drake
@@ -1165,7 +1192,6 @@ Metadata/Monsters/VaalMonsters/Living/VaalGoliathLivingPatrol_                  
 Metadata/Monsters/VaalMonsters/Living/VaalShapeshifterBloodied__                          		----		Vaal Formshifter
 Metadata/Monsters/VaalMonsters/Living/VaalShapeshifterPatrol                              		----		Vaal Formshifter
 Metadata/Monsters/Procession/ProcessionBannerSpectre                                      		----		Vaal Embalmed Bearer
-Metadata/Monsters/GoldenOnes/GoldenOnesOneHandMace                                        		----		Gold-Melted Shambler
 Metadata/Monsters/GoldenOnes/GoldenOnesOneHandClub                                        		----		Gold-Melted Shambler
 Metadata/Monsters/GoldenOnes/GoldenOnesSpear                                              		----		Gold-Melted Shambler
 Metadata/Monsters/DrownedCrew/DrownedCrewAxe                                              		----		Drowned Explorer
@@ -1190,8 +1216,6 @@ Metadata/Monsters/VaalHumanoids/VaalHumanoidPyramidHands/Runemarked/VaalPyramidH
 Metadata/Monsters/GullGoliath/Runemarked/GullGoliathRunemarked                            		----		Goliath Shrike
 Metadata/Monsters/Skeletons/FleshPicked/FleshPickedSkeletonNoEmerge                       		----		Scavenged Skeleton
 Metadata/Monsters/NecromancerRemakeBook/Runemarked/SpinedNecromancerRunemarked            		----		Spined Necromancer
-Metadata/Monsters/RatMonster/RatMonsterPrisonMedium                                       		----		Eaten Rat
-Metadata/Monsters/RatMonster/RatMonsterPrisonSmall                                        		----		Eaten Rat
 Metadata/Monsters/Skeletons/Basic/PrisonSkeletonOneHandSword                              		----		Risen Rattler
 Metadata/Monsters/Skeletons/Basic/PrisonSkeletonOneHandSwordShield                        		----		Risen Rattler
 Metadata/Monsters/Zombies/UpperPrison/PrisonZombieOneHandAxe                              		----		Eternal Prisoner
@@ -1199,6 +1223,9 @@ Metadata/Monsters/Zombies/UpperPrison/PrisonZombieUnarmed_                      
 Metadata/Monsters/SkeletonProwler/SkeletonProwlerWet_                                     		----		Prowling Skeleton
 Metadata/Monsters/TarHulk/Runemarked/PaleHulkRunemarked_                                  		----		Pale Abductor
 Metadata/Monsters/DeepDwellerBoss/Runemarked/SpikedDwellerRunemarked                      		----		Spiked Scuttler
+Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion2                                      		----		The Sandstrider
+Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion1                                      		----		Great White One
+Metadata/Monsters/GreatWhiteOne/GreatWhiteOneMinion2                                      		----		The Sandstrider
 Metadata/Monsters/Goblins/GoblinStabberNoSkullRider                                       		----		Feral Kin
 Metadata/Monsters/Goblins/GoblinSpearman/GoblinSpearman                                   		----		Spearbearer Kin
 Metadata/Monsters/Goblins/GoblinSpearman/GoblinSpearman                                   		----		Spearbearer Kin
@@ -1207,6 +1234,8 @@ Metadata/Monsters/Goblins/GoblinTusker/GoblinTusker                             
 Metadata/Monsters/Goblins/GoblinTusker/GoblinTusker                                       		----		Tuskbearer Kin
 Metadata/Monsters/Goblins/GoblinShaman/GoblinShaman                                       		----		Shaman Kin
 Metadata/Monsters/Goblins/GoblinShaman/GoblinShaman                                       		----		Shaman Kin
+Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_                                    		----		The Ravenous Fang
+Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion1_                                    		----		The Ravenous Fang
 Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion2                                     		----		The Ravenous Fang
 Metadata/Monsters/ElectricStingray/Runemarked/ElectricStingrayRunemarked                  		----		Spiked Ray
 Metadata/Monsters/KaruiTuatara/KaruiTuatara_                                              		----		Guardian Lizard
@@ -1245,7 +1274,6 @@ Metadata/Monsters/FallenGods/FallenHooks                                        
 Metadata/Monsters/TwilightOrderCleric/TwilightOrderCleric                                 		----		Twilight Order Priest
 Metadata/Monsters/FallenGods/FallenGodMinibossStalkerMinion                               		----		Forgotten Stalker
 Metadata/Monsters/FallenGods/FallenGodMinibossHooksMinion__                               		----		Forgotten Satyr
-Metadata/Monsters/RabidFeralDogMonster/RabidDogLargeFarmlandsNoName                       		----		Rabid Dog
 Metadata/Monsters/Ghouls/FarudinCrawlerQuarry                                             		----		Faridun Crawler
 Metadata/Monsters/TitanWalker/TitanWalkerSanctumTrial                                     		----		Walking Goliath
 Metadata/Monsters/TitanWalker/TitanWalkerCorpse                                           		----		Walking Goliath
@@ -1259,6 +1287,15 @@ Metadata/Monsters/UndeadMarakethPriest/UndeadMarakethPriestSanctumTrialTime     
 Metadata/Monsters/Zombies/CourtGuardZombieUnarmed                                         		----		Rotting Guard
 Metadata/Monsters/ChaosGodTriHeadBat/ChaosGodTri-headBatInterlude                         		----		Cerberic Bat
 Metadata/Monsters/ChaosGodGorilla/ChaosGodGorillaInterlude                                		----		Stoneclad Gorilla
+Metadata/Monsters/ChaosGodOwlBoss/ChaosGodOwlBossMinion                                   		----		Bahlak, the Sky Seer
+Metadata/Monsters/ChaosGodOwlBoss/ChaosGodOwlBossMinion                                   		----		Bahlak, the Sky Seer
+Metadata/Monsters/ChaosGodOwlBoss/ChaosGodOwlBossMinion                                   		----		Bahlak, the Sky Seer
+Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion1                                       		----		Rakkar, the Frozen Talon
+Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion1                                       		----		Rakkar, the Frozen Talon
+Metadata/Monsters/ChaosGodOwlBoss/IcyOwlBossMinion2                                       		----		Thraeven, Wing of Winter
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion2                        		----		Karash, The Dune Dweller
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion1_                       		----		Ashar, the Sand Mother
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariMinion2                        		----		Karash, The Dune Dweller
 Metadata/Monsters/LeagueDelirium/DeliriumMinionEssence1                                   		----		Rage
 Metadata/Monsters/LeagueDelirium/DeliriumMinionEssence2                                   		----		Spite
 Metadata/Monsters/LeagueDelirium/DeliriumMinionEssence3                                   		----		Disgust
@@ -1318,6 +1355,15 @@ Metadata/Monsters/PlagueNymph/TwilightOrderPlagueNymph                          
 Metadata/Monsters/TumourMonsters/Statue07/QimarMonstrositySpectre                         		----		Bloodbilge
 Metadata/Monsters/Sanctified/Floppy/SanctifiedFloppyBig                                   		----		Fettered Hook
 Metadata/Monsters/Sanctified/Floppy/SanctifiedFloppyMinion                                		----		Fettered Hook
+Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion2                        		----		Morvak, the Infernal
+Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion1                        		----		Vornas, the Fell Flame
+Metadata/Monsters/Goblins/Beast/FireBeastBoss/FireBeastBossMinion2                        		----		Morvak, the Infernal
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion                       		----		Anundr, the Sandworm
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion                       		----		Anundr, the Sandworm
+Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion                       		----		Anundr, the Sandworm
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion                      		----		Akthi, the Final Sting
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion                      		----		Akthi, the Final Sting
+Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion                      		----		Akthi, the Final Sting
 Metadata/Monsters/LeagueAbyss/Blackblood/CollectorSpectre                                 		----		Blackblooded Proboscite
 Metadata/Monsters/LeagueAbyss/Blackblood/CollectorStrongbox                               		----		Blackblooded Proboscite
 Metadata/Monsters/LeagueAbyss/Blackblood/CretinSpectre                                    		----		Blackblooded Cretin
@@ -1364,7 +1410,6 @@ Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster3AbyssSpectre                
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster3AbyssStrongbox                        		----		Primordium of the Pit
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2Spectre                               		----		Hound of the Pit
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2Strongbox                             		----		Hound of the Pit
-Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2LargeSpectre                          		----		Hound of the Pit
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2LargeSpectre                          		----		Hound of the Pit
 Metadata/Monsters/LeagueAbyss/Pit/PrimordialMonster2LargeStrongbox                        		----		Hound of the Pit
 Metadata/Monsters/LeagueIncursionNew/Smithy/ProcessionAxeShieldIncursion                  		----		Vaal Embalmed Axeman
@@ -1457,6 +1502,10 @@ Metadata/Monsters/LeagueIncursionNew/Corruption/SunVaalApparitionIncursion      
 Metadata/Monsters/LeagueIncursionNew/SynthfleshLab/VaalScientistIncursion                 		----		Surgical Experimentalist
 Metadata/Monsters/LeagueIncursionNew/SynthfleshLab/ExperimentBladeHands                   		----		Warrior Transcendent
 Metadata/Monsters/LeagueIncursionNew/SynthfleshLab/ExperimentStalker                      		----		Bladelash Transcendent
+Metadata/Monsters/LeagueIncursionNew/MiniBosses/SoulCoreQuadrillaBoss/SoulCoreQuadrillaMinion		----		Quadrilla Sergeant
+Metadata/Monsters/LeagueIncursionNew/MiniBosses/SoulCoreQuadrillaBoss/SoulCoreQuadrillaMinion		----		Quadrilla Sergeant
+Metadata/Monsters/LeagueIncursionNew/MiniBosses/IncursionChainedBeastBoss/ChainedBeastBossMinion_		----		Unchained Beast
+Metadata/Monsters/LeagueIncursionNew/MiniBosses/IncursionChainedBeastBoss/ChainedBeastBossMinion_		----		Unchained Beast
 Metadata/Monsters/LeagueExpeditionNew/Expedition2/HumanoidFaction/GoldenOnesTwoHandSwordExpedition		----		Gold-Melted Shambler
 Metadata/Monsters/LeagueExpeditionNew/Expedition2/HumanoidFaction/GoldenOnesOneHandMaceExpedition		----		Gold-Melted Shambler
 Metadata/Monsters/LeagueExpeditionNew/Expedition2/HumanoidFaction/GoldenOnesDualAxesExpedition		----		Gold-Melted Shambler

--- a/src/Export/Minions/Spectres.txt
+++ b/src/Export/Minions/Spectres.txt
@@ -718,6 +718,12 @@ local minions, mod, flag = ...
 #flags recommendedSpectre
 #emit
 
+#spectre Metadata/Monsters/PorcupineAnt/PorcupineAntMedium
+#emit
+
+#spectre Metadata/Monsters/PorcupineAnt/PorcupineAntLarge
+#emit
+
 #spectre Metadata/Monsters/CaveDweller/CaveDweller
 #emit
 
@@ -1879,4 +1885,75 @@ local minions, mod, flag = ...
 
 #spectre Metadata/Monsters/MarakethSanctumTrial/Boss/Shakari/ShakariDuoMinion
 #flags recommendedBeast
+#emit
+#spectre Metadata/Monsters/Monkeys/MonkeyJungleTamed
+#emit
+
+#spectre Metadata/Monsters/QuillCrab/QuillCrabBigElite
+#emit
+
+#spectre Metadata/Monsters/QuillCrab/QuillCrabBigPoisonElite
+#emit
+
+#spectre Metadata/Monsters/HuhuGrub/HuhuGrubLarvaeRanged1Spectre
+#emit
+
+#spectre Metadata/Monsters/DemonSpiders/BlackStrider
+#emit
+
+#spectre Metadata/Monsters/DemonSpiders/BlackStriderSanctumTrial
+#emit
+
+#spectre Metadata/Monsters/EtchedBeetles/SmallEtchedBeetleArmouredDullSanctumScorpionBoss
+#emit
+
+#spectre Metadata/Monsters/EtchedBeetles/MediumEtchedBeetleArmouredTuskWideSanctumTrial
+#emit
+
+#spectre Metadata/Monsters/EtchedBeetles/LargeEtchedBeetleBossMinion
+#emit
+
+#spectre Metadata/Monsters/HyenaMonster/HyenaMonsterHighAggro
+#emit
+
+#spectre Metadata/Monsters/HyenaMonster/HyenaCentaurSpearBossMinion_
+#emit
+
+#spectre Metadata/Monsters/PorcupineAnt/PorcupineAntMediumSanctumTrial
+#emit
+
+#spectre Metadata/Monsters/PorcupineAnt/PorcupineAntLargeSanctumTrial
+#emit
+
+#spectre Metadata/Monsters/CaveDweller/CaveDwellerSanctumTrial__
+#emit
+
+#spectre Metadata/Monsters/PlagueNymph/PlagueNymphFoundry
+#emit
+
+#spectre Metadata/Monsters/ChawMongrel/ChawMongrelLeashBoss
+#emit
+
+#spectre Metadata/Monsters/Goblins/Beast/ArenaBeastBossMinion2
+#emit
+
+#spectre Metadata/Monsters/ParasiteMonsters/ParasiteMonster01
+#emit
+
+#spectre Metadata/Monsters/ParasiteMonsters/ParasiteMonster02
+#emit
+
+#spectre Metadata/Monsters/MorayClanMonster/MorayClan
+#emit
+
+#spectre Metadata/Monsters/Baron/BaronWerewolfProwlerSummon
+#emit
+
+#spectre Metadata/Monsters/RabidFeralDogMonster/RabidDogLargeFarmlandsNoName
+#emit
+
+#spectre Metadata/Monsters/PlagueNymph/TwilightOrderPlagueNymph
+#emit
+
+#spectre Metadata/Monsters/MudBurrower/DevourerDuo/DevourerBossDuoHeadMinion
 #emit

--- a/src/Export/Scripts/spectreList.lua
+++ b/src/Export/Scripts/spectreList.lua
@@ -29,8 +29,11 @@ if file then
 end
 
 for monster in dat("MonsterVarieties"):Rows() do
+	local isBeast = monster.MonsterCategory and monster.MonsterCategory.Type == "Beast"
+	-- Beast bosses keep their health bar on the companion variety (e.g. Anundr,
+	-- the Sandworm), so bossness alone cannot disqualify a beast
 	if monster.NotSpectre == false
-		and monster.BossHealthBar == false
+		and (monster.BossHealthBar == false or isBeast)
 		and not monster.Type.IsPlayerMinion == true
 		and not monster.Id:match("NPC")
 		and not monster.Name:match("DNT")
@@ -91,7 +94,10 @@ for monster in dat("MonsterVarieties"):Rows() do
 
 		table.sort(skillIds)
 
-		local signature = monster.Name .. "|" .. table.concat(skillIds, ",")
+		-- Same name and skills but a different Spirit cost is a real variant
+		-- (e.g. the small/medium/large Rasp Scavengers), not a duplicate;
+		-- reservation is derived from ExperienceMultiplier (see minions.lua)
+		local signature = monster.Name .. "|" .. skillSource.ExperienceMultiplier .. "|" .. table.concat(skillIds, ",")
 
 		------------------------------------------------------------
 		-- Duplicate check (name + skills)

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -1254,3 +1254,387 @@ statMap = {
 #flags attack melee area
 #mods
 #skillEnd
+
+
+#skill MeleeMudBurrowerLeftCleave Left Cleave
+#set MeleeMudBurrowerLeftCleave
+#flags attack melee
+#mods
+#skillEnd
+
+#skill MeleeMudBurrowerRightCleave Right Cleave
+#set MeleeMudBurrowerRightCleave
+#flags attack melee
+#mods
+#skillEnd
+
+#skill MeleeMudBurrowerBite Bite
+#set MeleeMudBurrowerBite
+#flags attack melee
+#mods
+#skillEnd
+
+#skill MPAMudBurrowerBloodProj Blood Spit
+#set MPAMudBurrowerBloodProj
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill GAMudBurrowerBloodProj Blood Spit Impact
+#set GAMudBurrowerBloodProj
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill MPAMudBurrowerSprayProj Blood Spray
+#set MPAMudBurrowerSprayProj
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill GAMudBurrowerSpraySmallImpact Blood Spray Impact
+#set GAMudBurrowerSpraySmallImpact
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill MPAMudBurrowerGoopSmallBall Goop Ball
+#set MPAMudBurrowerGoopSmallBall
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill GAMudBurrowerGoopSmallImpact Goop Ball Impact
+#set GAMudBurrowerGoopSmallImpact
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill MPAMudBurrowerGoopBigBall Large Goop Ball
+#set MPAMudBurrowerGoopBigBall
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill MudBurrowerGoopExplode Goop Explosion
+#set MudBurrowerGoopExplode
+#flags spell area triggerable
+#mods
+#skillEnd
+
+#skill GAMudBurrowerHeadSlam Head Slam
+#set GAMudBurrowerHeadSlam
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAMudBurrowerDivePush Dive
+#set GAMudBurrowerDivePush
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill CGEMudBurrowerVomit Vomit Ground
+#set CGEMudBurrowerVomit
+#flags spell area triggerable duration
+#mods
+#skillEnd
+
+#skill MPAMudBurrowerVomitProj Vomit
+#set MPAMudBurrowerVomitProj
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill MudBurrowerMaggotSummon Summon Maggots
+#set MudBurrowerMaggotSummon
+#flags spell
+#mods
+#skillEnd
+
+
+#skill GPAPorcupineAntSpikeNova Spike Nova
+#set GPAPorcupineAntSpikeNova
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill MMAPorcupineAntSpikeball Spike Mortar
+#set MMAPorcupineAntSpikeball
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill GPAPorcupineAntSpikeNovaSanctum Spike Nova
+#set GPAPorcupineAntSpikeNovaSanctum
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill MMAPorcupineAntSpikeballSanctum Spike Mortar
+#set MMAPorcupineAntSpikeballSanctum
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+
+#skill MPWBlackStriderWebProjectile Web Projectile
+#set MPWBlackStriderWebProjectile
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill GABlackStriderWebMortarImpact Web Impact
+#set GABlackStriderWebMortarImpact
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill BlackStriderMassMortar Mass Mortar
+#set BlackStriderMassMortar
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill MPWBlackStriderWebProjectileSanctum Web Projectile
+#set MPWBlackStriderWebProjectileSanctum
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill CGESanctumBlackStriderWeb Web Ground
+#set CGESanctumBlackStriderWeb
+#flags spell area triggerable duration
+#mods
+#skillEnd
+
+
+#skill QuillCrabSpikeShrapnel Spike Shrapnel
+#set QuillCrabSpikeShrapnel
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill QuillCrabSpikeShrapnelPoison Spike Shrapnel
+#set QuillCrabSpikeShrapnelPoison
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+#skill CGEQuillCrabFireGround Burning Ground
+#set CGEQuillCrabFireGround
+#flags spell area triggerable duration
+#mods
+#skillEnd
+
+#skill CGEQuillCrabCausticGround Caustic Ground
+#set CGEQuillCrabCausticGround
+#flags spell area triggerable duration
+#mods
+#skillEnd
+
+
+#skill GSBeetleLightningNova Lightning Nova
+#set GSBeetleLightningNova
+#flags spell area triggerable
+#mods
+#skillEnd
+
+
+#skill GSCaveDwellerSonicPulse Sonic Pulse
+#set GSCaveDwellerSonicPulse
+#flags spell triggerable
+#mods
+#skillEnd
+
+#skill GSCaveDwellerSuperProjectile Sonic Projectile
+#set GSCaveDwellerSuperProjectile
+#flags spell projectile triggerable
+#mods
+#skillEnd
+
+#skill GPSCaveDwellerSuperProjectileSanctum Sonic Projectile
+#set GPSCaveDwellerSuperProjectileSanctum
+#flags spell projectile triggerable
+#mods
+#skillEnd
+
+
+#skill GSPlagueNymphLaser Laser
+#set GSPlagueNymphLaser
+#flags spell triggerable
+#mods
+#skillEnd
+
+#skill MPSPlagueNymphRailGun Rail Gun
+#set MPSPlagueNymphRailGun
+#flags spell projectile triggerable hit
+#mods
+#skillEnd
+
+#skill GSTwilightOrderPlagueNymphLaser Laser
+#set GSTwilightOrderPlagueNymphLaser
+#flags spell triggerable
+#mods
+#skillEnd
+
+#skill MPSTwilightOrderPlagueNymphRailGun Rail Gun
+#set MPSTwilightOrderPlagueNymphRailGun
+#flags spell projectile triggerable hit
+#mods
+#skillEnd
+
+
+#skill GSSerpentClanAcidSpit Acid Spit
+#set GSSerpentClanAcidSpit
+#flags spell triggerable
+#mods
+#skillEnd
+
+
+#skill HyenaCentaurSpearThrowCliff Spear Throw
+#set HyenaCentaurSpearThrowCliff
+#flags attack projectile triggerable
+#mods
+#skillEnd
+
+
+#skill MeleeAtAnimationSpeed2
+#set MeleeAtAnimationSpeed
+#flags attack melee
+#mods
+#skillEnd
+
+#skill MAASBaronEndgameBasic
+#set MAASBaronEndgameBasic
+#flags attack melee
+#mods
+#skillEnd
+
+
+#skill GAArenaBeastSlam Slam
+#set GAArenaBeastSlam
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAArenaBeastSlamEmpowered Empowered Slam
+#set GAArenaBeastSlamEmpowered
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAGoblinArenaBeastHeadbutt Headbutt
+#set GAGoblinArenaBeastHeadbutt
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAGoblinArenaBeastHeadbuttEmpowered Empowered Headbutt
+#set GAGoblinArenaBeastHeadbuttEmpowered
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAGoblinArenaBeastGroundSlash Ground Slash
+#set GAGoblinArenaBeastGroundSlash
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAGoblinArenaBeastGroundSlashLightning Lightning Ground Slash
+#set GAGoblinArenaBeastGroundSlashLightning
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossBigSlam Big Slam
+#set GAArenaBeastBossBigSlam
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossShockwave Shockwave
+#set GAArenaBeastBossShockwave
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossPunchLeft Punch
+#set GAArenaBeastBossPunchLeft
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossPunchLeftEmpowered Empowered Punch
+#set GAArenaBeastBossPunchLeftEmpowered
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossPunchRight Punch
+#set GAArenaBeastBossPunchRight
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossPunchRightEmpowered Empowered Punch
+#set GAArenaBeastBossPunchRightEmpowered
+#flags attack melee
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossFissureDamage Fissure
+#set GAArenaBeastBossFissureDamage
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill GAArenaBeastBossFissureExplosion Fissure Explosion
+#set GAArenaBeastBossFissureExplosion
+#flags attack area triggerable
+#mods
+#skillEnd
+
+#skill CGEArenaBeastBossSulpurGas Sulphur Gas
+#set CGEArenaBeastBossSulpurGas
+#flags spell area triggerable duration
+#mods
+#skillEnd
+
+#skill GAArenaBeastLeapSlam Leap Slam
+#set GAArenaBeastLeapSlam
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAArenaBeastLeapSlamEnraged Enraged Leap Slam
+#set GAArenaBeastLeapSlamEnraged
+#flags attack melee area
+#mods
+#skillEnd
+
+#skill GAArenaBeastLeapSlamEnragedKick Enraged Kick
+#set GAArenaBeastLeapSlamEnragedKick
+#flags attack melee area
+#mods
+#skillEnd
+
+
+#skill DTTParasiteSwarmLeap Leap
+#set DTTParasiteSwarmLeap
+#flags attack
+#mods
+#skillEnd
+
+#skill DTTParasiteSwarmLeapAttach Leap Attach
+#set DTTParasiteSwarmLeapAttach
+#flags attack
+#mods
+#skillEnd
+
+#skill BlackStriderWebProjectile Web Projectile
+#set BlackStriderWebProjectile
+#flags attack projectile triggerable
+#mods
+#skillEnd


### PR DESCRIPTION
Add 26 beast spectre/companion varieties:
- Anundr, the Sandworm
- The Ravenous Fang (map variant)
- Rasp Scavenger (medium, large and Sekhema Trial sizes)
- Black Strider (incl. Sekhema Trial variant)
- Porcupine Crab
- Venomous Crab Matriarch
- Tarnished Beetle
- Adorned Scarab
- Adorned Beetle
- Hyena Demon
- Sun Clan Scavenger
- Tombshrieker (Sekhema Trial variant)
- Plague Nymph
- Nymph Wasp
- Chaw Mongrel
- Moray Clan
- Armoured Parasite
- Kreth Parasite
- Feral Primate
- Flesh Larva (ranged variant)
- Tendril Prowler
- Rabid Dog

Add the monster skills these beasts use to the spectre skill export; this also fills in the previously-empty kits shared by The Devourer, The Ravenous Fang and Rasp Scavenger.

The spectre list report now counts same-name monsters with different Spirit reservations as distinct variants instead of duplicates, and beast-category monsters are no longer excluded by the boss-health-bar filter, since boss beast companions like Anundr carry it.
