### PR TITLE
Fix manifest script SHA HASH when files have different line endings

### DIFF
--- a/update_manifest.py
+++ b/update_manifest.py
@@ -102,6 +102,9 @@ def create_manifest(version: str | None = None, replace: bool = False) -> None:
             if exclude_dirs and _exclude_directory(exclude_dirs, path):
                 continue
             data = path.read_bytes()
+            # Normalize line endings for non-binary files in case they were accidentally mixed
+            if b"\0" not in data:
+                data = re.sub(rb"\r\n?|\n", b"\r\n", data)
             sha1 = hashlib.sha1(data).hexdigest()
             name = path.relative_to(config[section]["path"]).as_posix()
             attributes = (


### PR DESCRIPTION
### Description of the problem being solved:
Sometimes when someone is editing a file on their system, the line endings get mixed or change to a different system. PoB expects them to use CRLF so if you hash a file based on different line endings then it can result in the wrong hash and PoB will not download it
We now use a regex to normalise all the lines before hashing so that we always get a CRLF hash