### PR TITLE
Fix crash when importing some Djinn builds

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -2040,7 +2040,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 					controls.mainSkillMinion.enabled = #controls.mainSkillMinion.list > 1
 					controls.mainSkillMinion.shown = true
 					wipeTable(controls.mainSkillMinionSkill.list)
-					if activeSkill.minion then
+					if activeSkill.minion and activeSkill.minion.activeSkillList then
 						for _, minionSkill in ipairs(activeSkill.minion.activeSkillList) do
 							t_insert(controls.mainSkillMinionSkill.list, minionSkill.activeEffect.grantedEffect.name)
 						end


### PR DESCRIPTION
Fixes #2217

### Description of the problem being solved:
The skill Kelari's Deception assumed that we had a skill for it but it is a part of the minion as GGG handle the minion in a weird way
We now make sure that the activeSkillList exists before looping through it

### Link to a build that showcases this PR:
https://poe.ninja/poe2/profile/Kosmo2409-4451/runesofaldur/character/KozzieCull

### Before screenshot:
<img width="728" height="281" alt="image" src="https://github.com/user-attachments/assets/bbd38ade-8f99-487d-8427-b28697820f2d" />

### After screenshot:
<img width="445" height="87" alt="image" src="https://github.com/user-attachments/assets/ba380c85-4487-4229-80c2-d60fb7617ed1" />
