### PR TITLE
Fix Discipline not being converted by Eldritch Battery

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -30,6 +30,25 @@ describe("TestDefence", function()
 		return build.calcsTab.calcs.reducePoolsByDamage(nil, takenDamages, build.calcsTab.calcsEnv.player)
 	end
 
+	it("converts total energy shield modifiers to mana", function()
+		build.configTab.input.customMods = "Convert 100% of maximum Energy Shield to maximum Mana\n100% increased maximum Mana"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local manaWithoutTotalEnergyShield = build.calcsTab.mainOutput.Mana
+		local env = build.calcsTab.mainEnv
+		local player = env.player
+
+		player.modDB:NewMod("EnergyShieldTotal", "BASE", 100, "Test")
+		player.output = { }
+		build.calcsTab.calcs.defence(env, player)
+
+		assert.are.equals(0, player.output.EnergyShield)
+		assert.are.equals(0, player.modDB:Sum("BASE", nil, "ExtraMana"))
+		assert.are.equals(100, player.modDB:Sum("BASE", nil, "ManaTotal"))
+		assert.are.equals(manaWithoutTotalEnergyShield + 100, player.output.Mana)
+	end)
+
 	it("no armour max hits", function()
 		build.configTab.input.enemyIsBoss = "None"
 		build.configTab.input.customMods = ""

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -86,14 +86,15 @@ function calcs.doActorLifeManaSpirit(actor, skipBreakdown)
 	for _, res in ipairs({ "Life", "Mana", "Spirit" }) do
 		local base = modDB:Sum("BASE", nil, res)
 		local extra = modDB:Sum("BASE", nil, "Extra" .. res)
+		local total = modDB:Sum("BASE", nil, res .. "Total")
 		local inc = modDB:Sum("INC", nil, res)
 		local more = modDB:More(nil, res)
 		local conv = m_min(modDB:Sum("BASE", nil, res .. "ConvertToEnergyShield", res .. "ConvertToArmour", res .. "ConvertToEvasion"), 100)
 		local override = modDB:Override(nil, res)
 		output[res.."HasOverride"] = override ~= nil
-		output[res] = override or m_max(round((base * (1 - conv/100) + extra) * (1 + inc/100) * more), 1)
+		output[res] = override or m_max(round((base * (1 - conv/100) + extra) * (1 + inc/100) * more + total), 1)
 		if breakdown then
-			if inc ~= 0 or more ~= 1 or conv ~= 0 or extra ~= 0 then
+			if inc ~= 0 or more ~= 1 or conv ~= 0 or extra ~= 0 or total ~= 0 then
 				breakdown[res][1] = s_format("%g ^8(base)", base)
 				if conv ~= 0 then
 					t_insert(breakdown[res], s_format("x %.2f ^8(converted from)", 1 - conv/100))
@@ -110,7 +111,10 @@ function calcs.doActorLifeManaSpirit(actor, skipBreakdown)
 				if more ~= 1 then
 					t_insert(breakdown[res], s_format("x %.2f ^8(more/less)", more))
 				end
-				if inc ~= 0 or more ~= 1 then
+				if total ~= 0 then
+					t_insert(breakdown[res], s_format("+ %g ^8(total)", total))
+				end
+				if inc ~= 0 or more ~= 1 or total ~= 0 then
 					t_insert(breakdown[res], s_format("= %g", output[res]))
 				end
 			end
@@ -1324,6 +1328,7 @@ function calcs.defence(env, actor)
 				local item = actor.itemList[slot]
 				source.basePerSlot[slot] = item and item.armourData and item:GetArmourDataValue(source.name, actor.level) or 0
 			end
+			source.totalBase = modDB:Sum("BASE", nil, unpack(source.modsTotal))
 		end
 		for _, source in ipairs(resourceList) do
 			local globalBase = modDB:Sum("BASE", nil, unpack(source.mods)) + source.globalBase
@@ -1331,6 +1336,7 @@ function calcs.defence(env, actor)
 			if globalOverride then
 				globalBase = globalOverride
 			end
+			local totalBase = source.totalBase
 			for _, target in ipairs(resourceList) do
 				if source.name ~= target.name then
 					if source.defence then
@@ -1351,18 +1357,22 @@ function calcs.defence(env, actor)
 									source.basePerSlot[slot] = source.basePerSlot[slot] * (100 - source.totalConversion) / 100
 								end
 							end
-							target.globalBase = target.globalBase + globalBase * rate / 100
+							local targetBase = globalBase * rate / 100
+							local targetTotalBase = totalBase * rate / 100
+							target.globalBase = target.globalBase + targetBase
+							target.totalBase = target.totalBase + targetTotalBase
 							if breakdown then
-								breakdown.slot("Global", source.name .. " to " .. target.name .. " conversion", nil, globalBase, nil, unpack(target.mods))
+								breakdown.slot("Global", source.name .. " to " .. target.name .. " conversion", nil, targetBase, nil, unpack(target.mods))
 							end
 						end
-						source.globalBase = globalBase * (100 - source.totalConversion) / 100
 					else
 						local gainRate = modDB:Sum("BASE", nil, source.name .. "GainAs" .. target.name)
 						local rate = source.conversionRate[target.name] + gainRate
 						if rate > 0 then
 							local targetBase = math.ceil(globalBase * rate / 100)
+							local targetTotalBase = math.ceil(totalBase * rate / 100)
 							target.globalBase = target.globalBase + targetBase
+							target.totalBase = target.totalBase + targetTotalBase
 							if breakdown then
 								breakdown.slot("Conversion", source.name .. " to " .. target.name, nil, targetBase, nil, unpack(target.mods))
 							end
@@ -1370,15 +1380,20 @@ function calcs.defence(env, actor)
 					end
 				end
 			end
+			if source.defence then
+				source.globalBase = globalBase * (100 - source.totalConversion) / 100
+				source.totalBase = totalBase * (100 - source.totalConversion) / 100
+			end
 		end
 		for _, res in ipairs(resourceList) do
 			if res.defence then
 				for _, slot in pairs({"Helmet","Gloves","Boots","Body Armour","Weapon 2","Weapon 3"}) do
 					output[res.name] = output[res.name] + res.basePerSlot[slot] * calcLib.mod(modDB, { slotName = slot }, unpack(res.mods))
 				end
-				output[res.name] = output[res.name] + res.globalBase * calcLib.mod(modDB, nil, unpack(res.mods)) + modDB:Sum("BASE", nil, unpack(res.modsTotal))
+				output[res.name] = output[res.name] + res.globalBase * calcLib.mod(modDB, nil, unpack(res.mods)) + res.totalBase
 			else
 				modDB:NewMod("Extra"..res.name, "BASE", res.globalBase, "Conversion")
+				modDB:NewMod(res.name.."Total", "BASE", res.totalBase, "Conversion")
 			end
 		end
 


### PR DESCRIPTION
Fixes #2170

### Description of the problem being solved:
Sources of total energy shield like from the Discipline aura were not being used in the stat conversion logic


### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/qq14f90e
### Before screenshot:
<img width="600" height="296" alt="image" src="https://github.com/user-attachments/assets/df8935d8-b2e4-42c5-a59e-3e260c567cc1" />

### After screenshot:
<img width="593" height="312" alt="image" src="https://github.com/user-attachments/assets/cc7e8138-c820-48c1-8cbf-86ef55579e0e" />
