### PR TITLE
Fix jewels socketed in gloves not importing correctly

### DIFF
--- a/spec/System/TestImportReimport_spec.lua
+++ b/spec/System/TestImportReimport_spec.lua
@@ -187,6 +187,39 @@ Fireball 20/0  1
 		assert.is_false(groupsByGem.Fireball.enabled)
 	end)
 
+	it("imports item socketed jewels using jewel socket order instead of raw socket index", function()
+		build.importTab.controls.charImportItemsClearItems.state = true
+		build.importTab.controls.charImportItemsClearSkills.state = true
+
+		local gloves = makeImportItem("Linen Wraps", "Gloves", "test-import-gloves")
+		gloves.sockets = {
+			{ type = "rune" },
+			{ type = "jewel" },
+		}
+		gloves.socketedItems = {
+			{ baseType = "Greater Rune of Nobility" },
+			{
+				id = "test-import-jewel",
+				frameType = 2,
+				name = "Vivid Ornament",
+				typeLine = "Sapphire",
+				baseType = "Sapphire",
+				inventoryId = "PassiveJewels",
+				ilvl = DEFAULT_ITEM_LEVEL,
+				properties = {},
+				socket = 1,
+			},
+		}
+
+		build.importTab:ImportItemsAndSkills(buildImportPayload({ gloves }, {}))
+		runCallback("OnFrame")
+
+		local socketedJewel = build.itemsTab.items[build.itemsTab.slots["Gloves Jewel Socket 1"].selItemId]
+		assert.is_not_nil(socketedJewel)
+		assert.are.equal("test-import-jewel", socketedJewel.uniqueID)
+		assert.are.equal(0, build.itemsTab.slots["Gloves Jewel Socket 2"].selItemId)
+	end)
+
 	it("preserves skill part selection when reimporting items and skills", function()
 		assertReimportPreservesSkillSubstate("Twig Focus", "Offhand", "Dark Effigy", "skillPart", 2)
 	end)

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1286,7 +1286,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 
 	item.runes = { }
 	if itemData.socketedItems then
-		self:ImportSocketedItems(item, itemData.socketedItems, slotName)
+		self:ImportSocketedItems(item, itemData.socketedItems, slotName, itemData.sockets)
 	end
 	if itemData.requirements and (not itemData.socketedItems or not itemData.socketedItems[1]) then
 		-- Requirements cannot be trusted if there are socketed gems, as they may override the item's natural requirements
@@ -1437,11 +1437,19 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	end
 end
 
-function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
+function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName, sockets)
 	-- Build socket group list
 	for _, socketedItem in ipairs(socketedItems) do
 		if isValueInTable({ "Diamond", "Emerald", "Ruby", "Sapphire" }, socketedItem.baseType) then
-			self:ImportItem(socketedItem, slotName .. " Jewel Socket "..socketedItem.socket + 1)
+			local jewelSocketIndex = socketedItem.socket + 1
+			if sockets then
+				for index = 1, socketedItem.socket + 1 do
+					if sockets[index] and sockets[index].type ~= "jewel" then
+						jewelSocketIndex = jewelSocketIndex - 1
+					end
+				end
+			end
+			self:ImportItem(socketedItem, slotName .. " Jewel Socket "..jewelSocketIndex)
 		else
 			t_insert(item.runes, socketedItem.baseType)
 		end


### PR DESCRIPTION
Fixes #2294

### Description of the problem being solved:
The Jewel is in the second socket of the item so the previous code would try to add the jewel to Gloves Jewel Socket 2 instead of socket 1
We now remove non-jewel types from the index list incase GGG adds other jewel + rune combos in the future

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldur/character/thdxps-2023/Alduten?i=0&search=items%3DSylvan%2527s%2BEffigy

### Before screenshot:
<img width="425" height="196" alt="image" src="https://github.com/user-attachments/assets/cdfc9760-2d84-45cf-b205-be09a0212810" />

### After screenshot:
<img width="855" height="340" alt="image" src="https://github.com/user-attachments/assets/906b64c7-6bf4-4247-a442-b392e028d3bd" />
