### PR TITLE
Added missing emotions from new league

### DIFF
--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -12,7 +12,7 @@ local m_floor = math.floor
 local m_huge = math.huge
 local s_format = string.format
 
-local emotionList = {"Ire", "Guilt", "Greed", "Paranoia", "Envy", "Disgust", "Despair", "Fear", "Suffering", "Isolation" }
+local emotionList = {"Ire", "Guilt", "Greed", "Paranoia", "Envy", "Disgust", "Despair", "Fear", "Suffering", "Isolation", "Contempt", "Ferocity",  "Melancholy"}
 
 ---@param node table
 ---@return boolean
@@ -22,7 +22,7 @@ end
 
 ---@class NotableDBControl : ListControl
 local NotableDBClass = newClass("NotableDBControl", "ListControl", function(self, anchor, rect, itemsTab, db, dbType)
-	local headerHeight = 68
+	local headerHeight = 96
 	local innerRect = {rect[1], rect[2]+headerHeight, rect[3], rect[4]-headerHeight}
 	self.ListControl(anchor, innerRect, 16, "VERTICAL", false)
 	self.itemsTab = itemsTab
@@ -77,7 +77,14 @@ local NotableDBClass = newClass("NotableDBControl", "ListControl", function(self
 
 	local emotionCheckBoxes = {}
 	for i,emo in ipairs(emotionList) do
-		local emoCtl = emoCheck(emo, emotionCheckBoxes[i-1] or self.controls.emotionLabel)
+		local emoCtl
+		if i == 11 then
+			local ctl = new("CheckBoxControl", {"TOPLEFT", emotionCheckBoxes[1], "BOTTOMLEFT"}, {0, 2, 26, 26}, "", emoCheckOnChange(emo), "Distilled "..emo, true)
+			if self.emotionImages then ctl:SetCheckImage(self.emotionImages[emo]) end
+			emoCtl = ctl
+		else
+			emoCtl = emoCheck(emo, emotionCheckBoxes[i-1] or self.controls.emotionLabel)
+		end
 		emotionCheckBoxes[i] = emoCtl
 		self.controls["emotionCheckbox"..emo] = emoCtl
 	end


### PR DESCRIPTION
Fixes #2265 .

### Description of the problem being solved:
`0.5` added three new emotions which were missing from the anoint list.

### Steps taken to verify a working solution:
- The missing emotions from `0.5` now show up properly in the annoint gui
- Annoint has a second row for the three emotions

### Link to a build that showcases this PR:

### Before screenshot:
<img width="413" height="482" alt="610899175-fff185b0-5a33-4e38-a904-c82b4b17c79c" src="https://github.com/user-attachments/assets/ecf11095-1aa2-459a-8359-23dcab1e8f08" />


### After screenshot:
<img width="501" height="582" alt="2026-06-23_08-10" src="https://github.com/user-attachments/assets/026b02d1-725b-48b0-ba95-0bef091947fc" />
