### PR TITLE
Fix Bloodhounds Mark not counting the enemy as Marked

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -535,6 +535,11 @@ skills["BloodhoundsMarkPlayer"] = {
 			label = "Mark",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "bloodhounds_mark",
+			statMap = {
+				["hunters_mark_%_of_max_threshold_to_trigger_explosion_on_death"] = {
+					mod("ExplosionThreshold", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -66,6 +66,11 @@ statMap = {
 #skill BloodhoundsMarkPlayer
 #set BloodhoundsMarkPlayer
 #flags
+statMap = {
+	["hunters_mark_%_of_max_threshold_to_trigger_explosion_on_death"] = {
+		mod("ExplosionThreshold", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+	},
+},
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #2215

### Description of the problem being solved:
The gem didn't have any stats mapped to apply as a mark on the enemy

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/x73hbl0h

### Before screenshot:
<img width="532" height="165" alt="image" src="https://github.com/user-attachments/assets/def831c6-178f-41a3-b02e-cfd8dbc5f511" />

### After screenshot:
<img width="525" height="188" alt="image" src="https://github.com/user-attachments/assets/8813a69f-67a1-4105-8238-8141cfc296ba" />