### PR TITLE
Fix Demon Form not counting as being Shapeshifted

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -369,6 +369,9 @@ local function doActorAttribsConditions(env, actor)
 			modDB:NewMod("StunThreshold", "INC", 50, "Wyvern Form")
 			modDB:NewMod("AilmentThreshold", "INC", 50, "Wyvern Form")
 		end
+		if env.configInput.inDemonForm then
+			condList["Shapeshifted"] = true
+		end
 		if skillFlags.hit and not skillFlags.trap and not skillFlags.mine and not skillFlags.totem then
 			condList["HitRecently"] = true
 			if skillFlags.spell then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -369,9 +369,6 @@ local function doActorAttribsConditions(env, actor)
 			modDB:NewMod("StunThreshold", "INC", 50, "Wyvern Form")
 			modDB:NewMod("AilmentThreshold", "INC", 50, "Wyvern Form")
 		end
-		if env.configInput.inDemonForm then
-			condList["Shapeshifted"] = true
-		end
 		if skillFlags.hit and not skillFlags.trap and not skillFlags.mine and not skillFlags.totem then
 			condList["HitRecently"] = true
 			if skillFlags.spell then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -343,6 +343,7 @@ local configSettings = {
 	end },
 	{ label = "Demon Form:", ifSkill = "Demon Form" },
 	{ var = "inDemonForm", type = "check", label = "Are you in Demon Form?", ifSkill = "Demon Form", defaultState = true, tooltip = "Players need a minimum of 2 ^xE05030Life ^7to enter Demon Form, so you cannot use it with Chaos Inoculation", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config")
 		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "StatThreshold", stat = "Life", threshold = 2 })
 	end },
 	{ var = "demonFormStacks", type = "count", label = "Demonflame Stacks", ifSkill = "Demon Form", defaultPlaceholderState = 10, apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Turning on demon form in config did not apply the shape shifted condition.

### Steps taken to verify a working solution:
Verified passive tree shapeshifted nodes to check whether the condition was being verified true:
- Life Regen on shapeshift
- Max Lightning res on shapeshift

### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/20fb0

### Before screenshot:

### After screenshot:
