### PR TITLE
Fix Sine Aequo Immobilisation buildup calculation

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5781,8 +5781,8 @@ local specialModList = {
 		flag("CannotHeavyStun"),
 		flag("CannotPin"),
 	},
-	["immobilise enemies at (%d+)%% buildup instead of (%d+)%%"] = function(num, _, base) return {
-		mod("EnemyModifier", "LIST", { mod = mod("PoiseThreshold", "MORE",-num) }),
+	["immobilise enemies at (%d+)%% buildup instead of (%d+)%%"] = function(num) return {
+		mod("EnemyModifier", "LIST", { mod = mod("PoiseThreshold", "MORE",(num - 100)) }),
 	} end,
 	["the effect of blind on you is reversed"] = { flag("BlindEffectReversed") },
 	["blind does not affect your chance to hit"] = { flag("IgnoreBlindHitChance") },


### PR DESCRIPTION
Fixes #2212

### Description of the problem being solved:
The calc was not behaving correctly at values other than 50%
e.g. Immobilising enemies at 44% buildup instead of 100% is meant to apply 56% less poise threshold, not 44%


### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/t13hd20h

### Before screenshot:
<img width="577" height="91" alt="image" src="https://github.com/user-attachments/assets/29541d28-fcd8-4bbc-ae8a-a4cd9dda8ede" />

### After screenshot:
<img width="580" height="93" alt="image" src="https://github.com/user-attachments/assets/5d6cd493-b0e6-4b69-9562-6fab23703954" />
