### PR TITLE
Fix gem group counting logic

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -539,6 +539,8 @@ describe("TestSkills", function()
 
 		local skillsTab = {
 			socketGroupList = {
+				{ enabled = false, gemList = { fakeGem("Disabled Skill") } },
+				{ enabled = true, gemList = { fakeGem("Disabled Gem", nil, { enabled = false }) } },
 				{ enabled = true, gemList = { fakeGem("Item Skill", { fromItem = true }) } },
 				{ enabled = true, gemList = { fakeGem("Tree Skill", { fromTree = true }) } },
 				{ enabled = true, gemList = { fakeGem("Stored Item Skill", nil, { fromItem = true }) } },

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1570,6 +1570,6 @@ function SkillsTabClass:UpdateGlobalGemCountAssignments()
 			end
 		end
 	end
-	GlobalGemAssignments["GemGroupCount"] = self:CountGemGroups()
+	GlobalGemAssignments["GemGroupCount"] = SkillsTabClass.CountGemGroups(self)
 end
 

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1517,19 +1517,37 @@ function SkillsTabClass:SetActiveSkillSet(skillSetId, deferSync)
 	end
 end
 
+-- Count the number of gem groups that have at least one enabled non-provided gem
+function SkillsTabClass:CountGemGroups()
+	local gemGroupCount = 0
+	for _, socketGroup in ipairs(self.socketGroupList) do
+		if socketGroup.enabled then
+			local hasEnabledNonProvidedGem = false
+			for _, gem in ipairs(socketGroup.gemList) do
+				if gem.enabled then
+					local grantedEffect = gem and (gem.grantedEffect or gem.gemData and gem.gemData.grantedEffect)
+					local provided = ((gem and (gem.fromItem or gem.fromTree)
+						or (grantedEffect and (grantedEffect.fromItem or grantedEffect.fromTree))))
+					if not provided then
+						hasEnabledNonProvidedGem = true
+						break
+					end
+				end
+			end
+			if hasEnabledNonProvidedGem then
+				gemGroupCount = gemGroupCount + 1
+			end
+		end
+	end
+	return gemGroupCount
+end
+
 -- Loop over all socket groups and gem instances
 -- to updated global gem count assignments
 function SkillsTabClass:UpdateGlobalGemCountAssignments()
 	wipeTable(GlobalGemAssignments)
-	local countSocketGroups = 0
 	for _, socketGroup in ipairs(self.socketGroupList) do
-		local countGroup = true
 		if socketGroup.enabled then
-			local activeGem = socketGroup.gemList[1]
-			local activeGrantedEffect = activeGem and (activeGem.grantedEffect or activeGem.gemData and activeGem.gemData.grantedEffect)
-			if activeGem and (activeGem.fromItem or activeGem.fromTree or activeGrantedEffect and (activeGrantedEffect.fromItem or activeGrantedEffect.fromTree)) then
-				countGroup = false
-			end
 			for _, gemInstance in ipairs(socketGroup.gemList) do
 				if gemInstance.gemData and gemInstance.enabled then
 					if GlobalGemAssignments[gemInstance.gemData.name] then
@@ -1551,10 +1569,7 @@ function SkillsTabClass:UpdateGlobalGemCountAssignments()
 				end
 			end
 		end
-		if countGroup then
-			countSocketGroups = countSocketGroups + 1
-		end
 	end
-	GlobalGemAssignments["GemGroupCount"] = countSocketGroups
+	GlobalGemAssignments["GemGroupCount"] = self:CountGemGroups()
 end
 

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1517,38 +1517,21 @@ function SkillsTabClass:SetActiveSkillSet(skillSetId, deferSync)
 	end
 end
 
--- Count the number of gem groups that have at least one enabled non-provided gem
-function SkillsTabClass:CountGemGroups()
-	local gemGroupCount = 0
-	for _, socketGroup in ipairs(self.socketGroupList) do
-		if socketGroup.enabled then
-			local hasEnabledNonProvidedGem = false
-			for _, gem in ipairs(socketGroup.gemList) do
-				if gem.enabled then
-					local grantedEffect = gem and (gem.grantedEffect or gem.gemData and gem.gemData.grantedEffect)
-					local provided = ((gem and (gem.fromItem or gem.fromTree)
-						or (grantedEffect and (grantedEffect.fromItem or grantedEffect.fromTree))))
-					if not provided then
-						hasEnabledNonProvidedGem = true
-						break
-					end
-				end
-			end
-			if hasEnabledNonProvidedGem then
-				gemGroupCount = gemGroupCount + 1
-			end
-		end
-	end
-	return gemGroupCount
-end
-
 -- Loop over all socket groups and gem instances
 -- to updated global gem count assignments
 function SkillsTabClass:UpdateGlobalGemCountAssignments()
 	wipeTable(GlobalGemAssignments)
+	local countSocketGroups = 0
 	for _, socketGroup in ipairs(self.socketGroupList) do
+		local countGroup = false
 		if socketGroup.enabled then
 			for _, gemInstance in ipairs(socketGroup.gemList) do
+				if gemInstance.enabled and not countGroup then
+					local grantedEffect = gemInstance.grantedEffect or gemInstance.gemData and gemInstance.gemData.grantedEffect
+					local provided = gemInstance.fromItem or gemInstance.fromTree or
+						grantedEffect and (grantedEffect.fromItem or grantedEffect.fromTree)
+					countGroup = not provided
+				end
 				if gemInstance.gemData and gemInstance.enabled then
 					if GlobalGemAssignments[gemInstance.gemData.name] then
 						GlobalGemAssignments[gemInstance.gemData.name].count = GlobalGemAssignments[gemInstance.gemData.name].count + 1
@@ -1569,7 +1552,10 @@ function SkillsTabClass:UpdateGlobalGemCountAssignments()
 				end
 			end
 		end
+		if countGroup then
+			countSocketGroups = countSocketGroups + 1
+		end
 	end
-	GlobalGemAssignments["GemGroupCount"] = SkillsTabClass.CountGemGroups(self)
+	GlobalGemAssignments["GemGroupCount"] = countSocketGroups
 end
 


### PR DESCRIPTION
### Description of the problem being solved:

Before, when you had a granted skill from an item / tree, and disabled that socket group, it would be counted towards the limit of 9.

### Steps taken to verify a working solution:

- equip 9 `Arc` gems, each in its own group
- equip `Sadist's Mercy Flanged Mace`
- disable the granted `Harbinger of Madness`
- verify that there is no warning message for going over the limit of 9
- add another socket group with `Arc` and `Ice Nova` (in the same group)
- verify that there's a warning for the limit iff the socket group is enabled and at least one of `Arc` and `Ice Nova` is enabled
