### PR TITLE
Add Necrotic Catalyst (Minion)

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -11,8 +11,8 @@ local m_max = math.max
 local m_floor = math.floor
 
 local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"}
-local catalystList = {"Flesh", "Neural", "Carapace", "Uul-Netol's", "Xoph's", "Tul's", "Esh's", "Chayula's", "Reaver", "Sibilant", "Skittering", "Adaptive"}
-local catalystDescriptorList = {"Life", "Mana", "Defence", "Physical", "Fire", "Cold", "Lightning", "Chaos", "Attack", "Caster", "Speed", "Attribute"}
+local catalystList = {"Flesh", "Neural", "Carapace", "Uul-Netol's", "Xoph's", "Tul's", "Esh's", "Chayula's", "Reaver", "Sibilant", "Skittering", "Adaptive", "Necrotic"}
+local catalystDescriptorList = {"Life", "Mana", "Defence", "Physical", "Fire", "Cold", "Lightning", "Chaos", "Attack", "Caster", "Speed", "Attribute", "Minion"}
 local catalystTags = {
 	{ "life" },
 	{ "mana" },
@@ -26,6 +26,7 @@ local catalystTags = {
 	{ "caster" },
 	{ "speed" },
 	{ "attribute" },
+	{ "minion" },
 }
 
 local minimumReqLevel = { }

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -43,6 +43,7 @@ local catalystQualityFormat = {
 	"^x7F7F7FQuality (Caster Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
 	"^x7F7F7FQuality (Speed Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
 	"^x7F7F7FQuality (Attribute Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
+	"^x7F7F7FQuality (Minion Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
 }
 
 local flavourLookup = {}

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -593,6 +593,7 @@ holding Shift will put it in the second.]])
 		"Sibilant (Caster)",
 		"Skittering (Speed)",
 		"Adaptive (Attribute)",
+		"Necrotic (Minion)",
 		},
 		function(index, value)
 			self.displayItem.catalyst = index - 1

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -206,11 +206,11 @@ Heartbound Loop
 Pearl Ring
 Implicits: 1
 {tags:caster,speed}(7-10)% increased Cast Speed
-{tags:life}Minions have (10-15)% increased maximum Life
+{tags:life,minion}Minions have (10-15)% increased maximum Life
 {tags:life}(10-15) Life Regeneration per second
 {tags:mana}(20-40)% increased Mana Regeneration Rate
 {tags:physical}300 Physical Damage taken on Minion Death
-Minions Revive (10-15)% faster
+{tags:minion}Minions Revive (10-15)% faster
 ]],[[
 Icefang Orbit
 Iron Ring

--- a/src/Export/Scripts/uModsToText.lua
+++ b/src/Export/Scripts/uModsToText.lua
@@ -14,6 +14,7 @@ local catalystTags = {
 	["lightning"] = true,
 	["chaos"] = true,
 	["defences"] = true,
+	["minion"] = true,
 }
 local itemTypes = {
 	"axe",


### PR DESCRIPTION
### Description of the problem being solved:
Necrotic Catalyst was missing from the dropdown, so pasting amulet or rings with minion quality would not find the matching catalyst.

### After screenshot:
<img width="549" height="730" alt="image" src="https://github.com/user-attachments/assets/7e3f2338-ef7a-4db0-945a-e4b438793cd1" />
