### PR TITLE
Fix Ritualist Mystic Attunement node not scaling gem level mods

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1415,7 +1415,7 @@ function calcs.perform(env, skipEHP)
 
 	for slot, item in pairs(env.player.itemList) do
 		local slotEffectMod = modDB:Sum("INC", nil, "EffectOfBonusesFrom" .. slot) / 100
-		if slotEffectMod > 0 then
+		if slotEffectMod > 0 and slot ~= "Amulet" then
 			if item.name:match("Kalandra's Touch") then
 				if slot == "Ring 2" then
 					item = env.player.itemList["Ring 1"]

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1373,8 +1373,18 @@ function calcs.initEnv(build, mode, override, specEnv)
 		local modList = env.player.itemList["Weapon 2"].modList
 		for _, mod in ipairs(modList) do
 			local modCopy = copyTable(mod)
-			modCopy.source = "Many Sources:" .. tostring(quiverEffectMod * 100) .. "% Quiver Bonus Effect"
+			modCopy.source = "Many Sources:".. colorCodes.SOURCE .. tostring(quiverEffectMod * 100) .. "% Quiver Bonus Effect"
 			modDB:ScaleAddMod(modCopy, quiverEffectMod)
+		end
+	end
+	
+	if env.player.itemList["Amulet"] and env.player.itemList["Amulet"].type == "Amulet" then
+		local amuletEffectMod = env.modDB:Sum("INC", nil, "EffectOfBonusesFromAmulet") / 100
+		local modList = env.player.itemList["Amulet"].modList
+		for _, mod in ipairs(modList) do
+			local modCopy = copyTable(mod)
+			modCopy.source = "Many Sources:".. colorCodes.SOURCE .. tostring(amuletEffectMod * 100) .. "% Amulet Bonus Effect"
+			modDB:ScaleAddMod(modCopy, amuletEffectMod)
 		end
 	end
 


### PR DESCRIPTION
Fixes #2287

### Description of the problem being solved:
The ascendancy node wasn't scaling gem levels as it wasn't being handled in CalcSetup before gems were initialised

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/hebqsu0h

### Before screenshot:
<img width="525" height="159" alt="image" src="https://github.com/user-attachments/assets/4d62e9bc-cfd5-4884-b107-f7381f4b193f" />

### After screenshot:
<img width="567" height="172" alt="image" src="https://github.com/user-attachments/assets/b1bfb816-c890-4d73-a099-3344814b0af7" />
