### PR TITLE
Fix Mirage Archer having no Spirit cost

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -950,12 +950,20 @@ local function setupGem(gem, gemId)
 	end
 	if gem.grantedEffectDisplayOrder then
 		local tempTable = {}
-		local moved = false
-		for i, temp in ipairs(gem.grantedEffectList) do
-			if gem.grantedEffectDisplayOrder[i] then
-				tempTable[i] = gem.grantedEffectList[gem.grantedEffectDisplayOrder[i] + 1]
+		local used = {}
+		for i, order in ipairs(gem.grantedEffectDisplayOrder) do
+			local index = order + 1
+			if gem.grantedEffectList[index] and not used[index] then
+				tempTable[i] = gem.grantedEffectList[index]
+				used[index] = true
 			else
-				tempTable[i] = temp
+				tempTable[i] = gem.grantedEffectList[i]
+				used[i] = true
+			end
+		end
+		for i, effect in ipairs(gem.grantedEffectList) do
+			if not used[i] then
+				table.insert(tempTable, effect)
 			end
 		end
 		gem.grantedEffectList = tempTable


### PR DESCRIPTION
Added fail-safe for grantedEffectDisplayOrder in cases where there are more effects granted than arguments in grantedEffectDisplayOrder to resolve "MetaMirageArcherPlayer" being discarded and thus spirit not being reserved for mirage archer and potentially other skills.

Fixes Mirage archer not reserving spirit as reported in issue 2151

### Description of the problem being solved:   In Gems.lua SkillGemMirageArcher grants 3 effects but only assigning an order to 2 of them "grantedEffectDisplayOrder = { 1, 2 },"

### Steps taken to verify a working solution:
- Verified Mirage archer was not reserving any spirit
- Added failsafe for when grantedEffectDisplayOrder contains less entries than the number of effects granted and append any missing effects.
- Applied fix, added mirage archer with ice shot, confirmed spirit was being reserved correctly and damage calculations were uneffected.

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/bh7ilp0w
### Before screenshot:
<img width="1485" height="734" alt="image" src="https://github.com/user-attachments/assets/1c545a9a-d324-4c71-bbed-40a5645acb16" />

### After screenshot:
<img width="1494" height="707" alt="image" src="https://github.com/user-attachments/assets/1e7ee3c6-8886-4a8e-afd8-d875c521b80d" />
