### PR TITLE
Fix crash on hovering over legacy shared items

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -33,6 +33,20 @@ describe("TetsItemMods", function()
 		assert.are.equals(2, legacyLines)
 	end)
 
+	it("shows a fallback tooltip when an item's base is no longer supported", function()
+		local item = new("Item", [[
+			Rarity: Unique
+			Legacy Item
+			Removed Base
+		]])
+		local tooltip = new("Tooltip")
+
+		assert.has_no.errors(function()
+			build.itemsTab:AddItemTooltip(tooltip, item)
+		end)
+		assert.is_truthy(tooltip.lines[#tooltip.lines].text:find("Item base is not supported", 1, true))
+	end)
+
 	it("aggregates matching ring item rarity lines before applying ring bonus effect", function()
 		build.configTab.input.customMods = "30% increased bonuses gained from left Equipped Ring"
 		build.configTab:BuildModList()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3232,6 +3232,13 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 	tooltip.tooltipHeader = item.rarity
 	tooltip.center = true
 	tooltip.color = rarityCode
+	-- Shared items can use old base names that no longer exist. Add a tooltip so they can be copied or removed without causing a crash.
+	if not item.base or not item.baseName then
+		tooltip:AddLine(fontSizeTitle, rarityCode..(item.title or item.name or "Unknown Item"), "FONTIN SC")
+		tooltip:AddSeparator(30)
+		tooltip:AddLine(fontSizeTitle, colorCodes.NEGATIVE.."Item base is not supported by the current version.", "FONTIN SC")
+		return
+	end
 	-- Item name
 	if item.title then
 		tooltip:AddLine(fontSizeTitle, rarityCode..item.title, "FONTIN SC")


### PR DESCRIPTION
Fixes #2262

### Description of the problem being solved:
Some base types have changed names between updates so the old item no longer works. We were not checking that the base still exists before trying to render the tooltip for them
Now adds specific popup just for these items so that it doesn't run the other tooltip code and cause a crash

### Before screenshot:
<img width="713" height="337" alt="image" src="https://github.com/user-attachments/assets/1338aa06-745d-4915-8897-62db77277942" />

### After screenshot:
<img width="650" height="115" alt="image" src="https://github.com/user-attachments/assets/1c0b6a7b-681e-4d69-ae01-199c7240a3fe" />
