### PR TITLE
Add option to disable scroll wheel interacting with controls

### DIFF
--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -462,6 +462,9 @@ function DropDownClass:OnKeyUp(key)
 		if self.dropped and self.controls.scrollBar.enabled then
 			self.controls.scrollBar:Scroll(1)
 		else
+			if main.disableScrollControlInteraction then
+				return
+			end
 			self:SetSel(self:ListIndexToDropIndex(self.selIndex, 0) + 1)
 		end
 		return self
@@ -473,6 +476,9 @@ function DropDownClass:OnKeyUp(key)
 		if self.dropped and self.controls.scrollBar.enabled then
 			self.controls.scrollBar:Scroll(-1)
 		else
+			if main.disableScrollControlInteraction then
+				return
+			end
 			self:SetSel(self:ListIndexToDropIndex(self.selIndex, 0) - 1)
 		end
 		return self

--- a/src/Classes/DropDownControl.lua
+++ b/src/Classes/DropDownControl.lua
@@ -462,7 +462,7 @@ function DropDownClass:OnKeyUp(key)
 		if self.dropped and self.controls.scrollBar.enabled then
 			self.controls.scrollBar:Scroll(1)
 		else
-			if main.disableScrollControlInteraction then
+			if main.disableScrollControlInteraction and key == "WHEELDOWN" then
 				return
 			end
 			self:SetSel(self:ListIndexToDropIndex(self.selIndex, 0) + 1)
@@ -476,7 +476,7 @@ function DropDownClass:OnKeyUp(key)
 		if self.dropped and self.controls.scrollBar.enabled then
 			self.controls.scrollBar:Scroll(-1)
 		else
-			if main.disableScrollControlInteraction then
+			if main.disableScrollControlInteraction and key == "WHEELUP" then
 				return
 			end
 			self:SetSel(self:ListIndexToDropIndex(self.selIndex, 0) - 1)

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -675,7 +675,7 @@ function EditClass:OnKeyUp(key)
 		end
 	elseif self.isNumeric then
 		local cur = tonumber(self.buf)
-		if key == "WHEELUP" or key == "UP" then
+		if not main.disableScrollControlInteraction and (key == "WHEELUP" or key == "UP") then
 			if cur then
 				self:SetText(tostring(cur + (self.numberInc or 1)), true)
 			else
@@ -685,7 +685,7 @@ function EditClass:OnKeyUp(key)
 					self:SetText("1", true)
 				end
 			end
-		elseif key == "WHEELDOWN" or key == "DOWN" then
+		elseif not main.disableScrollControlInteraction and (key == "WHEELDOWN" or key == "DOWN") then
 			if cur then
 				local value = cur - (self.numberInc or 1)
 				if self.filter == "%D" or self.filter == "^%d." then

--- a/src/Classes/EditControl.lua
+++ b/src/Classes/EditControl.lua
@@ -675,7 +675,7 @@ function EditClass:OnKeyUp(key)
 		end
 	elseif self.isNumeric then
 		local cur = tonumber(self.buf)
-		if not main.disableScrollControlInteraction and (key == "WHEELUP" or key == "UP") then
+		if (not main.disableScrollControlInteraction and (key == "WHEELUP")) or key == "UP" then
 			if cur then
 				self:SetText(tostring(cur + (self.numberInc or 1)), true)
 			else
@@ -685,7 +685,7 @@ function EditClass:OnKeyUp(key)
 					self:SetText("1", true)
 				end
 			end
-		elseif not main.disableScrollControlInteraction and (key == "WHEELDOWN" or key == "DOWN") then
+		elseif (not main.disableScrollControlInteraction and (key == "WHEELDOWN")) or key == "DOWN" then
 			if cur then
 				local value = cur - (self.numberInc or 1)
 				if self.filter == "%D" or self.filter == "^%d." then

--- a/src/Classes/SliderControl.lua
+++ b/src/Classes/SliderControl.lua
@@ -161,7 +161,7 @@ function SliderClass:OnKeyUp(key)
 			local cursorX, cursorY = GetCursorPos()
 			self:SetValFromKnobX((cursorX - self.dragCX) + self.dragKnobX)
 		end
-	elseif (not main.invertSliderScrollDirection and key == "WHEELDOWN") or (main.invertSliderScrollDirection and  key == "WHEELUP") or key == "DOWN" or key == "LEFT" then
+	elseif not main.disableScrollControlInteraction and (not main.invertSliderScrollDirection and key == "WHEELDOWN") or (main.invertSliderScrollDirection and  key == "WHEELUP") or key == "DOWN" or key == "LEFT" then
 		if IsKeyDown("SHIFT") then
 			self:SetVal(self.val - self.scrollWheelSpeedTbl["SHIFT"])
 		elseif IsKeyDown("CTRL") then
@@ -169,7 +169,7 @@ function SliderClass:OnKeyUp(key)
 		else
 			self:SetVal(self.val - self.scrollWheelSpeedTbl["DEFAULT"])
 		end
-	elseif (not main.invertSliderScrollDirection and key == "WHEELUP") or (main.invertSliderScrollDirection and key == "WHEELDOWN") or key == "UP" or key == "RIGHT" then
+	elseif not main.disableScrollControlInteraction and (not main.invertSliderScrollDirection and key == "WHEELUP") or (main.invertSliderScrollDirection and key == "WHEELDOWN") or key == "UP" or key == "RIGHT" then
 		if IsKeyDown("SHIFT") then
 			self:SetVal(self.val + self.scrollWheelSpeedTbl["SHIFT"])
 		elseif IsKeyDown("CTRL") then

--- a/src/Classes/SliderControl.lua
+++ b/src/Classes/SliderControl.lua
@@ -161,7 +161,7 @@ function SliderClass:OnKeyUp(key)
 			local cursorX, cursorY = GetCursorPos()
 			self:SetValFromKnobX((cursorX - self.dragCX) + self.dragKnobX)
 		end
-	elseif not main.disableScrollControlInteraction and (not main.invertSliderScrollDirection and key == "WHEELDOWN") or (main.invertSliderScrollDirection and  key == "WHEELUP") or key == "DOWN" or key == "LEFT" then
+	elseif (not main.invertSliderScrollDirection and key == "WHEELDOWN") or (main.invertSliderScrollDirection and  key == "WHEELUP") or key == "DOWN" or key == "LEFT" then
 		if IsKeyDown("SHIFT") then
 			self:SetVal(self.val - self.scrollWheelSpeedTbl["SHIFT"])
 		elseif IsKeyDown("CTRL") then
@@ -169,7 +169,7 @@ function SliderClass:OnKeyUp(key)
 		else
 			self:SetVal(self.val - self.scrollWheelSpeedTbl["DEFAULT"])
 		end
-	elseif not main.disableScrollControlInteraction and (not main.invertSliderScrollDirection and key == "WHEELUP") or (main.invertSliderScrollDirection and key == "WHEELDOWN") or key == "UP" or key == "RIGHT" then
+	elseif (not main.invertSliderScrollDirection and key == "WHEELUP") or (main.invertSliderScrollDirection and key == "WHEELDOWN") or key == "UP" or key == "RIGHT" then
 		if IsKeyDown("SHIFT") then
 			self:SetVal(self.val + self.scrollWheelSpeedTbl["SHIFT"])
 		elseif IsKeyDown("CTRL") then

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -115,6 +115,7 @@ function main:Init()
 	self.showFlavourText = true
 	self.showAnimations = true
 	self.showAllItemAffixes = true
+	self.disableScrollControlInteraction = false
 	self.errorReadingSettings = false
 	
 	if not SetDPIScaleOverridePercent then SetDPIScaleOverridePercent = function(scale) end end
@@ -662,6 +663,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.showAllItemAffixes then
 					self.showAllItemAffixes = node.attrib.showAllItemAffixes == "true"
 				end
+				if node.attrib.disableScrollControlInteraction then
+					self.disableScrollControlInteraction = node.attrib.disableScrollControlInteraction == "true"
+				end
 				if node.attrib.dpiScaleOverridePercent then
 					self.dpiScaleOverridePercent = tonumber(node.attrib.dpiScaleOverridePercent) or 0
 					SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
@@ -797,6 +801,7 @@ function main:SaveSettings()
 		showFlavourText = tostring(self.showFlavourText),
 		showAnimations = tostring(self.showAnimations),
 		showAllItemAffixes = tostring(self.showAllItemAffixes),
+		disableScrollControlInteraction = tostring(self.disableScrollControlInteraction),
 		dpiScaleOverridePercent = tostring(self.dpiScaleOverridePercent)
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
@@ -881,6 +886,7 @@ function main:OpenOptionsPopup(savedState)
 		showFlavourText = self.showFlavourText,
 		showAnimations = self.showAnimations,
 		showAllItemAffixes = self.showAllItemAffixes,
+		disableScrollControlInteraction = self.disableScrollControlInteraction,
 		dpiScaleOverridePercent = self.dpiScaleOverridePercent
 	}
 
@@ -1052,7 +1058,13 @@ function main:OpenOptionsPopup(savedState)
 	controls.showAllItemAffixes = new("CheckBoxControl", { "TOPLEFT", controls.sectionAnchor, "TOPLEFT" }, { currentX + defaultLabelPlacementX, currentY, 20 }, "^7Show all item affixes sliders:", function(state)
 		self.showAllItemAffixes = state
 	end)
-	controls.showAllItemAffixes.tooltipText = "Display all item affix slots as a stacked list instead of hiding them in dropdowns"
+	controls.showAllItemAffixes.tooltipText = "Display all item affix slots as a stacked list instead of hiding them in dropdowns."
+
+	nextRow()
+	controls.disableScrollControlInteraction = new("CheckBoxControl", { "TOPLEFT", controls.sectionAnchor, "TOPLEFT" }, { currentX + defaultLabelPlacementX, currentY, 20 }, "^7Disable control scroll interaction:", function(state)
+		self.disableScrollControlInteraction = state
+	end)
+	controls.disableScrollControlInteraction.tooltipText = "Disable changing the values in controls such as dropdowns, numeric inputs, or sliders when using the scroll wheel."
 
 	nextRow()
 	
@@ -1169,6 +1181,7 @@ function main:OpenOptionsPopup(savedState)
 	controls.showFlavourText.state = self.showFlavourText
 	controls.showAnimations.state = self.showAnimations
 	controls.showAllItemAffixes.state = self.showAllItemAffixes
+	controls.disableScrollControlInteraction.state = self.disableScrollControlInteraction
 
 	-- Adjust height in case of two-column layout
 	currentY = m_max(leftColumnMaxY, currentY)

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1064,7 +1064,7 @@ function main:OpenOptionsPopup(savedState)
 	controls.disableScrollControlInteraction = new("CheckBoxControl", { "TOPLEFT", controls.sectionAnchor, "TOPLEFT" }, { currentX + defaultLabelPlacementX, currentY, 20 }, "^7Disable control scroll interaction:", function(state)
 		self.disableScrollControlInteraction = state
 	end)
-	controls.disableScrollControlInteraction.tooltipText = "Disable changing the values in controls such as dropdowns, numeric inputs, or sliders when using the scroll wheel."
+	controls.disableScrollControlInteraction.tooltipText = "Disable changing the values in controls such as dropdowns or numeric inputs when using the scroll wheel."
 
 	nextRow()
 	
@@ -1243,6 +1243,7 @@ function main:OpenOptionsPopup(savedState)
 		self.showFlavourText = savedState.showFlavourText
 		self.showAnimations = savedState.showAnimations
 		self.showAllItemAffixes = savedState.showAllItemAffixes
+		self.disableScrollControlInteraction = savedState.disableScrollControlInteraction
 		self.dpiScaleOverridePercent = savedState.dpiScaleOverridePercent
 		SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
 		main:ClosePopup()


### PR DESCRIPTION
Fixes #2164.

### Description of the problem being solved:

Fixes scroll affecting controls by adding an option that lets you disable it. Not a default option, though I hate this enough that I think it should be on by default.

Initially this also included slider controls, but I think it kind of makes sense there, and they're not really included in UIs where this is annoying.

### Steps taken to verify a working solution:
- Everything scrolled over

### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/1f163
### Before and after:

https://github.com/user-attachments/assets/e19d2dc6-f9f2-4a14-9cbd-095d95ab34ad


