### PR TITLE
Fix Legacy of Gold mods not increasing Item Rarity value

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -86,7 +86,7 @@ local legacies = {
 	},
 	LegacyOfGold = {
 		effects = {
-			{ stat = "ItemRarity", type = "INC", value = 45 },
+			{ stat = "LootRarity", type = "INC", value = 45 },
 		}
 	},
 	LegacyOfGranite = {


### PR DESCRIPTION
### Description of the problem being solved:
The mod was using the wrong mod name so it wasn't working


### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/6hekly0w

### Before screenshot:
<img width="235" height="41" alt="image" src="https://github.com/user-attachments/assets/4c10fb29-552a-4788-832a-e8980a2b7e64" />

### After screenshot:
<img width="336" height="37" alt="image" src="https://github.com/user-attachments/assets/ecc1ed87-ee5d-4aa1-a17d-3673c988eb11" />
