### PR TITLE
Add option to return to build selection when crashing

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -357,6 +357,9 @@ function launch:ShowPrompt(r, g, b, str, func)
 	self.promptFunc = func or function(key)
 		if key == "RETURN" or key == "ESCAPE" then
 			return true
+		elseif key == "F4" then
+			self.main:SetMode("LIST")
+			return true
 		elseif key == "c" and IsKeyDown("CTRL") then
 			local cleanStr = str:gsub("%^%d", "")
 			Copy(cleanStr)
@@ -372,7 +375,7 @@ function launch:ShowErrMsg(fmt, ...)
 		local version = self.versionNumber and 
 			"^8v"..self.versionNumber..(self.versionBranch and " "..self.versionBranch or "")
 			or ""
-		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0"..string.format(fmt, ...).."\n"..version.."\n^0Press Enter/Escape to dismiss, or F5 to restart the application.\nPress CTRL + C to copy error text.")
+		self:ShowPrompt(1, 0, 0, "^1Error:\n\n^0"..string.format(fmt, ...).."\n"..version.."\n^0Press Enter/Escape to dismiss, F4 to return to build selection, or F5 to restart the application.\nPress CTRL + C to copy error text.")
 	end
 end
 

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -358,7 +358,11 @@ function launch:ShowPrompt(r, g, b, str, func)
 		if key == "RETURN" or key == "ESCAPE" then
 			return true
 		elseif key == "F4" then
-			self.main:SetMode("LIST")
+			if self.main then
+				self.main.popups = { }
+				self.main.inputEvents = { }
+				self.main:SetMode("LIST")
+			end
 			return true
 		elseif key == "c" and IsKeyDown("CTRL") then
 			local cleanStr = str:gsub("%^%d", "")


### PR DESCRIPTION
### Description of the problem being solved:
Fixes issues where users encounter an issue which crashes PoB when loading. This is obviously not very common, but in cases such as #2217 can cause PoB to crash when loading, which renders both the dismiss and restart options useless. There can also be crashes in Draw functions, such as when it happened to timeless jewels at the start of 0.5 due to missing textures.

This option lets users at least continue using PoB without having to manually remove the problematic profile file, which they probably won't know to do.
### Steps taken to verify a working solution:
- Yes
- Can be tested by e.g. adding an `error()` to a tab's Draw method

### Link to a build that showcases this PR:
https://pobb.in/wS-S5R5EYZfC (#2217 build which crashes)
### Before screenshot:
<img width="739" height="292" alt="image" src="https://github.com/user-attachments/assets/53c53fd8-7256-4d53-90ac-db22f6d23c35" />

### After screenshot:
<img width="772" height="300" alt="image" src="https://github.com/user-attachments/assets/e73ea5fb-1e30-49f7-939d-d9b5c973f0a1" />
