### PR TITLE
Fix Melee mods not affecting the damage of Combust

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -18070,6 +18070,7 @@ skills["TemperWeaponCombustionPlayer"] = {
 			baseFlags = {
 				attack = true,
 				area = true,
+				melee = true,
 			},
 			constantStats = {
 				{ "imbue_weapon_combust_trigger_chance_%", 100 },

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -1250,7 +1250,7 @@ statMap = {
 #from tree
 #skill TemperWeaponCombustionPlayer
 #set TemperWeaponCombustionPlayer
-#flags attack area
+#flags attack area melee
 #mods
 #skillEnd
 


### PR DESCRIPTION
Fixes #2235

### Description of the problem being solved:
Combust was missing the melee skill flag to be able to scale with melee damage mods

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/6rd7cy0w

### Before screenshot:
<img width="834" height="266" alt="image" src="https://github.com/user-attachments/assets/0a0cae8a-8e68-4633-88c9-d1b91548aade" />

### After screenshot:
<img width="835" height="464" alt="image" src="https://github.com/user-attachments/assets/d91f38ae-65a2-4abc-be9b-cb58deab9e8c" />
