### PR TITLE
Add support for "+X% to Fire Spell Critical Hit Chance" mod

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -73,6 +73,21 @@ describe("TestItemParse", function()
 		assert.are.equals(12, item.quality)
 	end)
 
+	it("parses '+X% to Fire Spell Critical Hit Chance' (issue #2226)", function()
+		local item = new("Item", [[
+			Rarity: Rare
+			Xoph's Test Band
+			Amethyst Ring
+			Implicits: 0
+			+5% to Fire Spell Critical Hit Chance
+		]])
+		-- grants base critical hit chance to fire spells specifically
+		assert.are.equals(5, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire }, "CritChance"))
+		-- must NOT apply to attacks, nor to non-fire spells
+		assert.are.equals(0, item.baseModList:Sum("BASE", { flags = ModFlag.Attack, keywordFlags = KeywordFlag.Fire }, "CritChance"))
+		assert.are.equals(0, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Cold }, "CritChance"))
+	end)
+
 	--TODO: impl sockets for POB2
 	--it("Sockets", function()
 	--end)

--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -73,19 +73,24 @@ describe("TestItemParse", function()
 		assert.are.equals(12, item.quality)
 	end)
 
-	it("parses '+X% to Fire Spell Critical Hit Chance' (issue #2226)", function()
+	it("parses '<element> spell' as a composable Spell + element tag (issue #2226)", function()
 		local item = new("Item", [[
 			Rarity: Rare
 			Xoph's Test Band
 			Amethyst Ring
 			Implicits: 0
 			+5% to Fire Spell Critical Hit Chance
+			+30% to Fire Spell Critical Damage Bonus
+			+7% to Cold Spell Critical Hit Chance
 		]])
-		-- grants base critical hit chance to fire spells specifically
+		-- the "fire spell" tag composes with any crit stat (chance and damage bonus)
 		assert.are.equals(5, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire }, "CritChance"))
-		-- must NOT apply to attacks, nor to non-fire spells
+		assert.are.equals(30, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire }, "CritMultiplier"))
+		-- ...and works per element
+		assert.are.equals(7, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Cold }, "CritChance"))
+		-- still correctly scoped: not attacks, and not the wrong element
 		assert.are.equals(0, item.baseModList:Sum("BASE", { flags = ModFlag.Attack, keywordFlags = KeywordFlag.Fire }, "CritChance"))
-		assert.are.equals(0, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Cold }, "CritChance"))
+		assert.are.equals(0, item.baseModList:Sum("BASE", { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Cold }, "CritMultiplier"))
 	end)
 
 	--TODO: impl sockets for POB2

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -755,6 +755,7 @@ local modNameList = {
 	["critical hit chance"] = "CritChance",
 	["attack critical hit chance"] = { "CritChance", flags = ModFlag.Attack },
 	["thorns critical hit chance"] = { "CritChance", flags = ModFlag.Thorns },
+	["fire spell critical hit chance"] = { "CritChance", flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire },
 	["critical damage bonus"] = "CritMultiplier",
 	["attack critical damage bonus"] = { "CritMultiplier", flags = ModFlag.Attack },
 	["critical spell damage bonus"] = { "CritMultiplier", flags = ModFlag.Spell },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -755,7 +755,6 @@ local modNameList = {
 	["critical hit chance"] = "CritChance",
 	["attack critical hit chance"] = { "CritChance", flags = ModFlag.Attack },
 	["thorns critical hit chance"] = { "CritChance", flags = ModFlag.Thorns },
-	["fire spell critical hit chance"] = { "CritChance", flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire },
 	["critical damage bonus"] = "CritMultiplier",
 	["attack critical damage bonus"] = { "CritMultiplier", flags = ModFlag.Attack },
 	["critical spell damage bonus"] = { "CritMultiplier", flags = ModFlag.Spell },
@@ -1038,6 +1037,10 @@ local modFlagList = {
 	["with ranged weapons"] = { flags = bor(ModFlag.WeaponRanged, ModFlag.Hit) },
 	-- Skill types
 	["spell"] = { flags = ModFlag.Spell },
+	["fire spell"] = { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Fire },
+	["cold spell"] = { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Cold },
+	["lightning spell"] = { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Lightning },
+	["chaos spell"] = { flags = ModFlag.Spell, keywordFlags = KeywordFlag.Chaos },
 	["for spells"] = { flags = ModFlag.Spell },
 	["for spell skills"] = { flags = ModFlag.Spell },
 	["for spell damage"] = { flags = ModFlag.Spell },


### PR DESCRIPTION
Closes #2226.

### Problem
The "of Xoph" suffix — `+X% to Fire Spell Critical Hit Chance` (mod group `FireSpellBaseCriticalChance`) — had no `modNameList` entry, so the `fire spell` qualifier was left unparsed and the affix granted nothing.

### Fix
Adds a `modNameList` mapping to `CritChance` (BASE) restricted to fire spells via `ModFlag.Spell` + `KeywordFlag.Fire`, matching the existing `fire spells` convention already used in `preFlagList`.

### Testing
Adds a parse regression test in `spec/System/TestItemParse_spec.lua`: `+5% to Fire Spell Critical Hit Chance` grants +5 base crit to fire spells, and 0 to attacks / 0 to cold spells. The full test suite and the ModCache check pass.