### PR TITLE
Fix staff runes showing on quarterstaves

### DIFF
--- a/spec/System/TestSocketables_spec.lua
+++ b/spec/System/TestSocketables_spec.lua
@@ -87,7 +87,7 @@ describe("TestSocketables", function()
 
     it("'(Caster) Staff' runes appear in Items tab", slotTypeTest("staff", "Voltaic Staff"))
 
-    it("'(Quarterstaff) War Staff' runes appear in Items tab", slotTypeTest("warstaff", "Striking Quarterstaff"))
+	it("'Quarterstaff' runes appear in Items tab", slotTypeTest("quarterstaff", "Striking Quarterstaff"))
 
     it("'Spear' runes appear in Items tab", slotTypeTest("spear", "Flying Spear"))
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1566,7 +1566,7 @@ function ItemClass:UpdateRunes()
 			local itemType = self.base.type:lower()
 			local baseType = self.base.weapon and "weapon" or self.base.armour and "armour" or (self.base.tags.wand or self.base.tags.staff or self.base.tags.sceptre) and "caster"
 			local specificType =
-				(subType == "warstaff" and "warstaff") or
+				(subType == "warstaff" and "quarterstaff") or
 				(itemType == "shield" and subType == "evasion" and "buckler") or
 				itemType
 			local gatheredMods = getModRunesForTypes(name, baseType, specificType)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1932,7 +1932,7 @@ function ItemsTabClass:GetValidRunesForItem(item)
 		local function isRuneValidForSlot(runeSlot)
 			if runeSlot == "None" then
 				return true
-			elseif runeSlot == "warstaff" then
+			elseif runeSlot == "quarterstaff" then
 				return subType == "warstaff"
 			elseif runeSlot == "buckler" then
 				return itemType == "shield" and subType == "evasion"
@@ -1943,7 +1943,7 @@ function ItemsTabClass:GetValidRunesForItem(item)
 			elseif runeSlot == "caster" then
 				return item.base.tags.wand or item.base.tags.staff or item.base.tags.sceptre
 			else
-				return itemType == runeSlot
+				return itemType == runeSlot and not (subType == "warstaff")
 			end
 		end
 		if isRuneValidForSlot(rune.slot) then

--- a/src/Data/ModRunes.lua
+++ b/src/Data/ModRunes.lua
@@ -3299,7 +3299,7 @@ return {
 				tradeHashes = { [103706408] = { "Rolls only the minimum or maximum Damage value for Physical Damage" },  },
 				rank = { 15 },
 		},
-		["warstaff"] = {
+		["quarterstaff"] = {
 				type = "Rune",
 				"Rolls only the minimum or maximum Damage value for Physical Damage",
 				statOrder = { 7793 },
@@ -3472,7 +3472,7 @@ return {
 		},
 	},
 	["Rune of Confrontation"] = {
-		["warstaff"] = {
+		["quarterstaff"] = {
 				type = "Rune",
 				"Gain 4 Rage on Melee Hit",
 				"-10 to Maximum Rage",

--- a/src/Export/Scripts/soulcores.lua
+++ b/src/Export/Scripts/soulcores.lua
@@ -10,10 +10,10 @@ classMap = {
 	["Armour"] = { "armour" },
 	["Wand or Staff"] = { "wand", "staff" },
 	["Maces or Talisman"] = { "one hand mace", "two hand mace", "talisman" },
-	["One Hand Mace or Quarterstaff"] = { "one hand mace", "warstaff" },
+	["One Hand Mace or Quarterstaff"] = { "one hand mace", "quarterstaff" },
 	["Shield or Buckler"] = { "shield", "buckler" },
 	["All"] = { "weapon", "armour", "caster" },
-	["Quarterstaff or Spear"] = { "warstaff", "spear" },
+	["Quarterstaff or Spear"] = { "quarterstaff", "spear" },
 	["Crossbow Bow or Spear"] = { "crossbow", "bow", "spear" },
 }
 


### PR DESCRIPTION
Related to #2216, but doesn't fix it as the actual issue is unrelated to the runes

### Description of the problem being solved:
Fixes staff runes being on quarterstaves. Runes now always export with the word quarterstaff.
### Steps taken to verify a working solution:
- Example works, and others are unaffected
- Quarterstaff specific runes work

### Link to a build that showcases this PR:
```
Item Class: Quarterstaves
Rarity: Rare
Cataclysm Branch
Dreaming Quarterstaff
--------
Quality: +23% (augmented)
Physical Damage: 838-1 270 (augmented)
Critical Hit Chance: 0.00%
Attacks per Second: 1.90 (augmented)
--------
Requires: Level 78, 127 Dex, 50 Int
--------
Sockets: S S S 
--------
Item Level: 82
--------
40% increased Physical Damage (rune)
Can roll Destruction modifiers (rune)
--------
{ Fractured Prefix Modifier "Merciless" (Tier: 1) — Damage, Physical, Attack — 15% Increased }
179(170-179)% increased Physical Damage
{ Prefix Modifier "Flaring" (Tier: 1) — Damage, Physical, Attack — 15% Increased }
Adds 51(37-55) to 92(63-94) Physical Damage
{ Desecrated Prefix Modifier "Dictator's" (Tier: 1) — Damage, Physical, Attack — 15% Increased }
78(75-79)% increased Physical Damage
+198(175-200) to Accuracy Rating
{ Suffix Modifier "of War" (Tier: 1) — Attack }
+5 to Level of all Melee Skills
{ Suffix Modifier "of Celebration" (Tier: 1) — Attack, Speed }
27(26-28)% increased Attack Speed
{ Suffix Modifier "of Destruction" (Tier: 1) — Physical — 15% Increased }
15(10-15)% increased Explicit Physical Modifier magnitudes — Unscalable Value
--------
Fractured Item
--------
Note: ~b/o 2 mirror
```
### Before screenshot:
<img width="737" height="1186" alt="image" src="https://github.com/user-attachments/assets/2ab0e7ae-3c90-465e-a959-66da22949598" />

### After screenshot:
<img width="774" height="1222" alt="image" src="https://github.com/user-attachments/assets/fe388be7-2c88-4d64-9316-a82844f323fb" />
<img width="974" height="726" alt="image" src="https://github.com/user-attachments/assets/d2a115d0-ba8a-44d3-9e9c-9e31c4dfc9f0" />

