### PR TITLE
Fix Overwhelming Presence quality mod multiplying Aura magnitude

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -515,7 +515,7 @@ return {
 	mod("Damage", "INC", nil, 0, 0, { type = "Condition", var = "LeechingEnergyShield" }),
 },
 ["aura_effect_+%"] = {
-	mod("AuraEffect", "INC", nil),
+	mod("Magnitude", "INC", nil, 0, 0, { type = "SkillType", skillType = SkillType.Aura }),
 },
 ["elusive_effect_+%"] = {
 	mod("ElusiveEffect", "MAX", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),


### PR DESCRIPTION
Fixes #2209

### Description of the problem being solved:
The stat on the gem was using Aura effect instead of magnitude which is why it was applying multiplicatively

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/wi3hds0h

### Before screenshot:
<img width="634" height="454" alt="image" src="https://github.com/user-attachments/assets/6539ea0d-6284-4c0c-bfd8-1c824d38cfdc" />

### After screenshot:
<img width="629" height="458" alt="image" src="https://github.com/user-attachments/assets/d6b34478-5552-4d25-902c-c6c62f096c5a" />
