### PR TITLE
Fix Blazing Critical not applying as a global buff

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -920,7 +920,7 @@ skills["SupportBlazingCriticalPlayer"] = {
 			statDescriptionScope = "gem_stat_descriptions",
 			statMap = {
 				["support_blazing_crits_gain_%_fire_damage_with_attacks_on_critical_hit"] = {
-					mod("DamageGainAsFire", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "CritRecently" }),
+					mod("DamageGainAsFire", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "CritRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Blazing Critical", unscalable = true }),
 				},
 				["support_blazing_crits_base_duration_ms"] = {
 					-- Display only

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -167,7 +167,7 @@ statMap = {
 #set SupportBlazingCriticalPlayer
 statMap = {
 	["support_blazing_crits_gain_%_fire_damage_with_attacks_on_critical_hit"] = {
-		mod("DamageGainAsFire", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "CritRecently" }),
+		mod("DamageGainAsFire", "BASE", nil, ModFlag.Attack, 0, { type = "Condition", var = "CritRecently" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Blazing Critical", unscalable = true }),
 	},
 	["support_blazing_crits_base_duration_ms"] = {
 		-- Display only


### PR DESCRIPTION
Fixes #2214

### Description of the problem being solved:
The skill gem is meant to apply the damage gain as a global buff to the character and not just the supported skill

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/kf3hc20h

### Before screenshot:
<img width="684" height="193" alt="image" src="https://github.com/user-attachments/assets/cf82b8e9-b017-4b31-bd8c-0e9044fe0361" />

### After screenshot:
<img width="692" height="200" alt="image" src="https://github.com/user-attachments/assets/6834e615-12bd-49e3-bab0-d7a6a4c8c098" />
