### PR TITLE
Fix Split Personality not working with Monk and Druid starting points

### DIFF
--- a/spec/System/TestImportTab_spec.lua
+++ b/spec/System/TestImportTab_spec.lua
@@ -47,17 +47,18 @@ describe("ImportTab", function()
 	it("imports Split Personality alternate class start from character JSON", function()
 		local spec = build.spec
 		local socketNode = spec.nodes[60735]
-		local rangerStartPassive = spec.nodes[56651]
+		local templarStartPassive = spec.nodes[13855]
 		assert.is_not_nil(socketNode)
-		assert.is_not_nil(rangerStartPassive)
+		assert.is_not_nil(templarStartPassive)
+		assert.is_nil(spec.tree.classNameMap.Templar)
+		assert.are.equals(61525, spec.tree.classStartNodeNameMap.Templar)
 
-		local hashes = { socketNode.id, rangerStartPassive.id }
+		local hashes = { socketNode.id, templarStartPassive.id }
 		for _, pathNode in ipairs(socketNode.path or { }) do
 			table.insert(hashes, pathNode.id)
 		end
 
-		local rangerStart = spec.nodes[spec.tree.classes[spec.tree.classNameMap.Ranger].startNodeId]
-		local importPayload = {
+		build.importTab:ImportPassiveTreeAndJewels({
 			name = "Split Import Test",
 			class = "Witch2",
 			league = "Test",
@@ -73,7 +74,7 @@ describe("ImportTab", function()
 					ilvl = 84,
 					properties = { },
 					explicitMods = {
-						"Can Allocate Passive Skills from the Ranger's starting point",
+						"Can Allocate Passive Skills from the Templar's starting point",
 					},
 				},
 			},
@@ -84,17 +85,14 @@ describe("ImportTab", function()
 				jewel_data = { },
 				quest_stats = { },
 			},
-		}
-
-		build.importTab:ImportPassiveTreeAndJewels(importPayload)
+		})
 
 		local importedSpec = build.spec
 		local importedJewel = build.itemsTab.items[importedSpec.jewels[socketNode.id]]
-		assert.are.equals("Ranger", importedJewel.jewelData.alternateClassStart)
-
-		assert.are.equals(0, importedSpec.nodes[rangerStart.id].pathDist)
-		assert.True(importedSpec.nodes[rangerStartPassive.id].alloc)
-		assert.True(importedSpec.nodes[rangerStartPassive.id].connectedToStart)
+		assert.are.equals("Templar", importedJewel.jewelData.alternateClassStart)
+		assert.are.equals(0, importedSpec.nodes[spec.tree.classStartNodeNameMap.Templar].pathDist)
+		assert.True(importedSpec.nodes[templarStartPassive.id].alloc)
+		assert.True(importedSpec.nodes[templarStartPassive.id].connectedToStart)
 	end)
 end)
 

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1231,8 +1231,8 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		if self.allocNodes[socketNodeId] then
 			local item = self:GetJewel(itemId)
 			local className = item and item.jewelData.alternateClassStart
-			local classData = className and self.tree.classes[self.tree.classNameMap[className]]
-			local startNode = classData and self.nodes[classData.startNodeId]
+			local startNodeId = self.tree.classStartNodeNameMap[className]
+			local startNode = startNodeId and self.nodes[startNodeId]
 			if startNode then
 				alternateClassStartNodes[startNode.id] = startNode
 			end

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -89,6 +89,7 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 	self.ascendNameMap = { }
 	self.classIntegerIdMap = { }
 	self.internalAscendNameMap = { }
+	self.classStartNodeNameMap = { }
 	self.classNotables = { }
 
 	for classId, class in pairs(self.classes) do
@@ -203,6 +204,7 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 		if node.classesStart then
 			node.type = "ClassStart"
 			for _, className in ipairs(node.classesStart) do
+				self.classStartNodeNameMap[className] = node.id
 				local class = self.classes[self.classNameMap[className]]
 				if class ~= nil then
 					class.startNodeId = node.id

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4899,7 +4899,11 @@ c["Buffs on you expire 10% slower"]={{[1]={[1]={skillType=5,type="SkillType"},fl
 c["Bulwark"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Bulwark"}},nil}
 c["Burning Enemies you kill have a 5% chance to Explode, dealing a"]={nil,"Burning Enemies you kill have a 5% chance to Explode, dealing a "}
 c["Burning Enemies you kill have a 5% chance to Explode, dealing a tenth of their maximum Life as Fire Damage"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Burning"},flags=0,keywordFlags=0,name="ExplodeMod",type="LIST",value={amount=10,keyOfScaledMod="value",type="Fire",value=5}},[2]={flags=0,keywordFlags=0,name="CanExplode",type="FLAG",value=true}},nil}
+c["Can Allocate Passive Skills from the Mercenary's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Mercenary"}},nil}
+c["Can Allocate Passive Skills from the Ranger's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Ranger"}},nil}
+c["Can Allocate Passive Skills from the Shadow's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Shadow"}},nil}
 c["Can Allocate Passive Skills from the Sorceress's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Sorceress"}},nil}
+c["Can Allocate Passive Skills from the Templar's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Templar"}},nil}
 c["Can Allocate Passive Skills from the Warrior's starting point"]={{[1]={flags=0,keywordFlags=0,name="AlternateClassStart",type="LIST",value="Warrior"}},nil}
 c["Can Attack as though using a One Handed Mace while both of your hand slots are empty"]={{[1]={flags=0,keywordFlags=0,name="CanAttackAsOneHandMaceUnarmed",type="FLAG",value=true}},nil}
 c["Can Attack as though using a Quarterstaff while both of your hand slots are empty"]={nil,"Can Attack as though using a Quarterstaff while both of your hand slots are empty "}

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -58,6 +58,24 @@ Limited to: 3
 {variant:1}+4% to all Elemental Resistances per socketed Grand Spectrum
 {variant:2}+6% to all Elemental Resistances per socketed Grand Spectrum
 ]],[[
+Split Personality
+Ruby
+Variant: Mercenary
+Variant: Ranger
+Variant: Shadow
+Variant: Sorceress
+Variant: Templar
+Variant: Warrior
+League: Runes of Aldur
+Limited to: 1
+{variant:2}Can Allocate Passive Skills from the Ranger's starting point
+{variant:3}Can Allocate Passive Skills from the Shadow's starting point
+{variant:4}Can Allocate Passive Skills from the Sorceress's starting point
+{variant:6}Can Allocate Passive Skills from the Warrior's starting point
+{variant:1}Can Allocate Passive Skills from the Mercenary's starting point
+{variant:5}Can Allocate Passive Skills from the Templar's starting point
+Corrupted
+]],[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -56,6 +56,24 @@ Limited to: 3
 {variant:1}UniqueAllResistancePerStackableJewel1[4,4]
 {variant:2}UniqueAllResistancePerStackableJewel1
 ]],[[
+Split Personality
+Ruby
+Variant: Mercenary
+Variant: Ranger
+Variant: Shadow
+Variant: Sorceress
+Variant: Templar
+Variant: Warrior
+League: Runes of Aldur
+Limited to: 1
+{variant:1}UniqueJewelSplitPersonalityClassStart4
+{variant:2}UniqueJewelSplitPersonalityClassStart2
+{variant:3}UniqueJewelSplitPersonalityClassStart6
+{variant:4}UniqueJewelSplitPersonalityClassStart3
+{variant:5}UniqueJewelSplitPersonalityClassStart5
+{variant:6}UniqueJewelSplitPersonalityClassStart1
+Corrupted
+]],[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets


### PR DESCRIPTION
Fixes #2163

### Description of the problem being solved:
The naming of the item uses 'Templar' and 'Shadow' as starting points but since those classes don't exist yet in the game, we don't have them in our class map either
Made a different base class map that includes all the hidden classes so the map now works
Also adds the item to the unique list as it was missing

Changed the test to use templar to make sure hidden classes work

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldur/character/Jezie-4328/JonathanDodgers
