### PR TITLE
Fix many supports not adding cooldown

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2904,8 +2904,7 @@ return {
 	flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" } ),
 },
 ["warcry_count_power_from_enemies"] = {
-	flag("UsesWarcryPower", { type = "GlobalEffect", effectType = "Warcry" }),
-	flag("Condition:Empowered", { type = "GlobalEffect", effectType = "Warcry" }),
+	flag("UsesWarcryPower", { type = "GlobalEffect", effectType = "Warcry" })
 },
 ["chance_to_gain_1_more_charge_%"] = {
 	mod("AdditionalChargeChance", "BASE", nil)

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -576,8 +576,7 @@ return {
 	div = 1000,
 },
 ["support_hourglass_display_cooldown_time_ms"] = {
-	mod("CooldownRecovery", "BASE", nil),
-	div = 1000,
+	-- handled around 700 of CalcActiveSkill, search for level.cooldown
 },
 ["base_cooldown_modifiable_repeat_interval_ms"] = {
 	mod("CooldownRecovery", "BASE", nil),
@@ -2905,7 +2904,8 @@ return {
 	flag("Condition:CanGainRage", { type = "GlobalEffect", effectType = "Buff", effectName = "Rage" } ),
 },
 ["warcry_count_power_from_enemies"] = {
-	flag("UsesWarcryPower", { type = "GlobalEffect", effectType = "Warcry" })
+	flag("UsesWarcryPower", { type = "GlobalEffect", effectType = "Warcry" }),
+	flag("Condition:Empowered", { type = "GlobalEffect", effectType = "Warcry" }),
 },
 ["chance_to_gain_1_more_charge_%"] = {
 	mod("AdditionalChargeChance", "BASE", nil)

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -698,6 +698,9 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			if level.spiritReservationFlat then
 				skillModList:NewMod("ExtraSpirit", "BASE", level.spiritReservationFlat, skillEffect.grantedEffect.modSource)
 			end
+			if level.cooldown then
+				skillModList:NewMod("CooldownRecovery", "BASE", level.cooldown, skillEffect.grantedEffect.modSource)
+			end
 			-- Handle multiple triggers situation and if triggered by a trigger skill save a reference to the trigger.
 			local match = skillEffect.grantedEffect.addSkillTypes and (not skillFlags.disable)
 			if match and skillEffect.grantedEffect.isTrigger then


### PR DESCRIPTION
Fixes #2181 

### Description of the problem being solved:
Some supports like Zarokh's Revolt and Refrain have a cooldown in the gemData that was not being added to the supported activeSkill. 

Known fixed supports:
- Zarokh's Revolt
- Zarokh's Refrain
- Breachlord's Amalgam
- Nova Projectiles II
- Hayoxi's Fulmination

### Steps taken to verify a working solution:
- Validated previous cooldown supports like Hourglass and Expanse

### Link to a build that showcases this PR:
<pre>eNrNXN1zGjkSf87-FVM83FvMh-OP3SO7hcGOqbITDuzk7l625EGAzpoRK2mw2b9-uyXNB2BAAm_V7UOiEf3rbrWkVndL2fZvrwmPFlQqJtLPteZJoxbRNBZjlk4_1x4fbj5e1n779af2gOjZt8lVxjj-0vr1pw9t8xHFnCj1lST0c21I0imVtSghLB2J-JnqL1Jkc-Bai4iKaTrulsRfRUprkSZySvX3XHzjdyCNZ0SSWFN5RxeUdzIt7sUYEFpmgFgw-mK_-_eDb8OHWsSRDIWAUh_aA06WVI400ZGCPz7XOjA4MqW3TAOY8AyQ582Ty7OLs1p9J-Iqk0r3SAJNX-RoTum4IG6efGoBddP9uQ00kPR6MqGxZgvalUx3ZySNS5E_b8OF0t5nXLM5ZzhFjr61jf52g3Wz0dhG_CA04b3BqKC9vDw5Pb8ohr4bJ8p52SrhB9OzKw62PUAKYvvTlGl6IHggmBLpEeOrQrcOsZtxDjvLi3ZIFZULotmqWtt5i-SJpQdZ756kpCtUOUdn57tIB1TCPtcriMYewIjGAlxDFXLZ8BDyNnQr8o5NqD9l0EAcIFSbw8ZxPfKlC2Z8mEJDcJB-lCORcU9KXTqprWuzR19L97TVJ_dTvZ_VkP5RpWue7RC6ELjx9o_hQbKnTFMPQvQT17eDgvLTxcnF2WWrcdpqtS4_nW49OGZLxWLC78krS7IEfPYDeaalZudn21ffdKZTcDfboNuF3jBJw1FdwccHoGZEqPDR9Yh8TqlSvo4UHKM3AvethwoQCMS_IG0_jUvXuYvpYyqdMl7zN6FD2KIYqDxx6okoRbiN7nO4W1FTmjp5Sz8b3VEaz75AIDgkPlsA3Xppp8ZOsyJt1aw7mb5h1jNPQICREPi2kVq7IIFGGs2ZZF76WMo3xh6ACRj-dUrldDmaMcrHHudMhTq3V5fMfcYPs19Fe62CVXFBC7kKDZwrPBRDpS2Iqh4sF7vtYKn9TLAgY7oWz29fyxQC7SDEQIr_YfrCw2AwDM7DEQdK69EJR5jACYSTzxvhK6AjE5FJz1Vsib0mLz_lbSY6pOMs9os_iqTyikMy7juMAmWMHQTtaE3i554YT8NmNAixqt8om8_BYeFO8GWAAQyc-6wShn4886D-BrvYy01hrOMvoKT2FlBEb_5S1iD-Y8EIbE2MD7G3gGI678FLJnDemBLKvagcWVsdVRXxYwYO4VHBCEfPjPNS8MnpjrqLorBkhmTMMnVPNXyXQenWBQF5ulfSbQg9k_-BeAF7zbAYpsKoITouANtjdknTP5fe_FfIvQRcp-NM4vbzlrGOeEvMVTaZqCjOpKJ3sKYgUaLJXEjCIwCxFKTEInki2v5Yi56A3rUtgweWwGGmVI9oEo1d4vadSEZS3TRlybXOlulUpnZ5w7imsgf8UE0cSqQokfEMRdwQzp_A2aHYstcJbtdNaRRbXcJjZXTpp_NMR6mpfSZMxb-jtljIBAZammrr9c3Ndfeh__3aqV-FKFzVv6dZ8oTlO_t3uTdG9mSLVPakbPNz7TujL2Yv9KgmjIO12BgcLvaMKB5saD7OyVxR6J8QrugObgYHOVheD0Velc8ATtcwh7B-6RhXg9PqB1hQMqrCVbIKYISFk225mZJiACN7bnWJ0ja2M3ayldwALlhidcPpmjA9ANtP5oQ7yXk71BJ6OacKYgs2YXHFtOa3B_jN9YXYJYa9R-JlMdv5ERvAw1RtLQPXDADbyqtF5-0Qq5qqr7OqawfAezQmbuyuGQAu0gWRmpsH5FL0BXH6KlKzyMFFdBjHA8_N7DWnZUcAw296RqU9dx2ne_BHRUfYxrE1Lsen-h1iK1NTMRYyrQCorRuYMZhWyKZx2bTd7Sx0y67mvGY-VnoCWNmQydkwD7ZCpsFlHmYKXDtkJHneaQaRf4RsFOODOwvBxtY_mC2z3hnkNOAEPp6NySvegU2ROR7P64YT9exmOm8HwB8h7WV6uYeLuSjdvd2O44B77TgOGPUlB6OHRQgyXI8-POROc3dVfPjji7D1YA42uD4YbmL_g9HG9cN6xrSn4vvLnhD_qbO0B8YoN8bBrIxaa_5jKzOfIbpz0XOkezja_e4uH0oH4DpC_SQc47dFoHgopyJrvqWE4w214Mcx3LhkOYYZljyzOUnHObtvq-H5Frb7pkFoBTxNatXDyuqxNkxpsvRhVOjVrufpXHtApF5C9qg0S4k7hbHqMJqJl854gcv4ASZF5WpEZD6n6YpW7QdJaUTyWlZcvGDBjyiBbITKpYvKMM1MIVdUeHvx6eznWqQBXHk2c7bywqY_dukqXuISueys_pQy0NS82-mnICQlHHtbOQtQfln9Iac1NKjhh_bj8M40Psy0nqtf6vWXl5eTOdEzMaGvjNMTSMzrcwDB2D6a1PUjKlzvwH9X0z7-1TGM6jmntn0wpOr2C1eMZDBgK6ZdRJb5D2D716_WIjB7qS7akEznbcervsKsXUf7mtnECcBGH6sKOqKv-JeZ2ZV5MhmUAoETknH9hSb_ygiewsbGbv5sVq1d-UAilbpa9gajG4wG115grBDk75oUrJw7OoV0C38q1g12Y5HTQjCPg986d3e1ij539gFUKmRSXAa7peT0Muu76SbPdILNYp6NaT91Ba1CIr7e6pSjMkOiKV4z5nthncTsCkPHyRNqUnOzBrqZcg9o0E9hwtzSq3Y5rO1HZn0TjhP5bEtGuBOlzOa63NL5g69WAytGpm5TgApyZxMgmdIEf76nmoyJJvW-BvvW0ch1oz20HPSPyrzaEX_h4onwZj7uNTNUaVp5J5Zr7HYuFMpSXZRqjrGKXQb_JVI8z9SQLgTXe43UXLHRCtbxCzRZsRZXeIUYzym4x3qW_T_IXKh_qiiX8t7GvIVkaYreLdCQBe5IIxZ83t-AFdZvW23NFFeSknjGhRyrDviRKUm8rbEJPcAsFau8pcp7m6eUka-xyqg9zHX9SmMIfmngwslhxxko5_L-Zik5e1ohZircBgg61gLI4-8Yv-XrNfqvYkHK62j18CICLbHJ4Eh_ssnw_U2EMqKKkKjf37BX256tuwMO45EPDjcM-q2AI5-k_LbIXhaFhhOr6MPiinUe7xxgvHEd5rFob8lSvDJ1xVJ8yR967lkwTGHiEp_jtvEmv3e3khWRO_kVSf-Hi7YfU7OHA1ergx22TAvwO1se-Ea5Vl5nyZykBxwmBnXsaWKY_B3HiWPsZYEipJ5IWD2HxvYGfJw9Vnn9_cG9E7N9P7omhPQmc7cpublgF-mETV0abj9cHm5gRU-kmebUFPMxa66tZMRg6ZjOBB9T6a7bKRaHzHuW_IY7v3I_vTzP1duEJcU_scF_OOIuuePnLo5rRPmkcnN_tp2LEY4Pj9Zl_3y-A9WdoYFQnNp4ILB7iPmVUw5q-AwQy78pxQecNNV86SVyBIsxngXoWIrrsckE7JnqL_AHGVM0z9h_nO46Pye_aDT2GUYyja_uflBiXoavK93awUCxKePfJqZUDzhTo_dV1L3yE5ybf01XVdlD443F6jWV3UyiZVfvLwuF95oqv3LMEZeN89M9kOI5WtAKt1B0ZBVhrX1mgZ4DpOQKDrAYXJjTY88GAVC5IED-HMlvIWL5l2Go07WHAIynK5cbS7Lha4x1R3G2D7n6dtVzAt7Y9J0kEf47fkwTkd4ImWx4mn36FrffBaJ5ceax7_KHMYVhPBZKiDFHMxE_H-Q3zcuq5aMK9NTF6tymZbteHK32ZsR85dca-PYs-lOI5N8mZMDWfyov6EZaYqkeu11ccuoq3ZrofNJjrHSXdy8mTHHnPLaLavtWWJRBWGiuQMCJzyFTQYSNT-zzOstlB5kLEtZjB5cgcJE_zrPACCiZttFVwzYHT4_Du_ImogLpwBRRHQC4pTwJAjilWgGQKzFeRsVrEl8URHkLc8fqL0boEPohuJ4g4xpAKxRweoBxo9ELvnIOxTVDcXc0zAJIH2IAmPRg-hB9zBuPIAnmhUjQnFgZzWAZ4VqFyLiifM-ubdedJ7JvliVEtyPjJn9QPHiVvXo2_g9bX4W2N5nY6z7a9Y3_P8NfOVupiA==</pre>

### Before screenshot:
<img width="788" height="218" alt="image" src="https://github.com/user-attachments/assets/6dba0ce6-bbf9-4334-a4ae-330ad335dbf5" />

### After screenshot:
<img width="824" height="270" alt="image" src="https://github.com/user-attachments/assets/d14f3fa0-1dd0-47cc-a9ed-85bd64e07419" />
<img width="903" height="573" alt="image" src="https://github.com/user-attachments/assets/8121cade-8220-4a45-930a-5abac4ef4e7e" />
