### PR TITLE
Fix window title changing in compare tab

### DIFF
--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -1310,6 +1310,10 @@ function CompareTabClass:ImportBuild(xmlText, label)
 		t_insert(self.compareEntries, entry)
 		self.activeCompareIndex = #self.compareEntries
 		self:UpdateBuildSelector()
+		-- Restore primary build's window title
+		if self.primaryBuild.spec then
+			self.primaryBuild.spec:SetWindowTitleWithBuildClass()
+		end
 		return true
 	end
 	return false


### PR DESCRIPTION
Fixes #2081.

### Description of the problem being solved:
See title. The compare tab already does the same re-applying of the primary build's window title in many other places, but not when actually importing a build. This does that. The secondary build's title flashes briefly, but this solves the confusion of it staying that way
### Steps taken to verify a working solution:
- Yes

### Link to a build that showcases this PR:
N/A
### Before screenshot:
<img width="717" height="240" alt="image" src="https://github.com/user-attachments/assets/0eb1b768-c53d-47f9-977a-dfe1ce294002" />

### After screenshot:
<img width="659" height="233" alt="image" src="https://github.com/user-attachments/assets/4a2b64f9-db09-4aee-8d7a-5b5f9c07acda" />
