### PR TITLE
Remove old barkskin stacking behaviour

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -247,11 +247,6 @@ local configSettings = {
 	{ var = "bannerValour", type = "count", label = "Banner Valour:", tooltip = "The amount of valour consumed for the placed banner", ifSkill = { "Dread Banner", "War Banner", "Defiance Banner" }, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:ValourStacks", "BASE", val, "Config", { type = "IgnoreCond" }, { type = "Condition", var = "Combat" })
 	end },
-	{ label = "Barkskin:", ifSkill = "Barkskin" },
-	{ var = "barkskinStacks", type = "count", label = "# of Barkskin Stacks:", ifSkill = "Barkskin", apply = function(val, modList, enemyModList)
-		modList:NewMod("Multiplier:BarkskinStacks", "BASE",  m_min(val, 10), "Config")
-		modList:NewMod("Multiplier:MissingBarkskinStacks", "BASE", m_max(-val, -10), "Config")
-	end },
 	{ label = "Unbound Avatar:", ifSkill = "Unbound Avatar" },
 	{ var = "Unbound", type = "check", label = "Are you Unbound?", ifSkill = "Unbound Avatar", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Unbound", "FLAG", true, "Config")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1562,8 +1562,6 @@ local modTagList = {
 	["per animated weapon"] = { tag = { type = "Multiplier", var = "AnimatedWeapon", actor = "parent" } },
 	["per grasping vine"] = { tag =  { type = "Multiplier", var = "GraspingVinesCount" } },
 	["per fragile regrowth"] = { tag =  { type = "Multiplier", var = "FragileRegrowthCount" } },
-	["per bark"] = { tag =  { type = "Multiplier", var = "BarkskinStacks" } },
-	["per bark below maximum"] = { tag =  { type = "Multiplier", var = "MissingBarkskinStacks" } },
 	["per allocated mastery passive skill"] = { tag = { type = "Multiplier", var = "AllocatedMastery" } },
 	["per allocated notable passive skill"] = { tag = { type = "Multiplier", var = "AllocatedNotable" } },
 	["for each connected notable passive skill allocated"] = { tag = { type = "Multiplier", var = "AllocatedConnectedNotable" } },
@@ -3298,7 +3296,7 @@ local specialModList = {
 	},
 	-- Mutable Star // assumed 150% limit because overflow, could not verify in wiki
 	["defend against hits as though you had (%d+)%% more armour per (%d+)%% current energy shield"] =  function(armour, _, perCurrentES) return {
-		mod("ArmourDefense", "MAX", armour, { type = "Multiplier", var = "CurrentEnergyShield", div = perCurrentES, limit = 150 }, { type = "Condition", var = "UseCurrentEnergyShield"}),
+		mod("ArmourDefense", "MAX", armour, { typebarkskin = "Multiplier", var = "CurrentEnergyShield", div = perCurrentES, limit = 150 }, { type = "Condition", var = "UseCurrentEnergyShield"}),
 	} end,
 	-- Warrior - Titan
 	["(%d+)%% increased effect of small passive skills"] = function(num) return { mod("SmallPassiveSkillEffect", "INC", num) } end,
@@ -3326,9 +3324,6 @@ local specialModList = {
 		mod("DamageTakenOverTime", "MORE", -num * tonumber(duration) / 10, { type = "Condition", var = "HeartstopperAVERAGE" })
 	} end,
 	-- Warden
-	["prevent %+(%d+)%% of suppressed spell damage per bark below maximum"] = function(num) return {
-	    mod("SpellSuppressionEffect", "BASE", num, { type = "Multiplier", var = "MissingBarkskinStacks" })
-	} end,
 	["hits that would ignite instead scorch"] = { flag("IgniteCanScorch"), flag("CannotIgnite") },
 	["you can inflict an additional scorch on each enemy"] = { flag("ScorchCanStack"), mod("ScorchStacksMax", "BASE", 1) },
 	["maximum effect of shock is (%d+)%% increased damage taken"] = function (num) return { mod("ShockMax", "OVERRIDE", num) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3296,7 +3296,7 @@ local specialModList = {
 	},
 	-- Mutable Star // assumed 150% limit because overflow, could not verify in wiki
 	["defend against hits as though you had (%d+)%% more armour per (%d+)%% current energy shield"] =  function(armour, _, perCurrentES) return {
-		mod("ArmourDefense", "MAX", armour, { typebarkskin = "Multiplier", var = "CurrentEnergyShield", div = perCurrentES, limit = 150 }, { type = "Condition", var = "UseCurrentEnergyShield"}),
+		mod("ArmourDefense", "MAX", armour, { type = "Multiplier", var = "CurrentEnergyShield", div = perCurrentES, limit = 150 }, { type = "Condition", var = "UseCurrentEnergyShield"}),
 	} end,
 	-- Warrior - Titan
 	["(%d+)%% increased effect of small passive skills"] = function(num) return { mod("SmallPassiveSkillEffect", "INC", num) } end,


### PR DESCRIPTION
Fixes #2270 .

### Description of the problem being solved:

Barkskin still has the old poe1 behaviour. This PR removes some vestiges of it. Note that this PR does NOT implement the correct behaviour (which should be a separate input for the amount of energy shield lost and converted to armour).

### Steps taken to verify a working solution:
- Equip Barkskin
- Go to the configurations tab
- Verify that you don't see this: 
<img width="282" height="51" alt="image" src="https://github.com/user-attachments/assets/89e9d228-d5a8-4def-8427-70de40706fc3" />

