### PR TITLE
Fix some radius jewels mods not working correctly

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6849,6 +6849,7 @@ c["Unique Tamed Beasts have 30% increased movement speed"]={nil,"Unique Tamed Be
 c["Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
 c["Unwavering Stance"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Unwavering Stance"}},nil}
 c["Unwithered enemies are Withered for 8 seconds when they enter your Presence"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanWither",type="FLAG",value=true}},nil}
+c["Upgrades Radius to Very Large"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="timeLostJewelRadiusOverride",value=4}}},nil}
 c["Used when you are affected by a Slow"]={nil,"Used when you are affected by a Slow "}
 c["Used when you are affected by a Slow Grants Onslaught during effect"]={nil,"Used when you are affected by a Slow Grants Onslaught during effect "}
 c["Used when you become Frozen"]={nil,"Used when you become Frozen "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6849,7 +6849,6 @@ c["Unique Tamed Beasts have 30% increased movement speed"]={nil,"Unique Tamed Be
 c["Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
 c["Unwavering Stance"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Unwavering Stance"}},nil}
 c["Unwithered enemies are Withered for 8 seconds when they enter your Presence"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanWither",type="FLAG",value=true}},nil}
-c["Upgrades Radius to Very Large"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="timeLostJewelRadiusOverride",value=4}}},nil}
 c["Used when you are affected by a Slow"]={nil,"Used when you are affected by a Slow "}
 c["Used when you are affected by a Slow Grants Onslaught during effect"]={nil,"Used when you are affected by a Slow Grants Onslaught during effect "}
 c["Used when you become Frozen"]={nil,"Used when you become Frozen "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6372,8 +6372,7 @@ c["Only affects Passives in Massive Ring"]={{[1]={flags=0,keywordFlags=0,name="J
 c["Only affects Passives in Medium Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=8}}},nil}
 c["Only affects Passives in Medium-Large Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=9}}},nil}
 c["Only affects Passives in Medium-Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=7}}},nil}
-c["Only affects Passives in Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=6}}},nil}
-c["Only affects Passives in Very Large Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=11}}},nil}
+c["Only affects Passives in Small Ring"] = { { [1] = { flags = 0, keywordFlags = 0, name = "JewelData", type = "LIST", value = { key = "radiusIndex", value = 6 } } }, nil }
 c["Only affects Passives in Very Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=5}}},nil}
 c["Onslaught"]={{[1]={flags=0,keywordFlags=0,name="Condition:Onslaught",type="FLAG",value=true}},nil}
 c["Orb Skills have +1 to Limit"]={nil,"Orb Skills have +1 to Limit "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6372,7 +6372,8 @@ c["Only affects Passives in Massive Ring"]={{[1]={flags=0,keywordFlags=0,name="J
 c["Only affects Passives in Medium Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=8}}},nil}
 c["Only affects Passives in Medium-Large Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=9}}},nil}
 c["Only affects Passives in Medium-Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=7}}},nil}
-c["Only affects Passives in Small Ring"] = { { [1] = { flags = 0, keywordFlags = 0, name = "JewelData", type = "LIST", value = { key = "radiusIndex", value = 6 } } }, nil }
+c["Only affects Passives in Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=6}}},nil}
+c["Only affects Passives in Very Large Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=11}}},nil}
 c["Only affects Passives in Very Small Ring"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="radiusIndex",value=5}}},nil}
 c["Onslaught"]={{[1]={flags=0,keywordFlags=0,name="Condition:Onslaught",type="FLAG",value=true}},nil}
 c["Orb Skills have +1 to Limit"]={nil,"Orb Skills have +1 to Limit "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -7020,13 +7020,15 @@ local jewelOtherFuncs = {
 		return function(node, out, data)
 			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small")) then
 				local modList, line = parseMod(mod)
-				if not line and modList[1] then -- something failed to parse, do not add to list
-					modList[1].parsedLine = capitalizeWordsInString(mod)
-					modList[1].source = data.modSource
-					if type(modList[1].value) == "table" and modList[1].value.mod then
-						modList[1].value.mod.source = data.modSource
+				if not line and modList[1] then
+					for _, modListMod in ipairs(modList) do
+						modListMod.parsedLine = capitalizeWordsInString(mod)
+						modListMod.source = data.modSource
+						if type(modListMod.value) == "table" and modListMod.value.mod then
+							modListMod.value.mod.source = data.modSource
+						end
+						out:AddMod(modListMod)
 					end
-					out:AddMod(modList[1])
 				end
 			end
 		end
@@ -7035,13 +7037,15 @@ local jewelOtherFuncs = {
 		return function(node, out, data)
 			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small") or (node.type == "Normal" and node.isAttribute and firstToUpper(passiveType) == "Attribute")) then
 				local modList, line = parseMod(mod)
-				if not line and modList[1] then -- something failed to parse, do not add to list
-					modList[1].parsedLine = capitalizeWordsInString(mod)
-					modList[1].source = data.modSource
-					if type(modList[1].value) == "table" and modList[1].value.mod then
-						modList[1].value.mod.source = data.modSource
+				if not line and modList[1] then
+					for _, modListMod in ipairs(modList) do
+						modListMod.parsedLine = capitalizeWordsInString(mod)
+						modListMod.source = data.modSource
+						if type(modListMod.value) == "table" and modListMod.value.mod then
+							modListMod.value.mod.source = data.modSource
+						end
+						out:AddMod(modListMod)
 					end
-					out:AddMod(modList[1])
 				end
 			end
 		end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -7019,8 +7019,9 @@ local jewelOtherFuncs = {
 	["^(%w+) Passive Skills in Radius also grant (.*)$"] = function(passiveType, mod)
 		return function(node, out, data)
 			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small")) then
-				local modList, line = parseMod(mod)
-				if not line and modList[1] then
+				local modList, extra = parseMod(mod)
+				-- avoid adding mods if mod line wasn't parsed correctly
+				if not extra and modList[1] then
 					for _, modListMod in ipairs(modList) do
 						modListMod.parsedLine = capitalizeWordsInString(mod)
 						modListMod.source = data.modSource
@@ -7036,8 +7037,9 @@ local jewelOtherFuncs = {
 	["conquered (%w+) Passive Skills also grant (.*)$"] = function(passiveType, mod)
 		return function(node, out, data)
 			if node and (node.type == firstToUpper(passiveType) or (node.type == "Normal" and not node.isAttribute and firstToUpper(passiveType) == "Small") or (node.type == "Normal" and node.isAttribute and firstToUpper(passiveType) == "Attribute")) then
-				local modList, line = parseMod(mod)
-				if not line and modList[1] then
+				local modList, extra = parseMod(mod)
+				-- avoid adding mods if mod line wasn't parsed correctly
+				if not extra and modList[1] then
 					for _, modListMod in ipairs(modList) do
 						modListMod.parsedLine = capitalizeWordsInString(mod)
 						modListMod.source = data.modSource


### PR DESCRIPTION
Fixes #2260.

### Description of the problem being solved:

It seems that radius jewels were only adding the first mod for each line. This meant that a mod such as ailment speed, which has one mod for each ailment type, only had the first mod applied. This fix is also applied for conquered radius jewels as they used the exactly same code

### Steps taken to verify a working solution:
- Ailment jewel tested
- "Regular" time-lost jewels tested

### Link to a build that showcases this PR:
See #2260 
### Before screenshot:

### After screenshot:
<img width="1039" height="606" alt="image" src="https://github.com/user-attachments/assets/4217959d-5ec5-45a9-a479-1fe733bd7e5b" />
