### PR TITLE
Add support for Effect of Socketed Augments mod

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -591,6 +591,28 @@ describe("TestItemParse", function()
 		assert.is_not_nil(item:BuildRaw():match("{enchant}{rune}Gain 18%% of Damage as Extra Fire Damage"))
 	end)
 
+	it("applies increased effect of socketed augment items", function()
+		local item = new("Item", [[
+			Test Wand
+			Runic Fork
+			Sockets: S
+			Rune: Lesser Desert Rune
+			Implicits: 1
+			{enchant}{rune}Gain 6% of Damage as Extra Fire Damage
+			100% increased effect of Socketed Augment Items
+		]])
+		item:BuildAndParseRaw()
+
+		local damageGainAsFire = 0
+		for _, mod in ipairs(item.slotModList[1]) do
+			if mod.name == "DamageGainAsFire" and mod.type == "BASE" then
+				damageGainAsFire = damageGainAsFire + mod.value
+			end
+		end
+		assert.are.equals(12, damageGainAsFire)
+		assert.is_not_nil(item:BuildRaw():match("{enchant}{rune}Gain 12%% of Damage as Extra Fire Damage"))
+	end)
+
 	it("does not double-scale imported socketed rune text", function()
 		local item = new("Item", [[
 			Runeseeker's Call

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1140,13 +1140,13 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				table.sort(runes,  function(a, b) return compareRuneValueSets(a.values, b.values) end)
 			end
 
-			local gameSocketedRuneEffectModifier = 0
+			local gameSocketedAugmentEffectModifier = 0
 			if mode == "GAME" and shouldFixRunesOnItem then
 				for _, modLines in ipairs({ self.enchantModLines, self.implicitModLines, self.explicitModLines }) do
 					for _, effectModLine in ipairs(modLines) do
 						for _, mod in ipairs(effectModLine.modList or { }) do
-							if mod.name == "SocketedRuneEffect" and mod.type == "INC" then
-								gameSocketedRuneEffectModifier = gameSocketedRuneEffectModifier + mod.value / 100
+							if (mod.name == "SocketedRuneEffect" or mod.name == "SocketedAugmentItemEffect") and mod.type == "INC" then
+								gameSocketedAugmentEffectModifier = gameSocketedAugmentEffectModifier + mod.value / 100
 							end
 						end
 					end
@@ -1160,10 +1160,10 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				if groupedRunes and not modLine.bonded then -- found the rune category with the relevant stat.
 					local result, numRunes
 					local socketedRuneEffectAlreadyApplied
-					if gameSocketedRuneEffectModifier ~= 0 then
+					if gameSocketedAugmentEffectModifier ~= 0 then
 						local unscaledTargetValues = { }
 						for valueIndex, value in ipairs(targetValues) do
-							unscaledTargetValues[valueIndex] = value / (1 + gameSocketedRuneEffectModifier)
+							unscaledTargetValues[valueIndex] = value / (1 + gameSocketedAugmentEffectModifier)
 						end
 						result, numRunes = findRuneCombination(groupedRunes, unscaledTargetValues, remainingRunes)
 						socketedRuneEffectAlreadyApplied = result ~= nil
@@ -1604,8 +1604,12 @@ end
 
 function ItemClass:ApplySocketedRuneDisplayScalars()
 	for _, modLine in ipairs(self.runeModLines or { }) do
-		local effectModifier = modLine.augmentType == "SoulCore" and (self.socketedSoulCoreEffectModifier or 0)
-			or modLine.augmentType == "Rune" and (self.socketedRuneEffectModifier or 0)
+		local effectModifier = self.socketedAugmentItemEffectModifier or 0
+		if modLine.augmentType == "SoulCore" then
+			effectModifier = effectModifier + (self.socketedSoulCoreEffectModifier or 0)
+		elseif modLine.augmentType == "Rune" then
+			effectModifier = effectModifier + (self.socketedRuneEffectModifier or 0)
+		end
 		if effectModifier and effectModifier ~= 0 and not modLine.socketedRuneEffectAlreadyApplied then
 			modLine.displayValueScalar = 1 + effectModifier
 		else
@@ -2105,12 +2109,17 @@ function ItemClass:BuildModList()
 	end
 	self.socketedSoulCoreEffectModifier = calcLocal(baseList, "SocketedSoulCoreEffect", "INC", 0) / 100
 	self.socketedRuneEffectModifier = calcLocal(baseList, "SocketedRuneEffect", "INC", 0) / 100
+	self.socketedAugmentItemEffectModifier = calcLocal(baseList, "SocketedAugmentItemEffect", "INC", 0) / 100
 	if self.runeModLines[1] then
 		self:ApplySocketedRuneDisplayScalars()
 	end
 	for _, modLine in ipairs(self.runeModLines) do
-		local effectModifier = modLine.augmentType == "SoulCore" and self.socketedSoulCoreEffectModifier
-			or modLine.augmentType == "Rune" and self.socketedRuneEffectModifier
+		local effectModifier = self.socketedAugmentItemEffectModifier or 0
+		if modLine.augmentType == "SoulCore" then
+			effectModifier = effectModifier + self.socketedSoulCoreEffectModifier
+		elseif modLine.augmentType == "Rune" then
+			effectModifier = effectModifier + self.socketedRuneEffectModifier
+		end
 		if effectModifier and effectModifier ~= 0 and self:CheckModLineVariant(modLine) and not modLine.extra and not modLine.socketedRuneEffectAlreadyApplied then
 			for _, mod in ipairs(modLine.modList) do
 				baseList:ScaleAddMod(mod, effectModifier)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -1386,8 +1386,8 @@ c["100% increased Thorns damage"]={{[1]={flags=32,keywordFlags=0,name="Damage",t
 c["100% increased Thorns damage if you've consumed an Endurance Charge Recently"]={{[1]={[1]={limit=1,type="Multiplier",var="RemovableEnduranceCharge"},flags=32,keywordFlags=0,name="Damage",type="INC",value=100}},nil}
 c["100% increased amount of Life Leeched"]={{[1]={flags=0,keywordFlags=0,name="MaxLifeLeechRate",type="INC",value=100}},nil}
 c["100% increased chance to Shock"]={{[1]={flags=0,keywordFlags=0,name="EnemyShockChance",type="INC",value=100}},nil}
-c["100% increased effect of Socketed Augment Items"]={{[1]={flags=0,keywordFlags=0,name="LocalEffect",type="INC",value=100}},"  of Socketed Augment Items "}
-c["100% increased effect of Socketed Augment Items This item gains bonuses from Socketed Items as though it was a Body Armour"]={{[1]={flags=0,keywordFlags=0,name="LocalEffect",type="INC",value=100}},"  of Socketed Augment Items This item gains bonuses from Socketed Items as though it was a Body Armour "}
+c["100% increased effect of Socketed Augment Items"]={{[1]={flags=0,keywordFlags=0,name="SocketedAugmentItemEffect",type="INC",value=100}},nil}
+c["100% increased effect of Socketed Augment Items This item gains bonuses from Socketed Items as though it was a Body Armour"]={{[1]={flags=0,keywordFlags=0,name="SocketedAugmentItemEffect",type="INC",value=100}}," This item gains bonuses from Socketed Items as though it was a Body Armour "}
 c["100% increased effect of Socketed Soul Cores"]={{[1]={flags=0,keywordFlags=0,name="SocketedSoulCoreEffect",type="INC",value=100}},nil}
 c["100% increased maximum Divinity"]={{}," maximum Divinity "}
 c["100% increased maximum Divinity 20% reduced maximum Divinity per Corrupted Item Equipped"]={{}," maximum Divinity 20% reduced maximum Divinity per Corrupted Item Equipped "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -897,6 +897,7 @@ local modNameList = {
 	["effect of socketed abyss jewels"] = "SocketedJewelEffect",
 	["effect of socketed soul cores"] = "SocketedSoulCoreEffect",
 	["effect of socketed runes"] = "SocketedRuneEffect",
+	["effect of socketed augment items"] = "SocketedAugmentItemEffect",
 	["to inflict fire exposure on hit"] = "FireExposureChance",
 	["to apply fire exposure on hit"] = "FireExposureChance",
 	["to inflict cold exposure on hit"] = "ColdExposureChance",


### PR DESCRIPTION
### Description of the problem being solved:
The mod is very similar to the other soul core and rune effect mods we already supported
This now supports the mod on gloves and also the mod on Darkness Enthroned

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/6pbrnq0h

### Before screenshot:
<img width="628" height="864" alt="image" src="https://github.com/user-attachments/assets/bf19acc9-f182-494c-89b8-dbb6990e774e" />

### After screenshot:
<img width="627" height="865" alt="image" src="https://github.com/user-attachments/assets/fca02bc2-a6c9-41c3-8d03-0a3798b17ec5" />
