### PR TITLE
Fix Spirit per Level rune not working

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1472,6 +1472,7 @@ local modTagList = {
 	["per level"] = { tag = { type = "Multiplier", var = "Level" } },
 	["per player level"] = { tag = { type = "Multiplier", var = "Level" } },
 	["per (%d+) player levels"] = function(num) return { tag = { type = "Multiplier", var = "Level", div = num } } end,
+	["per (%d+) levels"] = function(num) return { tag = { type = "Multiplier", var = "Level", div = num } } end,
 	["per defiance"] = { tag = { type = "Multiplier", var = "Defiance" } },
 	["per (%d+)%% (%a+) effect on enemy"] = function(num, _, effectName) return { tag = { type = "Multiplier", var = firstToUpper(effectName) .. "Effect", div = num, actor = "enemy" } } end,
 	["per socketed rune or soul core"] = { tag = { type = "Multiplier", var = "RunesSocketedIn{SlotName}" } },


### PR DESCRIPTION
### Description of the problem being solved:
Fixes parsing for the `-1 to Spirit per 2 Levels` rune mod on Body Armours

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/mrb5eb0w
### Before screenshot:
<img width="488" height="157" alt="image" src="https://github.com/user-attachments/assets/6a786f14-5cb5-4acd-a200-f5ecc34e5c7c" />

### After screenshot:
<img width="571" height="153" alt="image" src="https://github.com/user-attachments/assets/89ae5de3-e0d8-4f03-b539-2deea093810c" />
