### PR TITLE
Fix not being able to highlight text in compare config tab

### DIFF
--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2069,7 +2069,7 @@ local function syncControlValue(ctrl, varData, val)
 			or varData.type == "countAllowZero" or varData.type == "float" then
 		local text = tostring(val or "")
 		-- avoid setting text every time as otherwise this clears user selections on every frame
-		if text ~= ctrl.buf then
+		if not ctrl.hasFocus and text ~= ctrl.buf then
 			ctrl:SetText(text)
 		end
 	elseif varData.type == "list" then

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2067,7 +2067,11 @@ local function syncControlValue(ctrl, varData, val)
 		ctrl.state = val or false
 	elseif varData.type == "count" or varData.type == "integer"
 			or varData.type == "countAllowZero" or varData.type == "float" then
-		ctrl:SetText(tostring(val or ""))
+		local text = tostring(val or "")
+		-- avoid setting text every time as otherwise this clears user selections on every frame
+		if text ~= ctrl.buf then
+			ctrl:SetText(text)
+		end
 	elseif varData.type == "list" then
 		ctrl:SelByValue(val or (varData.list[1] and varData.list[1].val), "val")
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Fixes compare tab config subtab controls clearing user selection on every frame.

~~Also fixes a crash when distance config has too many digits that I accidentally found~~ Reverted because @LocalIdentity had a fix implemented elsewhere

### Steps taken to verify a working solution:
- Tested with my own build while using pob

### Link to a build that showcases this PR:
https://pobb.in/x5Djmznj897s
https://pobb.in/CZfC5voLQXWp
### Before screenshot:
https://github.com/user-attachments/assets/f9b99948-7c29-46d5-909f-7c6625851728
### After screenshot:
https://github.com/user-attachments/assets/9db60c01-236e-4ef1-8caf-5fd46054be8b



