### PR TITLE
Add support for Atziri's Splendour socketed Soul Core types

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1545,7 +1545,7 @@ end
 -- Rebuild rune modifiers using the item's runes
 function ItemClass:UpdateRunes()
 	wipeTable(self.runeModLines)
-	local getModRunesForTypes = function(runeName, baseType, specificType)
+	local getModRunesForTypes = function(runeName, baseType, specificType, alsoAsSoulCoreTypes)
 		local rune = data.itemMods.Runes[runeName]
 		local gatheredRuneMods = { }
 		if rune then
@@ -1559,8 +1559,33 @@ function ItemClass:UpdateRunes()
 					t_insert(gatheredRuneMods, rune[specificType])
 				-- end
 			end
+			for alsoAsType, _ in pairs(alsoAsSoulCoreTypes) do
+				if rune[alsoAsType] and rune[alsoAsType].type == "SoulCore" then
+					-- for _, mod in pairs(rune[alsoAsType]) do
+						t_insert(gatheredRuneMods, rune[alsoAsType])
+					-- end
+				end
+			end
 		end
 		return gatheredRuneMods
+	end
+
+	-- baseModList may not be populated at the time this function is called
+	local alsoAsSoulCoreTypes = { }
+	for _, modLines in ipairs({ self.enchantModLines, self.implicitModLines, self.explicitModLines }) do
+		for _, effectModLine in ipairs(modLines) do
+			for _, mod in ipairs(effectModLine.modList or { }) do
+				if mod.name == "SocketSoulCoresAlsoAsBoots" and mod.type == "FLAG" and mod.value then
+					alsoAsSoulCoreTypes["boots"] = true
+				elseif mod.name == "SocketSoulCoresAlsoAsGloves" and mod.type == "FLAG" and mod.value then
+					alsoAsSoulCoreTypes["gloves"] = true
+				elseif mod.name == "SocketSoulCoresAlsoAsHelmet" and mod.type == "FLAG" and mod.value then
+					alsoAsSoulCoreTypes["helmet"] = true
+				elseif mod.name == "SocketSoulCoresAlsoAsShield" and mod.type == "FLAG" and mod.value then
+					alsoAsSoulCoreTypes["shield"] = true
+				end
+			end
+		end
 	end
 
 	local statOrder = {}
@@ -1574,7 +1599,7 @@ function ItemClass:UpdateRunes()
 				(subType == "warstaff" and "quarterstaff") or
 				(itemType == "shield" and subType == "evasion" and "buckler") or
 				itemType
-			local gatheredMods = getModRunesForTypes(name, baseType, specificType)
+			local gatheredMods = getModRunesForTypes(name, baseType, specificType, alsoAsSoulCoreTypes)
 			for _, mod in ipairs(gatheredMods) do
 				for i, modLine in ipairs(mod) do
 					local order = mod.statOrder[i]

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -428,6 +428,7 @@ holding Shift will put it in the second.]])
 		self.displayItem:BuildAndParseRaw()
 		self:UpdateDisplayItemTooltip()
 		self:UpdateDisplayItemRangeLines()
+		self:UpdateRuneControls()
 	end)
 	self.controls.displayItemVariant.maxDroppedWidth = 1000
 	self.controls.displayItemVariant.shown = function()
@@ -1929,17 +1930,24 @@ end)
 function ItemsTabClass:GetValidRunesForItem(item)
 	local runes = { }
 	local socketedItemType
+	local subType = item.base.subType and item.base.subType:lower()
+	local itemType = item.base.type:lower()
+	local alsoAsSoulCoreTypes = { }
 	if item.baseModList then
 		if item.baseModList:Flag(nil, "SocketedSoulCoresOnly") then
 			socketedItemType = "SoulCore"
 		elseif item.baseModList:Flag(nil, "SocketedRunesOnly") then
 			socketedItemType = "Rune"
 		end
+		alsoAsSoulCoreTypes["boots"] = item.baseModList:Flag(nil, "SocketSoulCoresAlsoAsBoots")
+		alsoAsSoulCoreTypes["gloves"] = item.baseModList:Flag(nil, "SocketSoulCoresAlsoAsGloves")
+		alsoAsSoulCoreTypes["helmet"] = item.baseModList:Flag(nil, "SocketSoulCoresAlsoAsHelmet")
+		alsoAsSoulCoreTypes["shield"] = item.baseModList:Flag(nil, "SocketSoulCoresAlsoAsShield")
 	end
 	for _, rune in pairs(runeModLines) do
-		local subType = item.base.subType and item.base.subType:lower()
-		local itemType = item.base.type:lower()
-		local function isRuneValidForSlot(runeSlot)
+		local function isRuneValidForSlot(rune)
+			local runeSlot = rune.slot
+			local runeType = rune.type
 			if runeSlot == "None" then
 				return true
 			elseif runeSlot == "quarterstaff" then
@@ -1953,10 +1961,10 @@ function ItemsTabClass:GetValidRunesForItem(item)
 			elseif runeSlot == "caster" then
 				return item.base.tags.wand or item.base.tags.staff or item.base.tags.sceptre
 			else
-				return itemType == runeSlot and not (subType == "warstaff")
+				return (itemType == runeSlot and not (subType == "warstaff")) or (alsoAsSoulCoreTypes[runeSlot] and runeType == "SoulCore")
 			end
 		end
-		if isRuneValidForSlot(rune.slot) then
+		if isRuneValidForSlot(rune) then
 			if rune.slot == "None" or not socketedItemType or rune.type == socketedItemType then
 				table.insert(runes, rune)
 			end

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6804,14 +6804,10 @@ c["This item gains bonuses from Socketed Items as though it was a Body Armour Th
 c["This item gains bonuses from Socketed Items as though it was a Helmet"]={nil,"This item gains bonuses from Socketed Items as though it was a Helmet "}
 c["This item gains bonuses from Socketed Items as though it was a Helmet This item gains bonuses from Socketed Items as though it was a Shield"]={nil,"This item gains bonuses from Socketed Items as though it was a Helmet This item gains bonuses from Socketed Items as though it was a Shield "}
 c["This item gains bonuses from Socketed Items as though it was a Shield"]={nil,"This item gains bonuses from Socketed Items as though it was a Shield "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also Boots"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also Boots "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also Boots This item gains bonuses from Socketed Soul Cores as though it was also Gloves"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also Boots This item gains bonuses from Socketed Soul Cores as though it was also Gloves "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also Gloves"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also Gloves "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also Gloves This item gains bonuses from Socketed Soul Cores as though it was also a Helmet"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also Gloves This item gains bonuses from Socketed Soul Cores as though it was also a Helmet "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also a Helmet"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also a Helmet "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also a Helmet This item gains bonuses from Socketed Soul Cores as though it was also a Shield"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also a Helmet This item gains bonuses from Socketed Soul Cores as though it was also a Shield "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also a Shield"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also a Shield "}
-c["This item gains bonuses from Socketed Soul Cores as though it was also a Shield Has no Attribute Requirements"]={nil,"This item gains bonuses from Socketed Soul Cores as though it was also a Shield Has no Attribute Requirements "}
+c["This item gains bonuses from Socketed Soul Cores as though it was also Boots"]={{[1]={flags=0,keywordFlags=0,name="SocketSoulCoresAlsoAsBoots",type="FLAG",value=true}},nil}
+c["This item gains bonuses from Socketed Soul Cores as though it was also Gloves"]={{[1]={flags=0,keywordFlags=0,name="SocketSoulCoresAlsoAsGloves",type="FLAG",value=true}},nil}
+c["This item gains bonuses from Socketed Soul Cores as though it was also a Helmet"]={{[1]={flags=0,keywordFlags=0,name="SocketSoulCoresAlsoAsHelmet",type="FLAG",value=true}},nil}
+c["This item gains bonuses from Socketed Soul Cores as though it was also a Shield"]={{[1]={flags=0,keywordFlags=0,name="SocketSoulCoresAlsoAsShield",type="FLAG",value=true}},nil}
 c["Thorns Damage has 25% chance to ignore Enemy Armour"]={{[1]={flags=32,keywordFlags=0,name="ChanceToIgnoreEnemyArmour",type="BASE",value=25}},nil}
 c["Thorns Damage has 50% chance to ignore Enemy Armour"]={{[1]={flags=32,keywordFlags=0,name="ChanceToIgnoreEnemyArmour",type="BASE",value=50}},nil}
 c["Thorns can Retaliate against all Hits"]={nil,"Thorns can Retaliate against all Hits "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3436,6 +3436,10 @@ local specialModList = {
 		-- Handled in Item.lua
 	} end,
 	["only soul cores can be socketed in this item"] = { flag("SocketedSoulCoresOnly") },
+	["this item gains bonuses from socketed soul cores as though it was also boots"] = { flag("SocketSoulCoresAlsoAsBoots") },
+	["this item gains bonuses from socketed soul cores as though it was also gloves"] = { flag("SocketSoulCoresAlsoAsGloves") },
+	["this item gains bonuses from socketed soul cores as though it was also a helmet"] = { flag("SocketSoulCoresAlsoAsHelmet") },
+	["this item gains bonuses from socketed soul cores as though it was also a shield"] = { flag("SocketSoulCoresAlsoAsShield") },
 	["only runes can be socketed in this item"] = { flag("SocketedRunesOnly") },
 	["has (%d+) sockets?"] = function(num) return { mod("SocketCount", "BASE", num) } end,
 	["no physical damage"] = { mod("WeaponData", "LIST", { key = "PhysicalMin" }), mod("WeaponData", "LIST", { key = "PhysicalMax" }), mod("WeaponData", "LIST", { key = "PhysicalDPS" }) },


### PR DESCRIPTION
### Description of the problem being solved:

The mod "This item gains bonuses from Socketed Soul Cores as though it was also \<x\>" from Atziri's Splendour is not supported.

### Steps taken to verify a working solution:
- Create Atziri's Splendour item
- Change variant
- List of socketable soul cores should change accordingly
- Importing a character with Atziri's Splendour equipped through the API should also correctly recognize the socketed soul cores
