### PR TITLE
Allow From Nothing to shorten power report distance

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -560,11 +560,12 @@ function CalcsTabClass:PowerBuilder()
 				local dist = node.pathDist or 1000
 				for _, leap in ipairs(node.intuitiveLeapLikesAffecting or {}) do
 					if leap.alloc then
-						dist = math.min(leap.pathDist or 1000, dist)
+						dist = math.max(math.min(leap.pathDist or 1000, dist), 1)
 					end
 				end
 				distanceMap[dist] = distanceMap[dist] or {}
 				distanceMap[dist][nodeId] = node
+				node.power.distance = dist
 				if (not self.nodePowerMaxDepth) or dist <= self.nodePowerMaxDepth then
 					total = total + 1
 				end
@@ -603,7 +604,7 @@ function CalcsTabClass:PowerBuilder()
 						for _, node in pairs(node.path) do
 							pathNodes[node] = true
 						end
-						if node.pathDist > 1 then
+						if distance > 1 then
 							node.power.pathPower = self:CalculatePowerStat(self.powerStat, calcFunc({ addNodes = pathNodes }, useFullDPS), calcBase)
 						end
 					end
@@ -613,8 +614,8 @@ function CalcsTabClass:PowerBuilder()
 					if node.path and not node.ascendancyName then
 						newPowerMax.offence = m_max(newPowerMax.offence, node.power.offence)
 						newPowerMax.defence = m_max(newPowerMax.defence, node.power.defence)
-						newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / node.pathDist)
-						newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / node.pathDist)
+						newPowerMax.offencePerPoint = m_max(newPowerMax.offencePerPoint, node.power.offence / distance)
+						newPowerMax.defencePerPoint = m_max(newPowerMax.defencePerPoint, node.power.defence / distance)
 					end
 				end
 			elseif node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then

--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -557,9 +557,15 @@ function CalcsTabClass:PowerBuilder()
 				end
 			end
 			if not hiddenByLockedAscendancyNode then
-				distanceMap[node.pathDist or 1000] = distanceMap[node.pathDist or 1000] or { }
-				distanceMap[node.pathDist or 1000][nodeId] = node
-				if not (self.nodePowerMaxDepth and self.nodePowerMaxDepth < node.pathDist) then
+				local dist = node.pathDist or 1000
+				for _, leap in ipairs(node.intuitiveLeapLikesAffecting or {}) do
+					if leap.alloc then
+						dist = math.min(leap.pathDist or 1000, dist)
+					end
+				end
+				distanceMap[dist] = distanceMap[dist] or {}
+				distanceMap[dist][nodeId] = node
+				if (not self.nodePowerMaxDepth) or dist <= self.nodePowerMaxDepth then
 					total = total + 1
 				end
 			end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -961,7 +961,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 			if isAlloc then
 				pathDist = #(node.depends or { }) == 0 and 1 or #node.depends
 			else
-				pathDist = #(node.path or { }) == 0 and 1 or #node.path
+				pathDist = node.power.distance or #(node.path or {}) == 0 and 1 or #node.path
 			end
 			local nodePower = (node.power.singleStat or 0) * ((displayStat.pc or displayStat.mod) and 100 or 1)
 			local pathPower = (node.power.pathPower or 0) / pathDist * ((displayStat.pc or displayStat.mod) and 100 or 1)


### PR DESCRIPTION
Fixes #power report

### Description of the problem being solved:

Allows power report to work with nodes that are affected by From Nothing. I.e. their distance will be zero.

### Steps taken to verify a working solution:
- Power report tested
- Tests pass
- PoE1 also tested

I'm not sure if the & Clusters option works correctly as I have no clue what it does

### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/22ac4
### Before screenshot:

### After screenshot:
<img width="2397" height="1650" alt="image" src="https://github.com/user-attachments/assets/3d1f16ef-2a20-4799-a503-0e48fecc858e" />
<img width="1492" height="1133" alt="image" src="https://github.com/user-attachments/assets/0b2a3a58-e305-4b43-afae-c03052188ffe" />
