### PR TITLE
Support Vestige of Darkness physical damage to Chill/Freeze modifier

### DIFF
--- a/spec/System/TestAilments_spec.lua
+++ b/spec/System/TestAilments_spec.lua
@@ -28,33 +28,4 @@ describe("TestAilments", function()
 
 		assert.are.equals(1.1, build.calcsTab.mainOutput.PoisonEffMult)
 	end)
-
-	it("physical damage contributes to chill and freeze with Vestige of Darkness modifier", function()
-		-- High flat physical, no cold, so any chill/freeze must come from physical
-		build.itemsTab:CreateDisplayItemFromRaw([[
-			New Item
-			Razor Quarterstaff
-			Quality: 20
-			Adds 40000 to 60000 Physical Damage
-		]])
-		build.itemsTab:AddDisplayItem()
-		runCallback("OnFrame")
-		build.skillsTab:PasteSocketGroup("Quarterstaff Strike 1/0  1")
-		runCallback("OnFrame")
-		build.calcsTab:BuildOutput()
-		runCallback("OnFrame")
-
-		-- Baseline: physical hits cannot chill or freeze
-		assert.are.equals(0, build.calcsTab.mainOutput.FreezeBuildupAvg)
-
-		build.configTab.input.customMods = "Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup"
-		build.configTab:BuildModList()
-		runCallback("OnFrame")
-		build.calcsTab:BuildOutput()
-		runCallback("OnFrame")
-
-		-- Physical hits now contribute to freeze buildup and chill
-		assert.True(build.calcsTab.mainOutput.FreezeBuildupAvg > 0)
-		assert.True((build.calcsTab.mainOutput.ChillDuration or 0) > 0)
-	end)
 end)

--- a/spec/System/TestAilments_spec.lua
+++ b/spec/System/TestAilments_spec.lua
@@ -28,4 +28,33 @@ describe("TestAilments", function()
 
 		assert.are.equals(1.1, build.calcsTab.mainOutput.PoisonEffMult)
 	end)
+
+	it("physical damage contributes to chill and freeze with Vestige of Darkness modifier", function()
+		-- High flat physical, no cold, so any chill/freeze must come from physical
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			New Item
+			Razor Quarterstaff
+			Quality: 20
+			Adds 40000 to 60000 Physical Damage
+		]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+		build.skillsTab:PasteSocketGroup("Quarterstaff Strike 1/0  1")
+		runCallback("OnFrame")
+		build.calcsTab:BuildOutput()
+		runCallback("OnFrame")
+
+		-- Baseline: physical hits cannot chill or freeze
+		assert.are.equals(0, build.calcsTab.mainOutput.FreezeBuildupAvg)
+
+		build.configTab.input.customMods = "Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		build.calcsTab:BuildOutput()
+		runCallback("OnFrame")
+
+		-- Physical hits now contribute to freeze buildup and chill
+		assert.True(build.calcsTab.mainOutput.FreezeBuildupAvg > 0)
+		assert.True((build.calcsTab.mainOutput.ChillDuration or 0) > 0)
+	end)
 end)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6431,8 +6431,7 @@ c["Physical Damage is Pinning"]={{[1]={flags=0,keywordFlags=0,name="PhysicalCanP
 c["Physical Damage of Enemies Hitting you is Unlucky"]={nil,"Physical Damage of Enemies Hitting you is Unlucky "}
 c["Physical Damage of Enemies Hitting you is Unlucky Convert All Armour to Evasion Rating"]={nil,"Physical Damage of Enemies Hitting you is Unlucky Convert All Armour to Evasion Rating "}
 c["Physical Spell Critical Hits build Pin"]={{[1]={[1]={type="Condition",var="CriticalStrike"},flags=2,keywordFlags=16,name="CanPin",type="FLAG",value=true}},nil}
-c["Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup"]={nil,"Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup "}
-c["Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup Enemies in your Presence are Blinded"]={nil,"Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup Enemies in your Presence are Blinded "}
+c["Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup"]={{[1]={flags=0,keywordFlags=0,name="PhysicalCanChill",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="PhysicalCanFreeze",type="FLAG",value=true}},nil}
 c["Pin Enemies which are Primed for Pinning"]={nil,"Pin Enemies which are Primed for Pinning "}
 c["Pin Enemies which are Primed for Pinning Require 4 fewer enemies to be Surrounded"]={nil,"Pin Enemies which are Primed for Pinning Require 4 fewer enemies to be Surrounded "}
 c["Pinned Enemies cannot deal Critical Hits"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Pinned"},flags=0,keywordFlags=0,name="NeverCrit",type="FLAG",value=true}}},[2]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Condition",var="Pinned"},flags=0,keywordFlags=0,name="Condition:NeverCrit",type="FLAG",value=true}}}},nil}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3896,6 +3896,7 @@ local specialModList = {
 	["your chaos damage can ignite"] = { flag("ChaosCanIgnite") },
 	["chaos damage can ignite, chill and shock"] = { flag("ChaosCanIgnite"), flag("ChaosCanChill"), flag("ChaosCanShock") },
 	["your physical damage can chill"] = { flag("PhysicalCanChill") },
+	["physical damage from hits contributes to chill magnitude and freeze buildup"] = {	flag("PhysicalCanChill"), flag("PhysicalCanFreeze")	},
 	["your physical damage can shock"] = { flag("PhysicalCanShock") },
 	["your physical damage can freeze"] = { flag("PhysicalCanFreeze") },
 	["your lightning damage can freeze"] = { flag("LightningCanFreeze") },
@@ -4065,9 +4066,6 @@ local specialModList = {
 		flag("FireCanChill"), flag("FireCanFreeze"), flag("FireCanShock"),
 		flag("ColdCanIgnite"), flag("ColdCanShock"),
 		flag("LightningCanIgnite"), flag("LightningCanChill"), flag("LightningCanFreeze"),
-	},
-	["physical damage from hits contributes to chill magnitude and freeze buildup"] = {
-		flag("PhysicalCanChill"), flag("PhysicalCanFreeze"),
 	},
 	-- Bleed
 	["melee attacks cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Melee) },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4066,6 +4066,9 @@ local specialModList = {
 		flag("ColdCanIgnite"), flag("ColdCanShock"),
 		flag("LightningCanIgnite"), flag("LightningCanChill"), flag("LightningCanFreeze"),
 	},
+	["physical damage from hits contributes to chill magnitude and freeze buildup"] = {
+		flag("PhysicalCanChill"), flag("PhysicalCanFreeze"),
+	},
 	-- Bleed
 	["melee attacks cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Melee) },
 	["attacks cause bleeding when hitting cursed enemies"] = { mod("BleedChance", "BASE", 100, nil, ModFlag.Attack, { type = "ActorCondition", actor = "enemy", var = "Cursed" }) },


### PR DESCRIPTION
## Description

Adds support for the **Vestige of Darkness** (Tenebrous Crown) unique helmet affix:

> **Physical damage from Hits Contributes to Chill Magnitude and Freeze Buildup**

This modifier was previously unrecognised by the mod parser, so equipping the helmet had no effect on Chill or Freeze.

## Changes

- **`src/Modules/ModParser.lua`** — new rule emitting `flag("PhysicalCanChill")`, `flag("PhysicalCanFreeze")`.
- **`src/Data/ModCache.lua`** — regenerated the stale cache entry for this line (it was cached as unrecognised, which shadowed the new parser rule).
- **`spec/System/TestAilments_spec.lua`** — new system test: a pure-physical Quarterstaff Strike has no Freeze buildup baseline, then gains Freeze buildup and Chill once the modifier is applied.

## Testing

- Full Busted suite passes (429 successes / 0 failures).
- Verified end-to-end with the actual unique equipped (ModCache loaded, normal app path): with the helmet, physical hits drive `FreezeBuildupAvg > 0` and apply Chill; without it both remain zero.

## Reference build

Example build affected by this modifier: https://maxroll.gg/poe2/pob/4a65hh0h