### PR TITLE
Fix ice bite and innervate only supporting attacks

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2648,7 +2648,7 @@ skills["SupportInnervatePlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
-					mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
+					mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
 				},
 				["support_innervate_buff_base_duration_ms"] = {
 					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -5615,7 +5615,7 @@ skills["SupportIceBitePlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-					mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
+					mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 				},
 				["support_ice_bite_base_buff_duration"] = {
 					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),
@@ -5656,7 +5656,7 @@ skills["SupportIceBitePlayerTwo"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-					mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
+					mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 				},
 				["support_ice_bite_base_buff_duration"] = {
 					mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -573,7 +573,7 @@ statMap = {
 #set SupportInnervatePlayer
 statMap = {
 	["support_innervate_buff_grant_%_added_lightning_attack_damage"] = {
-		mod("DamageGainAsLightning", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
+		mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Innervate" }),
 	},
 	["support_innervate_buff_base_duration_ms"] = {
 		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "KilledShockedLast3Seconds" }, { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -948,7 +948,7 @@ statMap = {
 #set SupportIceBitePlayer
 statMap = {
 	["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-		mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
+		mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 	},
 	["support_ice_bite_base_buff_duration"] = {
 		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),
@@ -962,7 +962,7 @@ statMap = {
 #set SupportIceBitePlayerTwo
 statMap = {
 	["support_ice_bite_buff_grant_%_added_cold_attack_damage"] = {
-		mod("DamageGainAsCold", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
+		mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Ice Bite" }),
 	},
 	["support_ice_bite_base_buff_duration"] = {
 		mod("Duration", "BASE", nil, 0, 0, { type = "Condition", var = "FrozenEnemyRecently" }, { type = "GlobalEffect", effectType = "Buff" }),


### PR DESCRIPTION
Fixes #2206.

### Description of the problem being solved:

Fix 0.5.1 gems that are no longer limited to attacks:

> The Cold, Lightning and Fire Attunement Support Gems are no longer limited to supporting just Attacks. These now grant Gain 25% of Damage as Extra Cold, Lightning or Fire Damage respectively.
> Ice Bite I Support is no longer limited to supporting just Attacks, and now grants Gain 25% of Damage as Cold Damage for 5 seconds on Freezing an Enemy with Supported Skills.
> Ice Bite II Support is no longer limited to supporting just Attacks, and now grants Gain 30% of Damage as Cold Damage for 6 seconds on Freezing an Enemy with Supported Skills.
> Innervate Support is no longer limited to supporting just Attacks, and now grants Gain 25% of Damage as Lightning Damage for 5 seconds on killing a Shocked enemy with Supported Skills.

Oddly enough it seems that the attunement gems didn't have attack filters in the first place.

### Steps taken to verify a working solution:
- Tested with spells and attacks

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="755" height="168" alt="image" src="https://github.com/user-attachments/assets/e0845235-8fdd-40c0-af12-5d0209c456ed" />
<img width="730" height="146" alt="image" src="https://github.com/user-attachments/assets/a3ea8ef6-7cbf-47b3-b05f-9a7a3e8004da" />

