### PR TITLE
Fix crash when importing items with +1 suffix rune

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -702,12 +702,13 @@ holding Shift will put it in the second.]])
 	end
 
 	-- Section: Affix Selection
+	local maxModCount = 9
 	self.controls.displayItemSectionAffix = new("Control", {"TOPLEFT",self.controls.displayItemSectionRune,"BOTTOMLEFT"}, {0, 0, 0, function()
 		if not self.displayItem or not self.displayItem.crafted then
 			return 0
 		end
 		local h = 6
-		for i = 1, 6 do
+		for i = 1, maxModCount do
 			if self.controls["displayItemAffix"..i]:IsShown() then
 				h = h + 24
 				if self.controls["displayItemAffixRange"..i]:IsShown() then
@@ -717,7 +718,7 @@ holding Shift will put it in the second.]])
 		end
 		return h
 	end})
-	for i = 1, 6 do
+	for i = 1, maxModCount do
 		local prev = self.controls["displayItemAffix"..(i-1)] or self.controls.displayItemSectionAffix
 		local drop, slider
 		local function verifyRange(range, index, drop) -- flips range if it will form discontinuous values


### PR DESCRIPTION
### Description of the problem being solved:
Fixes crash on 7 mod rares. Simply adds 3 more controls. This doesn't change how they're created and they are still made when itemsTab is initialised. I.e., this doesn't add support for an unlimited amount
### Steps taken to verify a working solution:
- Old items work as they used to
- Testing with various +# prefix/suffix modifier allowed mods works
- Real-world items tested work

### Link to a build that showcases this PR:
```
Item Class: Bows
Rarity: Rare
Eagle Bane
Obliterator Bow
--------
Quality: +30% (augmented)
Physical Damage: 375-677 (augmented)
Lightning Damage: 8-215 (lightning)
Critical Hit Chance: 10.00% (augmented)
Attacks per Second: 1.31 (augmented)
--------
Requires: Level 78, 163 Dex
--------
Sockets: S S S 
--------
Item Level: 82
--------
+1 Suffix Modifier allowed (rune)
20% increased Physical Damage (rune)
Bow Attacks fire an additional Arrow (rune)
--------
{ Implicit Modifier }
50% reduced Projectile Range
--------
{ Prefix Modifier "Merciless" (Tier: 1) — Damage, Physical, Attack }
171(170-179)% increased Physical Damage
{ Prefix Modifier "Vapourising" (Tier: 1) — Damage, Elemental, Lightning, Attack }
Adds 8(1-12) to 215(202-234) Lightning Damage
{ Desecrated Prefix Modifier "Flaring" (Tier: 1) — Damage, Physical, Attack }
Adds 37(26-39) to 64(44-66) Physical Damage
{ Fractured Suffix Modifier "of Unmaking" (Tier: 1) — Attack, Critical }
+5(4.41-5)% to Critical Hit Chance
{ Suffix Modifier "of the Sniper" (Tier: 1) }
+4 to Level of all Projectile Skills
{ Suffix Modifier "of Many" (Tier: 1) — Attack }
+198(175-200)% Surpassing chance to fire an additional Arrow
{ Suffix Modifier "of Acclaim" (Tier: 1) — Attack, Speed }
19(17-19)% increased Attack Speed
--------
Fractured Item
--------
Hinekora's Lock
--------
Note: ~b/o 1 mirror
```
### Before screenshot:
<img width="711" height="360" alt="image" src="https://github.com/user-attachments/assets/71aff221-e784-40e1-a73a-d6065a6b68a1" />

### After screenshot:
<img width="629" height="1112" alt="image" src="https://github.com/user-attachments/assets/e6f66e4d-fad7-47bc-88ff-cee75b362944" />

