### PR TITLE
Fix Curse rounding on enemies

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -94,6 +94,17 @@ describe("TestSkills", function()
 		assert.True(build.calcsTab.mainOutput.SpiritReservedPercent > oneCurseReservation)
 	end)
 
+	it("rounds Blasphemy curse magnitudes to the nearest integer", function()
+		build.configTab.input.customMods = "79% increased Curse Magnitudes"
+		build.configTab.input.enemyIsBoss = "None"
+		build.configTab:BuildModList()
+		build.skillsTab:PasteSocketGroup("Blasphemy 10/0  1\nDespair 12/0  1\n")
+
+		runCallback("OnFrame")
+
+		assert.are.equals(-42, build.calcsTab.mainEnv.enemyDB:Sum("BASE", nil, "ChaosResist"))
+	end)
+
 	it("applies active skill reservation multiplier to linked buff spirit reservation", function()
 		build.skillsTab:PasteSocketGroup("Purity of Fire 20/0  1\nVitality II 1/0  1\n")
 		runCallback("OnFrame")

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -42,7 +42,8 @@ local function getActor(self, actorType)
 	end
 end
 
-function ModStoreClass:ScaleAddMod(mod, scale)
+-- roundToNearest is reserved for effects that the game rounds instead of truncates.
+function ModStoreClass:ScaleAddMod(mod, scale, roundToNearest)
 	local unscalable = false
 	for _, effects in ipairs(mod) do
 		if effects.unscalable then
@@ -71,6 +72,8 @@ function ModStoreClass:ScaleAddMod(mod, scale)
 			if precision then
 				local power = 10 ^ precision
 				subMod.value = m_floor(subMod.value * scale * power) / power
+			elseif roundToNearest then
+				subMod.value = roundSymmetric(subMod.value * scale)
 			else
 				subMod.value = m_modf(round(subMod.value * scale, 2))
 			end
@@ -85,12 +88,12 @@ function ModStoreClass:CopyList(modList)
 	end
 end
 
-function ModStoreClass:ScaleAddList(modList, scale)
+function ModStoreClass:ScaleAddList(modList, scale, roundToNearest)
 	if scale == 1 then
 		self:AddList(modList)
 	else
 		for i = 1, #modList do
-			self:ScaleAddMod(modList[i], scale)
+			self:ScaleAddMod(modList[i], scale, roundToNearest)
 		end
 	end
 end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2414,23 +2414,23 @@ function calcs.perform(env, skipEHP)
 					end
 					if buff.type == "Curse" then
 						curse.modList = new("ModList")
-						curse.modList:ScaleAddList(buff.modList, mult)
+						curse.modList:ScaleAddList(buff.modList, mult, true)
 						if partyTabEnableExportBuffs then
 							buffExports["Curse"][buff.name] = { isMark = curse.isMark, effectMult = curse.isMark and mult or (1 + inc / 100) * moreMark, modList = buff.modList }
 						end
 					else
 						-- Curse applies a buff; scale by curse effect, then buff effect
 						local temp = new("ModList")
-						temp:ScaleAddList(buff.modList, mult)
+						temp:ScaleAddList(buff.modList, mult, true)
 						curse.buffModList = new("ModList")
 						local buffInc = modDB:Sum("INC", skillCfg, "BuffEffectOnSelf")
 						local buffMore = modDB:More(skillCfg, "BuffEffectOnSelf")
-						curse.buffModList:ScaleAddList(temp, (1 + buffInc / 100) * buffMore)
+						curse.buffModList:ScaleAddList(temp, (1 + buffInc / 100) * buffMore, true)
 						if env.minion then
 							curse.minionBuffModList = new("ModList")
 							local buffInc = env.minion.modDB:Sum("INC", nil, "BuffEffectOnSelf")
 							local buffMore = env.minion.modDB:More(nil, "BuffEffectOnSelf")
-							curse.minionBuffModList:ScaleAddList(temp, (1 + buffInc / 100) * buffMore)
+							curse.minionBuffModList:ScaleAddList(temp, (1 + buffInc / 100) * buffMore, true)
 						end
 					end
 					t_insert(curses, curse)
@@ -2894,7 +2894,7 @@ function calcs.perform(env, skipEHP)
 						local cfg = { skillName = grantedEffect.name }
 						local inc = modDB:Sum("INC", cfg, "CurseEffectOnSelf") + gemModList:Sum("INC", nil, "CurseEffectAgainstPlayer")
 						local more = modDB:More(cfg, "CurseEffectOnSelf") * gemModList:More(nil, "CurseEffectAgainstPlayer")
-						modDB:ScaleAddList(curseModList, m_max((1 + inc / 100) * more, 0))
+						modDB:ScaleAddList(curseModList, m_max((1 + inc / 100) * more, 0), true)
 					end
 				elseif not enemyDB:Flag(nil, "Hexproof") or modDB:Flag(nil, "CursesIgnoreHexproof") then
 					local curse = {
@@ -2903,7 +2903,7 @@ function calcs.perform(env, skipEHP)
 						priority = determineCursePriority(grantedEffect.name),
 					}
 					curse.modList = new("ModList")
-					curse.modList:ScaleAddList(curseModList, (1 + enemyDB:Sum("INC", nil, "CurseEffectOnSelf") / 100) * enemyDB:More(nil, "CurseEffectOnSelf"))
+					curse.modList:ScaleAddList(curseModList, (1 + enemyDB:Sum("INC", nil, "CurseEffectOnSelf") / 100) * enemyDB:More(nil, "CurseEffectOnSelf"), true)
 					t_insert(dest, curse)
 				end
 			end
@@ -2928,7 +2928,7 @@ function calcs.perform(env, skipEHP)
 		else
 			mult = mult * enemyDB:More(nil, "CurseEffectOnSelf")
 		end
-		newCurse.modList:ScaleAddList(curse.modList, mult)
+		newCurse.modList:ScaleAddList(curse.modList, mult, true)
 		t_insert(allyCurses, newCurse)
 	end
 


### PR DESCRIPTION
Fixes #2225

### Description of the problem being solved:
It appears that curses round to the nearest value instead of rounding down like other mods

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/6e3lop0h
### Before screenshot:
<img width="403" height="132" alt="image" src="https://github.com/user-attachments/assets/10495d59-3add-4f9e-b35d-8d29adf988de" />

### After screenshot:
<img width="403" height="128" alt="image" src="https://github.com/user-attachments/assets/c6ff81b2-426d-43d4-b671-226bfca5de9f" />
