### PR TITLE
Allow warcries for channeled skills

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3182,7 +3182,7 @@ function calcs.offence(env, actor, activeSkill)
 
 		if env.mode_buffs then
 			-- Iterative over all the active skills to account for exerted attacks provided by warcries
-			if not activeSkill.skillTypes[SkillType.NeverExertable] and not activeSkill.skillTypes[SkillType.Triggered] and not activeSkill.skillTypes[SkillType.Channel] and not activeSkill.skillTypes[SkillType.OtherThingUsesSkill] and not activeSkill.skillTypes[SkillType.Retaliation] then
+			if not activeSkill.skillTypes[SkillType.NeverExertable] and not activeSkill.skillTypes[SkillType.Triggered] and not activeSkill.skillTypes[SkillType.OtherThingUsesSkill] and not activeSkill.skillTypes[SkillType.Retaliation] then
 				for index, value in ipairs(actor.activeSkillList) do
 					if value.activeEffect.grantedEffect.name == "Ancestral Cry" and activeSkill.skillTypes[SkillType.MeleeSingleTarget] and not globalOutput.AncestralCryCalculated then
 						globalOutput.AncestralCryDuration = calcSkillDuration(value.skillModList, value.skillCfg, value.skillData, env, enemyDB)


### PR DESCRIPTION
Fixes #2316.

### Description of the problem being solved:

Warcry code in CalcOffence seemed to be behind 5 year old exert code. PoE2 doesn't seem to have a concept of exerted attacks, and only has empowered attacks which do work for channeled skills, so I removed the channeling guard

### Steps taken to verify a working solution:
- Tests pass
- Supercharged slam works

### Link to a build that showcases this PR:

### Before screenshot:
<img width="723" height="396" alt="image" src="https://github.com/user-attachments/assets/09fb3fc3-1f41-41d5-aeab-8a7d0339bcc1" />

### After screenshot:
<img width="549" height="306" alt="image" src="https://github.com/user-attachments/assets/ff781d76-cbec-4e5b-9c6f-c11d6fad8b6b" />
<img width="796" height="219" alt="image" src="https://github.com/user-attachments/assets/069d5112-3dc1-48d2-bbc4-3652662c3255" />
