### PR TITLE
Fix Undermine, Murderous Intent, Bloodlust and Lasting Ground missing the legacy tag

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -3221,6 +3221,7 @@ skills["SupportEmpoweredCullPlayer"] = {
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = 20, },
 	},
+	legacy = true,
 	statSets = {
 		[1] = {
 			label = "Murderous Intent",

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -7624,6 +7624,7 @@ skills["SupportUnderminePlayer"] = {
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
+	legacy = true,
 	statSets = {
 		[1] = {
 			label = "Undermine",

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -988,6 +988,7 @@ skills["SupportBloodlustPlayer"] = {
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
+	legacy = true,
 	statSets = {
 		[1] = {
 			label = "Bloodlust",
@@ -4882,6 +4883,7 @@ skills["SupportLastingGroundPlayer"] = {
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
+	legacy = true,
 	statSets = {
 		[1] = {
 			label = "Support",

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -710,6 +710,7 @@ statMap = {
 #skillEnd
 
 #skill SupportEmpoweredCullPlayer
+legacy = true
 #set SupportEmpoweredCullPlayer
 statMap = {
 	["support_empowered_culling_strike"] = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -1720,6 +1720,7 @@ statMap = {
 #skillEnd
 
 #skill SupportUnderminePlayer
+legacy = true
 #set SupportUnderminePlayer
 #mods
 #skillEnd

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -272,6 +272,7 @@ statMap = {
 #skillEnd
 
 #skill SupportBloodlustPlayer
+legacy = true
 #set SupportBloodlustPlayer
 statMap = {
 	["support_bloodlust_melee_physical_damage_+%_final_vs_bleeding_enemies"] = {
@@ -1124,6 +1125,7 @@ statMap = {
 #skillEnd
 
 #skill SupportLastingGroundPlayer
+legacy = true
 #set SupportLastingGroundPlayer
 #mods
 #skillEnd


### PR DESCRIPTION
Fixes #2253

### Description of the problem being solved:
These gems are drop-disabled and meant to have the legacy tag on them

### Before screenshot:
<img width="824" height="263" alt="image" src="https://github.com/user-attachments/assets/6c822e63-d985-4a86-8ff3-356804ec70be" />

### After screenshot:
<img width="822" height="297" alt="image" src="https://github.com/user-attachments/assets/17a1b5ec-8954-4c9b-be8d-24ce363254f9" />
