### PR TITLE
Fix JSON import order

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -328,8 +328,9 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		end
 
 		if self.importCodeJson then
-			self:ImportItemsAndSkills(self.importCodeJson)
 			self:ImportPassiveTreeAndJewels(self.importCodeJson)
+			self.build.calcsTab:BuildOutput()
+			self:ImportItemsAndSkills(self.importCodeJson)
 			return
 		end
 

--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -218,8 +218,9 @@ end
 function loadBuildFromJSON(getItemsJSON, getPassiveSkillsJSON)
 	mainObject.main:SetMode("BUILD", false, "")
 	runCallback("OnFrame")
+	build.importTab:ImportPassiveTreeAndJewels(getPassiveSkillsJSON)
+	build.calcsTab:BuildOutput()
 	local charData = build.importTab:ImportItemsAndSkills(getItemsJSON)
-	build.importTab:ImportPassiveTreeAndJewels(getPassiveSkillsJSON, charData)
 	-- You now have a build without a correct main skill selected, or any configuration options set
 	-- Good luck!
 end


### PR DESCRIPTION
### Description of the problem being solved:
The JSON import order was doing items before the passive tree so builds that used giants blood or the other nodes that change item equips would not work

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldur/character/thdxps-2023/Alduten?i=0&search=items%3DSylvan%2527s%2BEffigy

### Before screenshot:
<img width="405" height="53" alt="image" src="https://github.com/user-attachments/assets/64b9ba16-92cf-4fa2-b074-a3be0a5d97d2" />

### After screenshot:
<img width="414" height="63" alt="image" src="https://github.com/user-attachments/assets/cf4e1cff-b3ae-47e2-af7f-2c1c3da84846" />
