### PR TITLE
Add "Buy similar" button to item view

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -14,6 +14,7 @@ local m_min = math.min
 local m_ceil = math.ceil
 local m_floor = math.floor
 local m_modf = math.modf
+local buySimilar = LoadModule("Classes/CompareBuySimilar")
 
 local gemTooltip = LoadModule("Classes/GemTooltip")
 local rarityDropList = {
@@ -410,6 +411,15 @@ holding Shift will put it in the second.]])
 		self:SetDisplayItem()
 	end)
 
+	self.controls.displayItemBuySimilar = new("ButtonControl",
+		{ "LEFT", self.controls.removeDisplayItem, "RIGHT", true },
+		{ 8, 0, 100, 20 }, "Buy similar", function()
+			local itemSlot = self:GetComparisonSlotNameForItem(self.displayItem)
+			buySimilar.openPopup(self.displayItem, itemSlot, self.build)
+		end)
+	self.controls.displayItemBuySimilar.shown = function()
+		return self.displayItem
+	end
 	-- Section: Variant(s)
 
 	self.controls.displayItemSectionVariant = new("Control", {"TOPLEFT",self.controls.addDisplayItem,"BOTTOMLEFT"}, {0, 8, 0, function()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -14,6 +14,7 @@ local m_min = math.min
 local m_ceil = math.ceil
 local m_floor = math.floor
 local m_modf = math.modf
+local buySimilar = LoadModule("Classes/CompareBuySimilar")
 
 local rarityDropList = {
 	{ label = colorCodes.NORMAL.."Normal", rarity = "NORMAL" },
@@ -409,6 +410,15 @@ holding Shift will put it in the second.]])
 		self:SetDisplayItem()
 	end)
 
+	self.controls.displayItemBuySimilar = new("ButtonControl",
+		{ "LEFT", self.controls.removeDisplayItem, "RIGHT", true },
+		{ 8, 0, 100, 20 }, "Buy similar", function()
+			local itemSlot = self:GetComparisonSlotNameForItem(self.displayItem)
+			buySimilar.openPopup(self.displayItem, itemSlot, self.build)
+		end)
+	self.controls.displayItemBuySimilar.shown = function()
+		return self.displayItem
+	end
 	-- Section: Variant(s)
 
 	self.controls.displayItemSectionVariant = new("Control", {"TOPLEFT",self.controls.addDisplayItem,"BOTTOMLEFT"}, {0, 8, 0, function()

--- a/src/Classes/TradeHelpers.lua
+++ b/src/Classes/TradeHelpers.lua
@@ -256,8 +256,8 @@ function M.findTradeHash(item, modLine, modType, isDesecrated)
 			end
 		end
 	end
-	-- essence mods don't seem to have spawn weights and are tested last
-	for _, dbMod in pairs(data.itemMods.Item) do
+	-- essence and emotion mods don't seem to have spawn weights and are tested last
+	for _, dbMod in pairs(item.affixes) do
 		local tradeHashMaybe = findStat(dbMod, true)
 		if tradeHashMaybe then
 			return tradeHashMaybe

--- a/src/Classes/TradeHelpers.lua
+++ b/src/Classes/TradeHelpers.lua
@@ -168,6 +168,10 @@ end
 ---@return number? value         returned if the mod is an option and uses values. e.g. timeless jewel
 function M.findTradeHash(item, modLine, modType, isDesecrated)
 	local formattedLine = M.formatDatabaseText(modLine)
+	-- hack for belt implicits not matching. TODO: use stat_descriptions instead, which define what
+	-- description is the canonical form that is used on the trade site, either by assuming it's the
+	-- first one, or one with a marker called "canonical_line"
+	formattedLine = formattedLine:gsub("Has # Charm Slots", "Has # Charm Slot")
 	-- the data export splits some mods into different parts, even though they
 	-- are technically just one stat. we handle that here
 	local isUnique = item.rarity == "UNIQUE" or item.rarity == "RELIC"


### PR DESCRIPTION
Fixes #2192.

### Description of the problem being solved:

This adds a "Buy similar" button to the display item controls, which works the same way as the buttons in the comparison tab.

### Steps taken to verify a working solution:
- Various items tested from db and builds, including jewels, regular gear, and uniques

### Link to a build that showcases this PR:
Use item db
### Before screenshot:
N/A
### After screenshot:
<img width="615" height="269" alt="image" src="https://github.com/user-attachments/assets/317aa37c-3ec5-43a3-81c8-0bdb6a8a7989" />

<img width="956" height="510" alt="image" src="https://github.com/user-attachments/assets/c8f69891-b5c9-4309-9dd2-c6c94f28c51f" />

The second commit fixes the missing implicit mod there, but note that there's an error with specifically this item as the rare mod mod matches its value as 60, which is incorrect
