### PR TITLE
Change border size to be 1 px

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -698,10 +698,11 @@ function CalcBreakdownClass:Draw(viewPort)
 	else
 		SetDrawColor(0.33, 0.66, 0.33)
 	end
-	DrawImage(nil, x, y, width, 2)
-	DrawImage(nil, x, y + height - 2, width, 2)
-	DrawImage(nil, x, y, 2, height)
-	DrawImage(nil, x + width - 2, y, 2, height)
+	local borderThickness = 2
+	DrawImage(nil, x, y, width, borderThickness)
+	DrawImage(nil, x, y + height - borderThickness, width, borderThickness)
+	DrawImage(nil, x, y, borderThickness, height)
+	DrawImage(nil, x + width - borderThickness, y, borderThickness, height)
 	SetDrawLayer(nil, 10)
 	self:DrawControls(viewPort)
 	-- Draw the sections

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -11,7 +11,7 @@ local s_gmatch = string.gmatch
 
 -- Constants
 
-local BORDER_WIDTH = 3
+local BORDER_WIDTH = 1
 local H_PAD	= 12
 local V_PAD = 10
 -- spell-checker: disable


### PR DESCRIPTION
### Description of the problem being solved:

Changes the hard coded border size from the oddly thick 3 px to 1 px.

### Steps taken to verify a working solution:
- Many tooltips hovered

### Link to a build that showcases this PR:
https://pobb.in/jo5dOTxQjXQl
### Before screenshot:
<img width="973" height="768" alt="image" src="https://github.com/user-attachments/assets/2f739aac-0fb8-4e07-890a-bf2ec146ba5f" />
<img width="688" height="967" alt="image" src="https://github.com/user-attachments/assets/4f588ba4-047a-4be0-b838-d381ee5c17aa" />
<img width="698" height="680" alt="image" src="https://github.com/user-attachments/assets/e38b74fb-691f-4615-8541-933cd1d26a0c" />

### After screenshot:

Note that if Github scales these down, the edges might look more blurry than in reality where they are exactly 1 px.

<img width="1014" height="829" alt="image" src="https://github.com/user-attachments/assets/74142c4d-baff-466c-8bd9-680a76f7c524" />
<img width="681" height="990" alt="image" src="https://github.com/user-attachments/assets/3ef22f06-8071-44b2-b93a-5c8f628343a2" />
<img width="688" height="602" alt="image" src="https://github.com/user-attachments/assets/2d1ad2e7-1824-490f-80fe-68ee2d4250c2" />
