### PR TITLE
Fix mods duplicating when crafting some Crossbows

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -248,6 +248,62 @@ describe("TestItemParse", function()
 		assert.are.equals("+44 to Spirit", item.explicitModLines[1].line)
 	end)
 
+	it("Crafted affixes matching base implicits stay explicit", function()
+		local item = new("Item", [[
+			Rarity: Rare
+			New Item
+			Gemini Crossbow
+			Crafted: true
+			Prefix: None
+			Prefix: None
+			Prefix: None
+			Suffix: {range:0}AdditionalAmmo1
+			Suffix: None
+			Suffix: None
+			Implicits: 1
+			Loads an additional bolt
+		]])
+
+		item:Craft()
+		assert.are.equals(1, #item.implicitModLines)
+		assert.are.equals("Loads an additional bolt", item.implicitModLines[1].line)
+		assert.are.equals(1, #item.explicitModLines)
+		assert.are.equals("Loads an additional bolt", item.explicitModLines[1].line)
+
+		item.suffixes[1].range = 0.2
+		item:Craft()
+		assert.are.equals(1, #item.implicitModLines)
+		assert.are.equals(1, #item.explicitModLines)
+		assert.are.equals("Loads an additional bolt", item.explicitModLines[1].line)
+	end)
+
+	it("Pasted affixes matching base implicits stay explicit", function()
+		local item = new("Item", [[
+			Item Class: Crossbows
+			Rarity: Rare
+			New Item
+			Gemini Crossbow
+			--------
+			Physical Damage: 28-112
+			Critical Hit Chance: 5.00%
+			Attacks per Second: 1.60
+			Reload Time: 1.10
+			--------
+			Requires: Level 78, 89 Str, 89 Dex
+			--------
+			Item Level: 82
+			--------
+			Loads an additional bolt (implicit)
+			--------
+			Loads an additional bolt
+		]])
+
+		assert.are.equals(1, #item.implicitModLines)
+		assert.are.equals("Loads an additional bolt", item.implicitModLines[1].line)
+		assert.are.equals(1, #item.explicitModLines)
+		assert.are.equals("Loads an additional bolt", item.explicitModLines[1].line)
+	end)
+
 	--TODO: POB2 Leagues?
 	--it("League", function()
 	--end)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -72,7 +72,7 @@ local function baseHasImplicitLine(base, line)
 		return false
 	end
 	for implicitLine in base.implicit:gmatch("[^\n]+") do
-		if implicitLine == line or implicitLine:match("^Grants Skill:") and line:match("^" .. implicitLine:gsub("%(%d+%-%d+%)", "%%d+") .. "$") then
+		if implicitLine:match("^Grants Skill:") and (implicitLine == line or line:match("^" .. implicitLine:gsub("%(%d+%-%d+%)", "%%d+") .. "$")) then
 			return true
 		end
 	end
@@ -482,7 +482,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			end
 		else
 			line = linePrefix .. line .. linePostfix
-			local lineIsBaseImplicit = mode == "GAME" and baseHasImplicitLine(self.base, line)
+			local lineIsBaseImplicit = mode == "GAME" and not self.crafted and baseHasImplicitLine(self.base, line)
 			if self.checkSection then
 				if gameModeStage == "IMPLICIT" then
 					if foundImplicit and not lineIsBaseImplicit then


### PR DESCRIPTION
Fixes #2168

### Description of the problem being solved:
The logic should only be working on grants skill lines instead of any implicit mod line

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/arzid0ww

### Before screenshot:
<img width="654" height="554" alt="image" src="https://github.com/user-attachments/assets/c8a23df5-6daf-48ca-9290-e3cdb3ff67dd" />

### After screenshot:
<img width="654" height="529" alt="image" src="https://github.com/user-attachments/assets/ad8f42fd-6499-473d-a563-75d143630301" />
