### PR TITLE
Fix "+% to Critical Damage Bonus"  mods on weapons applying to Spells

### DIFF
--- a/spec/System/TestAttacks_spec.lua
+++ b/spec/System/TestAttacks_spec.lua
@@ -30,6 +30,35 @@ describe("TestAttacks", function()
 		assert.are.equals(2 + 0.25, build.calcsTab.mainOutput.CritMultiplier)
 	end)
 
+	it("local Critical Damage Bonus on a weapon does not apply to spells (issue #2199)", function()
+		-- baseline: a spell's crit multi with a plain quarterstaff (no local crit damage)
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Razor Quarterstaff
+		]])
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Fireball 20/0  1")
+		build.mainSocketGroup = 1
+		runCallback("OnFrame")
+		local baseSpellCritMulti = build.calcsTab.mainOutput.CritMultiplier
+
+		newBuild()
+
+		-- same spell + quarterstaff, now with a local "+X% to Critical Damage Bonus" affix
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Razor Quarterstaff
+			+50% to Critical Damage Bonus
+		]])
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Fireball 20/0  1")
+		build.mainSocketGroup = 1
+		runCallback("OnFrame")
+
+		-- the weapon-local crit damage must NOT reach the spell (it isn't using the weapon)
+		assert.are.equals(baseSpellCritMulti, build.calcsTab.mainOutput.CritMultiplier)
+	end)
+
 	it("correctly converts spell damage per stat to attack damage", function()
 		assert.are.equals(0, build.calcsTab.mainEnv.player.modDB:Sum("INC", { flags = ModFlag.Attack }, "Damage"))
 		build.itemsTab:CreateDisplayItemFromRaw([[

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1858,9 +1858,9 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 			weaponData[value.key] = value.value
 		end
 		for _, mod in ipairs(modList) do
-			-- Convert accuracy, L/MGoH and PAD Leech modifiers to local
+			-- Convert accuracy, crit damage bonus, L/MGoH and PAD Leech modifiers to local
 			if (
-				(mod.name == "Accuracy" and mod.flags == 0) or (mod.name == "ImpaleChance" and mod.flags ~= ModFlag.Spell) or
+				(mod.name == "Accuracy" and mod.flags == 0) or (mod.name == "CritMultiplier" and mod.flags == 0) or (mod.name == "ImpaleChance" and mod.flags ~= ModFlag.Spell) or
 				((mod.name == "LifeOnHit" or mod.name == "ManaOnHit") and mod.flags == ModFlag.Attack) or
 				((mod.name == "PhysicalDamageLifeLeech" or mod.name == "PhysicalDamageManaLeech") and mod.flags == ModFlag.Attack)
 			   ) and (mod.keywordFlags == 0 or mod.keywordFlags == KeywordFlag.Attack) and not mod[1] then


### PR DESCRIPTION
Closes #2199.

### Problem
A weapon's `+X% to Critical Damage Bonus` was parsed as a global `CritMultiplier` mod, so it incorrectly boosted skills that don't use the weapon — spells, shield skills, and own-base-damage skills (e.g. Bloodhound's Mark's explosion). In-game it's a local weapon affix that only applies to attacks using that weapon.

### Fix
In `ItemClass:BuildModListForSlotNum`, localize a plain weapon `CritMultiplier` mod (flags 0) the same way weapon Accuracy / leech already are — scoping it to `MainHandAttack` / `OffHandAttack` so it only applies to attacks using that weapon.

### Testing
Adds a regression test in `spec/System/TestAttacks_spec.lua`: a `Fireball` spell's crit multiplier is unchanged by `+50% to Critical Damage Bonus` on the equipped quarterstaff. The existing test that a weapon attack *does* gain the bonus still passes, and the full suite + ModCache check are green.