### PR TITLE
Fix Crit chance for Living Lightning and Caltrops

### DIFF
--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -6563,7 +6563,6 @@ skills["TBAbyssCarrionWingBeam"] = {
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
 				spell = true,
-				attack = true,
 				hit = true,
 				triggerable = true,
 			},
@@ -6721,7 +6720,6 @@ skills["TBVaalPyramidBeam"] = {
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
 				spell = true,
-				attack = true,
 				triggerable = true,
 			},
 			constantStats = {
@@ -7523,7 +7521,6 @@ skills["TBExcavatorSceptreErraticBeam"] = {
 			statDescriptionScope = "skill_stat_descriptions",
 			baseFlags = {
 				spell = true,
-				attack = true,
 				triggerable = true,
 				hit = true,
 			},

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -1004,7 +1004,7 @@ statMap = {
 
 #skill TBAbyssCarrionWingBeam Beam
 #set TBAbyssCarrionWingBeam
-#flags spell attack hit triggerable
+#flags spell hit triggerable
 #mods
 #skillEnd
 
@@ -1028,7 +1028,7 @@ statMap = {
 
 #skill TBVaalPyramidBeam Pyramid Beam
 #set TBVaalPyramidBeam
-#flags spell attack triggerable
+#flags spell triggerable
 #mods
 #skillEnd
 
@@ -1143,7 +1143,7 @@ statMap = {
 
 #skill TBExcavatorSceptreErraticBeam Beam
 #set TBExcavatorSceptreErraticBeam
-#flags spell attack triggerable hit
+#flags spell triggerable hit
 #mods
 #skillEnd
 

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2386,9 +2386,6 @@ function calcs.offence(env, actor, activeSkill)
 			-- Unarmed override for Concoction skills
 			if skillFlags.unarmed then
 				source = copyTable(data.unarmedWeaponData[env.classId])
-				if skillData.CritChance then
-					source.CritChance = skillData.CritChance
-				end
 			end
 			if source.FacebreakerItemDamage and activeSkill.activeEffect.grantedEffect.weaponTypes and activeSkill.activeEffect.grantedEffect.weaponTypes["One Hand Mace"] then
 				for _, damageType in ipairs(dmgTypeList) do
@@ -2398,6 +2395,9 @@ function calcs.offence(env, actor, activeSkill)
 			end
 			if critOverride and source.type and source.type ~= "None" then
 				source.CritChance = critOverride
+			end
+			if skillData.CritChance then
+				source.CritChance = skillData.CritChance
 			end
 			t_insert(passList, {
 				label = "Main Hand",
@@ -2416,9 +2416,6 @@ function calcs.offence(env, actor, activeSkill)
 			-- Unarmed override for Concoction skills
 			if skillFlags.unarmed then
 				source = copyTable(data.unarmedWeaponData[env.classId])
-				if skillData.CritChance then
-					source.CritChance = skillData.CritChance
-				end
 			end
 			if critOverride and source.type and source.type ~= "None" then
 				source.CritChance = critOverride


### PR DESCRIPTION
### Description of the problem being solved:
Both of these skills use a crit chance override which we were not taking into account unless you were dealing damage with an offhand weapon
Now all skills that have a crit chance value on the skill, will override the crit chance of the weapon or minion

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/7xcd9j0h

### Before screenshot:
<img width="242" height="103" alt="image" src="https://github.com/user-attachments/assets/494eb2fb-dbd1-42b2-9ab5-3d151832276a" />

### After screenshot:
<img width="236" height="100" alt="image" src="https://github.com/user-attachments/assets/d4bec77c-2055-4ba6-943b-629bcb007441" />
