### PR TITLE
Add support for Infernal Legion support gems

### DIFF
--- a/spec/System/TestInfernalLegion_spec.lua
+++ b/spec/System/TestInfernalLegion_spec.lua
@@ -1,0 +1,123 @@
+describe("TestInfernalLegion", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	-- Parsing: the minion-scoped "Magnitude of Damaging Ailments" gear mod must resolve to a
+	-- MinionModifier wrapping an AilmentMagnitude increase (so it reaches the minion's ignite).
+	it("parses minion 'increased Magnitude of Damaging Ailments' as a minion AilmentMagnitude", function()
+		local parseMod = LoadModule("Modules/ModParser")
+		local mods = parseMod("Minions have 40% increased Magnitude of Damaging Ailments")
+		assert.are.equals(1, #mods)
+		assert.are.equals("MinionModifier", mods[1].name)
+		local inner = mods[1].value.mod
+		assert.are.equals("AilmentMagnitude", inner.name)
+		assert.are.equals("INC", inner.type)
+		assert.are.equals(40, inner.value)
+		-- damaging-ailment keyword flags must include Ignite (what IL's ignite is gated on)
+		assert.True(inner.keywordFlags and bit.band(inner.keywordFlags, KeywordFlag.Ignite) ~= 0, "AilmentMagnitude should be flagged for Ignite")
+	end)
+
+	-- Parsing: Blackflame's "Withered ... increases Fire Damage taken" maps to a flag.
+	it("parses Blackflame 'Withered you inflict also increases Fire Damage taken' to a flag", function()
+		local parseMod = LoadModule("Modules/ModParser")
+		local mods = parseMod("Withered you inflict also increases Fire Damage taken")
+		assert.are.equals(1, #mods)
+		assert.are.equals("WitherIncreasesFireDamageTaken", mods[1].name)
+		assert.are.equals("FLAG", mods[1].type)
+	end)
+
+	-- Helper: minion supported by Infernal Legion, with the minion pointed at the IL skill.
+	-- Set any config/customMods before calling this so the build picks them up.
+	local function setupIL()
+		build.configTab:BuildModList()
+		build.skillsTab:PasteSocketGroup("Skeletal Warrior 20/0  1\nInfernal Legion I 1/0  1\n")
+		runCallback("OnFrame")
+		build.skillsTab:SetDisplayGroup(build.skillsTab.socketGroupList[1])
+		runCallback("OnFrame")
+		local env = build.calcsTab.mainEnv
+		local ilIndex
+		for i, s in ipairs(env.minion and env.minion.activeSkillList or {}) do
+			local ge = s.activeEffect and s.activeEffect.grantedEffect
+			if ge and ge.id == "InfernalLegion" then ilIndex = i break end
+		end
+		assert.is_not_nil(ilIndex, "Infernal Legion should be on the minion's skill list")
+		for _, gem in ipairs(build.skillsTab.socketGroupList[1].gemList) do
+			gem.skillMinionSkill = ilIndex
+			gem.skillMinionSkillCalcs = ilIndex
+		end
+		build.mainSocketGroup = 1
+		build.modFlag = true; build.buildFlag = true
+		for _ = 1, 6 do runCallback("OnFrame") end
+		return build.calcsTab.mainEnv
+	end
+
+	local function recalc()
+		build.configTab:BuildModList()
+		build.modFlag = true; build.buildFlag = true
+		for _ = 1, 4 do runCallback("OnFrame") end
+		return build.calcsTab.mainEnv
+	end
+
+	-- IL's "hit" is a pseudo-hit: it seeds the ignite but deals no damage of its own.
+	it("IL deals no hit damage (pseudo-hit) but still ignites", function()
+		local o = setupIL().minion.output
+		assert.are.equals(0, o.AverageDamage)
+		assert.are.equals(0, o.TotalDPS)
+		assert.True(o.IgniteDPS and o.IgniteDPS > 0, "IL should produce ignite DPS")
+	end)
+
+	-- IL ignite crits use a 50% base crit bonus (1.5x), not the minion's default 100% (2x).
+	it("IL uses a 50% base crit bonus (1.5x multiplier)", function()
+		assert.are.equals(1.5, setupIL().minion.output.PreEffectiveCritMultiplier)
+	end)
+
+	-- The minion's *increased* crit damage applies at half effectiveness for IL.
+	it("the minion's increased crit damage is half-effective for IL", function()
+		build.configTab.input.customMods = "Minions have 100% increased Critical Damage Bonus"
+		-- base 0.5 bonus, +100% increased applied at half (=+50%): 0.5 * (1 + 0.5) = 0.75 -> 1.75x.
+		-- (Full effectiveness would give 0.5 * 2.0 = 1.0 -> 2.0x.)
+		assert.are.equals(1.75, setupIL().minion.output.PreEffectiveCritMultiplier)
+	end)
+
+	-- Aggravated Ignite deals 100% extra (double) damage.
+	it("Aggravated Ignite doubles IL ignite damage", function()
+		local base = setupIL().minion.output.IgniteDPS
+		assert.True(base and base > 0)
+		build.configTab.input.conditionIgniteAggravated = true
+		local agg = recalc().minion.output.IgniteDPS
+		assert.True(math.abs(agg - 2 * base) < 1e-6, string.format("expected %.6f, got %.6f", 2 * base, agg))
+	end)
+
+	-- "Minions have X% increased Magnitude of Damaging Ailments" scales IL's ignite end-to-end.
+	it("minion 'increased Magnitude of Damaging Ailments' scales IL ignite", function()
+		local base = setupIL().minion.output.IgniteDPS
+		assert.True(base and base > 0)
+		build.configTab.input.customMods = "Minions have 100% increased Magnitude of Damaging Ailments"
+		local scaled = recalc().minion.output.IgniteDPS
+		-- +100% magnitude roughly doubles the ignite (baseline magnitude increase is 0 here).
+		assert.True(math.abs(scaled - 2 * base) < 1e-6, string.format("expected %.6f, got %.6f", 2 * base, scaled))
+	end)
+
+	-- Full DPS runs offence on the IL skill an extra time. The half-effect that
+	-- preDamageFunc injects must not stack, or crit would over-halve.
+	it("IL crit/ignite stay correct under Full DPS (no double-applied halving)", function()
+		local base = setupIL().minion.output.IgniteDPS
+		build.skillsTab.socketGroupList[1].includeInFullDPS = true
+		local env = recalc()
+		assert.are.equals(1.5, env.minion.output.PreEffectiveCritMultiplier)
+		assert.True(math.abs(env.minion.output.IgniteDPS - base) < 1e-6,
+			string.format("ignite changed under Full DPS: %.6f vs %.6f", env.minion.output.IgniteDPS, base))
+	end)
+
+	-- IL's hit is a pseudo-hit (no real damage), so a poison source must not seed a
+	-- poison off its big notional damage -- that was inflating Poison's evaluated value.
+	it("IL pseudo-hit does not seed poison from a poison source", function()
+		local igniteBefore = setupIL().minion.output.IgniteDPS
+		build.configTab.input.customMods = "Minions have 100% chance to Poison on Hit"
+		local env = recalc()
+		local poison = env.minion.output.PoisonDPS
+		assert.True(not poison or poison == 0, "IL pseudo-hit must not produce poison DPS")
+		assert.True(math.abs(env.minion.output.IgniteDPS - igniteBefore) < 1e-6, "ignite must be unchanged")
+	end)
+end)

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6935,8 +6935,7 @@ c["Wind Skills which can be boosted by Elemental Ground Surfaces count as being 
 c["Withered also causes enemies to deal 1% reduced Damage"]={nil,"Withered also causes enemies to deal 1% reduced Damage "}
 c["Withered does not expire on Enemies Ignited by you"]={nil,"Withered does not expire on Enemies Ignited by you "}
 c["Withered does not expire on Enemies Ignited by you 25% chance to Intimidate Enemies for 4 seconds on Hit"]={nil,"Withered does not expire on Enemies Ignited by you 25% chance to Intimidate Enemies for 4 seconds on Hit "}
-c["Withered you inflict also increases Fire Damage taken"]={nil,"Withered you inflict also increases Fire Damage taken "}
-c["Withered you inflict also increases Fire Damage taken Withered does not expire on Enemies Ignited by you"]={nil,"Withered you inflict also increases Fire Damage taken Withered does not expire on Enemies Ignited by you "}
+c["Withered you inflict also increases Fire Damage taken"]={{[1]={flags=0,keywordFlags=0,name="WitherIncreasesFireDamageTaken",type="FLAG",value=true}},nil}
 c["Withered you inflict has infinite Duration"]={nil,"Withered you inflict has infinite Duration "}
 c["You and Allies in your Presence have +23% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ExtraAura",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=23}}}},nil}
 c["You and Allies in your Presence have +37% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ExtraAura",type="LIST",value={mod={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=37}}}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -636,6 +636,9 @@ return {
 ["active_skill_base_radius_+"] = {
 	skill("radiusExtra", nil),
 },
+["infernal_legion_minion_burning_effect_radius"] = {
+	skill("radius", nil),
+},
 ["base_skill_area_of_effect_+%"] = {
 	mod("AreaOfEffect", "INC", nil),
 },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -8915,6 +8915,14 @@ skills["FrostBombPlayer"] = {
 			incrementalEffectiveness = 0.12999999523163,
 			damageIncrementalEffectiveness = 0.008899999782443,
 			statDescriptionScope = "frost_bomb",
+			statMap = {
+				-- Elemental Exposure starts at the base 20% magnitude (applied via the global exposure
+				-- mapping) and compounds 2% per pulse up to this cap (quality-scaled). Expose the cap as a
+				-- multiplier; the "# of Frost Bomb pulses" config reads it to apply the compounded value.
+				["active_skill_all_elemental_exposure_compounding_magnitude_cap"] = {
+					mod("Multiplier:FrostBombExposureCap", "BASE", nil),
+				},
+			},
 			baseFlags = {
 				spell = true,
 				area = true,

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -1095,6 +1095,131 @@ skills["MPSAncestralTotemSpiritSoulCasterProjectile"] = {
 				}
 			}
 
+			skills["InfernalLegion"] = {
+				name = "Infernal Legion",
+				hidden = true,
+				skillTypes = {
+					[SkillType.Damage] = true,
+					[SkillType.Area] = true,
+					[SkillType.Fire] = true,
+					[SkillType.CausesBurning] = true,
+				},
+				qualityStats = {
+				},
+				levels = {
+					-- no crit chance of its own; only enemy Critical Weakness can crit it
+					-- (the increased-crit half-effect is injected in preDamageFunc)
+					[1] = { critChance = 0, levelRequirement = 0, },
+				},
+				preDamageFunc = function(activeSkill, output)
+					local skillData = activeSkill.skillData
+					local sml = activeSkill.skillModList
+					local cfg = activeSkill.skillCfg
+					-- Fold non-fire damage into the ignite only if its <Type>CanIgnite flag
+					-- is set (Uul-Netol's Embrace, Xoph's Pyre, etc). Fire always folds in.
+					-- Two sources: flat BASE per-type damage, and %gain-as-extra-X (gated on
+					-- the destination type, e.g. PhysicalDamageGainAsCold needs ColdCanIgnite).
+					-- conditionIlNoAddedConversion turns it off.
+					local convertedBase = 0
+					local extraGainMult = 0
+					if sml and not sml:Flag(cfg, "Condition:IlNoAddedConversion")
+						and activeSkill.actor and activeSkill.actor.modDB then
+						local mdb = activeSkill.actor.modDB
+						local typeFlag = {
+							Physical  = "PhysicalCanIgnite",
+							Cold      = "ColdCanIgnite",
+							Lightning = "LightningCanIgnite",
+							Chaos     = "ChaosCanIgnite",
+						}
+						-- the flag can be on the skill's modlist (a support like Xoph's Pyre)
+						-- or the minion's modDB (passive/item/buff), so check both
+						local function ignites(dt)
+							if dt == "Fire" then return true end
+							local f = typeFlag[dt]
+							return sml:Flag(cfg, f) or mdb:Flag(nil, f)
+						end
+						-- flat damage: only types whose CanIgnite flag is set
+						for _, dt in ipairs({ "Physical", "Fire", "Cold", "Lightning", "Chaos" }) do
+							if ignites(dt) then
+								local lo = mdb:Sum("BASE", nil, dt .. "Min") or 0
+								local hi = mdb:Sum("BASE", nil, dt .. "Max") or 0
+								convertedBase = convertedBase + (lo + hi) / 2
+							end
+						end
+						-- gain-as-extra: gated on the destination type
+						local gainByDest = {
+							Fire      = { "PhysicalDamageGainAsFire",      "DamageGainAsFire" },
+							Cold      = { "PhysicalDamageGainAsCold",      "DamageGainAsCold" },
+							Lightning = { "PhysicalDamageGainAsLightning", "DamageGainAsLightning" },
+							Chaos     = { "PhysicalDamageGainAsChaos",     "DamageGainAsChaos", "FireDamageGainAsChaos" },
+						}
+						for dest, mods in pairs(gainByDest) do
+							if ignites(dest) then
+								for _, name in ipairs(mods) do
+									extraGainMult = extraGainMult + (mdb:Sum("BASE", nil, name) or 0)
+								end
+							end
+						end
+					end
+					-- fire base = Life * selfFireExplosionLifeMultiplier * (1 + gain-as-extra%)
+					-- plus the flat damage (already converted to fire). Magnitude gets applied
+					-- later by the normal ignite path.
+					local lifeBase = output.Life * skillData.selfFireExplosionLifeMultiplier
+					local base = (lifeBase * (1 + extraGainMult / 100) + convertedBase)
+					skillData.FireBonusMin = base
+					skillData.FireBonusMax = base
+					-- IL's increased crit chance and crit damage each count for half. Inject a
+					-- negative INC worth -50% of the current increased so the normal crit calc
+					-- reads the halved value (Transfiguration injects increased the same way).
+					if sml then
+						sml:NewMod("CritChance", "INC", -0.5 * sml:Sum("INC", cfg, "CritChance"), "Infernal Legion")
+						sml:NewMod("CritMultiplier", "INC", -0.5 * sml:Sum("INC", cfg, "CritMultiplier"), "Infernal Legion")
+					end
+				end,
+				statSets = {
+					[1] = {
+						label = "Infernal Legion",
+						incrementalEffectiveness = 0,
+						statDescriptionScope = "skill_stat_descriptions",
+						baseFlags = {
+							area = true,
+							fire = true,
+						},
+						baseMods = {
+							skill("selfFireExplosionLifeMultiplier", 0.01, { type = "Multiplier", var = "InfernalLegionBaseDamage" }),
+							-- IL doesn't really hit; the "hit" just seeds the ignite ("as though
+							-- dealing X"). hitIsPseudoHit zeroes its DPS in CalcOffence, but the
+							-- ignite is still built from it. It's a sustained ignite, so the DPS
+							-- is the ongoing IgniteDPS, not a per-hit burst.
+							skill("hitIsPseudoHit", true),
+							-- IL ignites on a fixed cadence, not the minion's attack speed.
+							-- timeOverride pins it: Speed = 1/timeOverride, so 1.25 -> 0.8/sec.
+							-- That gives StackPotential = duration(4) * 0.8 = 3.2 = N, the number
+							-- of overlapping rolling ignites that feeds the roll average and the
+							-- crit amplification. 0.8/sec matched the in-game timing tests.
+							skill("timeOverride", 1.25),
+							-- IL always ignites, so force 100% chance, otherwise PoE2's ailment
+							-- threshold drops it to almost never.
+							mod("EnemyIgniteChance", "BASE", 100),
+							-- gem crit chance is 0 (above), so the ignite only crits off enemy
+							-- Critical Weakness (SelfCritChance), which the normal crit path adds
+							-- in. The half-effect on the minion's increased crit chance/damage is
+							-- injected in preDamageFunc above.
+							-- IL crits for a 50% bonus, not the minion's 100%; the base +100 comes
+							-- from base_critical_hit_damage_bonus, so just knock 50 off it.
+							mod("CritMultiplier", "BASE", -50),
+						},
+						constantStats = {
+						},
+						stats = {
+						},
+						levels = {
+							[1] = { },
+						},
+					},
+				}
+			}
+
 skills["GAAnimateWeaponMaceSlam"] = {
 	name = "Mace Slam",
 	hidden = true,

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3503,6 +3503,15 @@ skills["SupportCathasBrilliance"] = {
 			label = "Catha's Brilliance",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				-- Catha's Brilliance ignites enemies for a % of the minion's max life, the
+				-- same mechanic as Infernal Legion: wire the stat to the IL base-damage
+				-- multiplier and grant the companion the IL skill so the ignite is modelled.
+				["support_minions_ignite_for_%_max_life"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
+					mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -15296,7 +15305,7 @@ skills["SupportScouringFlamePlayer"] = {
 	description = "Supports any skill that Hits enemies, causing inflicted Ignites to deal more damage but the skill to gain a Runic Ward cost.",
 	color = 4,
 	support = true,
-	requireSkillTypes = { SkillType.Attack, SkillType.Damage, SkillType.CrossbowAmmoSkill, },
+	requireSkillTypes = { SkillType.Attack, SkillType.Damage, SkillType.CrossbowAmmoSkill, SkillType.CreatesMinion, },
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "SearingFlame",},
@@ -15308,6 +15317,11 @@ skills["SupportScouringFlamePlayer"] = {
 			label = "Scouring Flame",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_scouring_flame_ignite_effect_+%_final"] = {
+					mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Ignite),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -8164,7 +8164,7 @@ skills["SupportStormfirePlayer"] = {
 	description = "Supports any skill that Hits enemies. Enemies Shocked by Supported Skills take a percentage of damage from Ignite as Lightning damage as well as Fire damage.",
 	color = 3,
 	support = true,
-	requireSkillTypes = { SkillType.Attack, SkillType.Damage, SkillType.CrossbowAmmoSkill, },
+	requireSkillTypes = { SkillType.Attack, SkillType.Damage, SkillType.CrossbowAmmoSkill, SkillType.CreatesMinion, },
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	gemFamily = { "StormFire",},
@@ -8176,6 +8176,11 @@ skills["SupportStormfirePlayer"] = {
 			label = "Stormfire",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_stormfire_targets_shocked_by_this_take_%_of_damage_from_ignite_as_lightning_damage"] = {
+					mod("IgniteAsExtraLightning", "BASE", nil),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -4612,9 +4612,8 @@ skills["SupportInfernalLegionPlayer"] = {
 					mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 					div = 6000,
 				},
-				["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-					div = 60,
+				["support_minions_ignite_for_%_max_life"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 					mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 				},
 			},
@@ -4655,9 +4654,8 @@ skills["SupportInfernalLegionPlayerTwo"] = {
 					mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 					div = 6000,
 				},
-				["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-					div = 60,
+				["support_minions_ignite_for_%_max_life"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 					mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 				},
 			},
@@ -4700,9 +4698,8 @@ skills["SupportInfernalLegionPlayerThree"] = {
 					mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 					div = 6000,
 				},
-				["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-					div = 60,
+				["support_minions_ignite_for_%_max_life"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 					mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 				},
 			},

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -121,6 +121,15 @@ directiveTable.addSkillTypes = function(state, args, out)
 	end
 end
 
+-- #requireSkillTypes <flag>[ <flag>[...]]
+-- extra skill types appended to a support's requireSkillTypes (the rest come from game data)
+directiveTable.requireSkillTypes = function(state, args, out)
+	state.requireSkillTypes = {}
+	for flag in args:gmatch("%a+") do
+		table.insert(state.requireSkillTypes, flag)
+	end
+end
+
 -- #skill <GrantedEffectId> [<Display name>]
 -- Initialises the skill data and emits the skill header
 directiveTable.skill = function(state, args, out)
@@ -220,6 +229,8 @@ directiveTable.skill = function(state, args, out)
 	skill.setIndex = 1
 	skill.addSkillTypes = state.addSkillTypes
 	state.addSkillTypes = nil
+	skill.requireSkillTypes = state.requireSkillTypes
+	state.requireSkillTypes = nil
 	if skillGem and not state.noGem then
 		out:write('\tcolor = ', gemColor, ',\n')
 	end
@@ -317,6 +328,11 @@ directiveTable.skill = function(state, args, out)
 		out:write('\trequireSkillTypes = { ')
 		for _, type in ipairs(granted.SupportTypes) do
 			out:write(mapAST(type), ', ')
+		end
+		if skill.requireSkillTypes then
+			for _, flag in ipairs(skill.requireSkillTypes) do
+				out:write('SkillType.', flag, ', ')
+			end
 		end
 		out:write('},\n')
 		out:write('\taddSkillTypes = { ')

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -673,6 +673,14 @@ statMap = {
 #skill FrostBombPlayer
 #set FrostBombPlayer
 #flags spell area duration
+statMap = {
+	-- Elemental Exposure starts at the base 20% magnitude (applied via the global exposure
+	-- mapping) and compounds 2% per pulse up to this cap (quality-scaled). Expose the cap as a
+	-- multiplier; the "# of Frost Bomb pulses" config reads it to apply the compounded value.
+	["active_skill_all_elemental_exposure_compounding_magnitude_cap"] = {
+		mod("Multiplier:FrostBombExposureCap", "BASE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -164,6 +164,131 @@ skills["MinionInstability"] = {
 	}
 }
 
+skills["InfernalLegion"] = {
+	name = "Infernal Legion",
+	hidden = true,
+	skillTypes = {
+		[SkillType.Damage] = true,
+		[SkillType.Area] = true,
+		[SkillType.Fire] = true,
+		[SkillType.CausesBurning] = true,
+	},
+	qualityStats = {
+	},
+	levels = {
+		-- no crit chance of its own; only enemy Critical Weakness can crit it
+		-- (the increased-crit half-effect is injected in preDamageFunc)
+		[1] = { critChance = 0, levelRequirement = 0, },
+	},
+	preDamageFunc = function(activeSkill, output)
+		local skillData = activeSkill.skillData
+		local sml = activeSkill.skillModList
+		local cfg = activeSkill.skillCfg
+		-- Fold non-fire damage into the ignite only if its <Type>CanIgnite flag
+		-- is set (Uul-Netol's Embrace, Xoph's Pyre, etc). Fire always folds in.
+		-- Two sources: flat BASE per-type damage, and %gain-as-extra-X (gated on
+		-- the destination type, e.g. PhysicalDamageGainAsCold needs ColdCanIgnite).
+		-- conditionIlNoAddedConversion turns it off.
+		local convertedBase = 0
+		local extraGainMult = 0
+		if sml and not sml:Flag(cfg, "Condition:IlNoAddedConversion")
+			and activeSkill.actor and activeSkill.actor.modDB then
+			local mdb = activeSkill.actor.modDB
+			local typeFlag = {
+				Physical  = "PhysicalCanIgnite",
+				Cold      = "ColdCanIgnite",
+				Lightning = "LightningCanIgnite",
+				Chaos     = "ChaosCanIgnite",
+			}
+			-- the flag can be on the skill's modlist (a support like Xoph's Pyre)
+			-- or the minion's modDB (passive/item/buff), so check both
+			local function ignites(dt)
+				if dt == "Fire" then return true end
+				local f = typeFlag[dt]
+				return sml:Flag(cfg, f) or mdb:Flag(nil, f)
+			end
+			-- flat damage: only types whose CanIgnite flag is set
+			for _, dt in ipairs({ "Physical", "Fire", "Cold", "Lightning", "Chaos" }) do
+				if ignites(dt) then
+					local lo = mdb:Sum("BASE", nil, dt .. "Min") or 0
+					local hi = mdb:Sum("BASE", nil, dt .. "Max") or 0
+					convertedBase = convertedBase + (lo + hi) / 2
+				end
+			end
+			-- gain-as-extra: gated on the destination type
+			local gainByDest = {
+				Fire      = { "PhysicalDamageGainAsFire",      "DamageGainAsFire" },
+				Cold      = { "PhysicalDamageGainAsCold",      "DamageGainAsCold" },
+				Lightning = { "PhysicalDamageGainAsLightning", "DamageGainAsLightning" },
+				Chaos     = { "PhysicalDamageGainAsChaos",     "DamageGainAsChaos", "FireDamageGainAsChaos" },
+			}
+			for dest, mods in pairs(gainByDest) do
+				if ignites(dest) then
+					for _, name in ipairs(mods) do
+						extraGainMult = extraGainMult + (mdb:Sum("BASE", nil, name) or 0)
+					end
+				end
+			end
+		end
+		-- fire base = Life * selfFireExplosionLifeMultiplier * (1 + gain-as-extra%)
+		-- plus the flat damage (already converted to fire). Magnitude gets applied
+		-- later by the normal ignite path.
+		local lifeBase = output.Life * skillData.selfFireExplosionLifeMultiplier
+		local base = (lifeBase * (1 + extraGainMult / 100) + convertedBase)
+		skillData.FireBonusMin = base
+		skillData.FireBonusMax = base
+		-- IL's increased crit chance and crit damage each count for half. Inject a
+		-- negative INC worth -50% of the current increased so the normal crit calc
+		-- reads the halved value (Transfiguration injects increased the same way).
+		if sml then
+			sml:NewMod("CritChance", "INC", -0.5 * sml:Sum("INC", cfg, "CritChance"), "Infernal Legion")
+			sml:NewMod("CritMultiplier", "INC", -0.5 * sml:Sum("INC", cfg, "CritMultiplier"), "Infernal Legion")
+		end
+	end,
+	statSets = {
+		[1] = {
+			label = "Infernal Legion",
+			incrementalEffectiveness = 0,
+			statDescriptionScope = "skill_stat_descriptions",
+			baseFlags = {
+				area = true,
+				fire = true,
+			},
+			baseMods = {
+				skill("selfFireExplosionLifeMultiplier", 0.01, { type = "Multiplier", var = "InfernalLegionBaseDamage" }),
+				-- IL doesn't really hit; the "hit" just seeds the ignite ("as though
+				-- dealing X"). hitIsPseudoHit zeroes its DPS in CalcOffence, but the
+				-- ignite is still built from it. It's a sustained ignite, so the DPS
+				-- is the ongoing IgniteDPS, not a per-hit burst.
+				skill("hitIsPseudoHit", true),
+				-- IL ignites on a fixed cadence, not the minion's attack speed.
+				-- timeOverride pins it: Speed = 1/timeOverride, so 1.25 -> 0.8/sec.
+				-- That gives StackPotential = duration(4) * 0.8 = 3.2 = N, the number
+				-- of overlapping rolling ignites that feeds the roll average and the
+				-- crit amplification. 0.8/sec matched the in-game timing tests.
+				skill("timeOverride", 1.25),
+				-- IL always ignites, so force 100% chance, otherwise PoE2's ailment
+				-- threshold drops it to almost never.
+				mod("EnemyIgniteChance", "BASE", 100),
+				-- gem crit chance is 0 (above), so the ignite only crits off enemy
+				-- Critical Weakness (SelfCritChance), which the normal crit path adds
+				-- in. The half-effect on the minion's increased crit chance/damage is
+				-- injected in preDamageFunc above.
+				-- IL crits for a 50% bonus, not the minion's 100%; the base +100 comes
+				-- from base_critical_hit_damage_bonus, so just knock 50 off it.
+				mod("CritMultiplier", "BASE", -50),
+			},
+			constantStats = {
+			},
+			stats = {
+			},
+			levels = {
+				[1] = { },
+			},
+		},
+	}
+}
+
 #addSkillTypes Melee MeleeSingleTarget Area
 #skill GAAnimateWeaponMaceSlam Mace Slam
 #set GAAnimateWeaponMaceSlam

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -241,6 +241,15 @@ statMap = {
 
 #skill SupportCathasBrilliance
 #set SupportCathasBrilliance
+statMap = {
+	-- Catha's Brilliance ignites enemies for a % of the minion's max life, the
+	-- same mechanic as Infernal Legion: wire the stat to the IL base-damage
+	-- multiplier and grant the companion the IL skill so the ignite is modelled.
+	["support_minions_ignite_for_%_max_life"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
+		mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
+	},
+},
 #mods
 #skillEnd
 
@@ -1045,8 +1054,14 @@ statMap = {
 #mods
 #skillEnd
 
+#requireSkillTypes CreatesMinion
 #skill SupportScouringFlamePlayer
 #set SupportScouringFlamePlayer
+statMap = {
+	["support_scouring_flame_ignite_effect_+%_final"] = {
+		mod("AilmentMagnitude", "MORE", nil, 0, KeywordFlag.Ignite),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -1458,8 +1458,14 @@ statMap = {
 #mods
 #skillEnd
 
+#requireSkillTypes CreatesMinion
 #skill SupportStormfirePlayer
 #set SupportStormfirePlayer
+statMap = {
+	["support_stormfire_targets_shocked_by_this_take_%_of_damage_from_ignite_as_lightning_damage"] = {
+		mod("IgniteAsExtraLightning", "BASE", nil),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -1046,9 +1046,8 @@ statMap = {
 		mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 		div = 6000,
 	},
-	["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-		div = 60,
+	["support_minions_ignite_for_%_max_life"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 		mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 	},
 },
@@ -1062,9 +1061,8 @@ statMap = {
 		mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 		div = 6000,
 	},
-	["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-		div = 60,
+	["support_minions_ignite_for_%_max_life"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 		mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 	},
 },
@@ -1079,9 +1077,8 @@ statMap = {
 		mod("MinionModifier", "LIST", { mod = mod("FireDegen", "BASE", nil, 0, 0, { type = "PerStat", stat = "Life" }, { type = "GlobalEffect", effectType = "Buff" }) }),
 		div = 6000,
 	},
-	["support_minion_instability_minion_base_fire_area_damage_per_minute"] = {
-		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Life", percent = 1 }) }),
-		div = 60,
+	["support_minions_ignite_for_%_max_life"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Multiplier:InfernalLegionBaseDamage", "BASE", nil) }),
 		mod("ExtraMinionSkill", "LIST", { skillId = "InfernalLegion" }),
 	},
 },

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5161,6 +5161,10 @@ function calcs.offence(env, actor, activeSkill)
 			-- Over-stacking stacks increases the chance a critical is present
 			local ailmentCritChance = 100 * (1 - m_pow(1 - output.CritChance / 100, m_max(globalOutput[ailment .. "StackPotential"], 1)))
 			globalOutput[ailment .. "MagnitudeEffect"] = calcLib.mod(skillModList, dotCfg, "AilmentMagnitude")
+			if ailment == "Ignite" and enemyDB:Flag(nil, "Condition:IgniteAggravated") then
+				-- Aggravated Ignite deals 100% extra damage (mirrors Aggravated Bleed)
+				globalOutput[ailment .. "MagnitudeEffect"] = globalOutput[ailment .. "MagnitudeEffect"] * 2
+			end
 			local ailmentPercentBase = data.misc[ailment .. "PercentBase"] * globalOutput[ailment .. "MagnitudeEffect"]
 			local baseMinVal = calcAilmentDamage(ailment, ailmentCritChance, hitMin, 0, true) * ailmentPercentBase
 			local baseMaxVal = calcAilmentDamage(ailment, 100, hitMax, critMax, true) * ailmentPercentBase
@@ -5201,6 +5205,37 @@ function calcs.offence(env, actor, activeSkill)
 							local sourceRes = env.modDB:Flag(nil, "Enemy" .. ailmentDamageType .."ResistEqualToYours") and "Your ".. ailmentDamageType .. " Resistance"
 								or (env.partyMembers.modDB:Flag(nil, "Enemy" .. ailmentDamageType .."ResistEqualToYours") and "Party Member ".. ailmentDamageType .. " Resistance" or ailmentDamageType)
 							globalBreakdown[ailment .. "EffMult"] = breakdown.effMult(ailmentDamageType, resist, 0, takenInc, effMult, takenMore, sourceRes, true)
+						end
+					end
+				end
+
+				-- Stormfire: shocked enemies take part of the Ignite as extra Lightning.
+				-- The skill carrying Stormfire might not be the one igniting, so scan every
+				-- active skill rather than just this one. Works for player and minion Ignite.
+				if env.mode_effective and ailment == "Ignite" then
+					local asLightning = 0
+					for _, otherSkill in ipairs(env.player.activeSkillList) do
+						if otherSkill.skillModList then
+							asLightning = m_max(asLightning, otherSkill.skillModList:Sum("BASE", nil, "IgniteAsExtraLightning"))
+						end
+					end
+					if env.minion and env.minion.activeSkillList then
+						for _, otherSkill in ipairs(env.minion.activeSkillList) do
+							if otherSkill.skillModList then
+								asLightning = m_max(asLightning, otherSkill.skillModList:Sum("BASE", nil, "IgniteAsExtraLightning"))
+							end
+						end
+					end
+					if asLightning > 0 and enemyDB:Flag(nil, "Condition:Shocked") then
+						local lightResist = calcResistForType("Lightning", dotCfg)
+						local lightTakenInc = enemyDB:Sum("INC", dotCfg, "DamageTaken", "DamageTakenOverTime", "LightningDamageTaken", "LightningDamageTakenOverTime", "ElementalDamageTaken")
+						local lightTakenMore = enemyDB:More(dotCfg, "DamageTaken", "DamageTakenOverTime", "LightningDamageTaken", "LightningDamageTakenOverTime", "ElementalDamageTaken")
+						local lightEffMult = (1 - lightResist / 100) * (1 + lightTakenInc / 100) * lightTakenMore
+						effMult = effMult + asLightning / 100 * lightEffMult
+						globalOutput[ailment .. "EffMult"] = effMult
+						if globalBreakdown and globalBreakdown[ailment .. "EffMult"] then
+							t_insert(globalBreakdown[ailment .. "EffMult"], s_format("+ %.0f%% as Lightning (Stormfire) x %.3f ^8(Lightning effective DPS modifier)", asLightning, lightEffMult))
+							t_insert(globalBreakdown[ailment .. "EffMult"], s_format("= %.3f ^8(total effective DPS modifier with Lightning)", effMult))
 						end
 					end
 				end
@@ -5463,8 +5498,10 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 
-		-- Calculate damaging ailment values
-		for _, damagingAilment in ipairs({"Bleed", "Poison", "Ignite"}) do
+		-- Calculate damaging ailment values. A pseudo-hit (Infernal Legion) deals no
+		-- real hit, so it only seeds its own Ignite; it must not inflict Bleed/Poison
+		-- off the big notional hit damage.
+		for _, damagingAilment in ipairs(skillData.hitIsPseudoHit and { "Ignite" } or { "Bleed", "Poison", "Ignite" }) do
 			local damageType = data.defaultAilmentDamageTypes[damagingAilment]["DamageType"]
 			if not canDeal[damageType] then
 				for _, type in ipairs(dmgTypeList) do
@@ -6106,6 +6143,16 @@ function calcs.offence(env, actor, activeSkill)
 		if breakdown and breakdown.SelfHitDamage then
 			breakdown.SelfHitDamage[#breakdown.SelfHitDamage] = nil -- Remove new line at the end
 		end
+	end
+
+	-- hitIsPseudoHit: the hit deals no damage of its own (e.g. Infernal Legion
+	-- "ignites as though dealing X"), it only seeds the ailment, which was already
+	-- derived from the stored hit damage above. Zero the hit outputs so only the
+	-- ailment/DoT counts toward DPS.
+	if skillData.hitIsPseudoHit then
+		output.AverageDamage = 0
+		output.AverageHit = 0
+		output.TotalDPS = 0
 	end
 
 	-- Calculate combined DPS estimate, including DoTs

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -712,6 +712,9 @@ local function doActorMisc(env, actor)
 			modDB:NewMod("Condition:CanWither", "FLAG", true, "Config")
 			local effect = modDB:Max(nil, "WitherEffectStack")
 			enemyDB:NewMod("ChaosDamageTaken", "INC", effect, "Withered", { type = "Multiplier", var = "WitheredStack", limit = 10 } )
+			if modDB:Flag(nil, "WitherIncreasesFireDamageTaken") then
+				enemyDB:NewMod("FireDamageTaken", "INC", effect, "Withered", { type = "Multiplier", var = "WitheredStack", limit = 10 } )
+			end
 		end
 		if modDB:Flag(nil, "Condition:CanInflictIncision") then
 			local effect = 10 * (1 + modDB:Sum("INC", nil, "IncisionEffect") / 100)
@@ -3315,6 +3318,20 @@ function calcs.perform(env, skipEHP)
 			end
 		end
 		return effect
+	end
+
+	-- Frost Bomb: Elemental Exposure compounds 2% per pulse (configured count) on top of the base 20%,
+	-- up to the skill's cap. Apply the resulting value directly so the exposure step picks it up.
+	local frostBombExposureCap = 0
+	for _, activeSkill in ipairs(env.player.activeSkillList) do
+		frostBombExposureCap = m_max(frostBombExposureCap, activeSkill.skillModList:GetMultiplier("FrostBombExposureCap", nil))
+	end
+	if frostBombExposureCap > 0 then
+		modDB:NewMod("Multiplier:FrostBombExposureCap", "BASE", frostBombExposureCap, "Frost Bomb") -- expose to player for the config option
+		local frostBombExposure = m_min(20 + 2 * modDB:GetMultiplier("FrostBombExposurePulse", nil), frostBombExposureCap)
+		for _, element in ipairs({ "Fire", "Cold", "Lightning" }) do
+			enemyDB:NewMod(element .. "Exposure", "BASE", frostBombExposure, "Frost Bomb")
+		end
 	end
 
 	-- Apply exposures

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -220,6 +220,23 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 						activeSkillCount = 1
 						activeSkill.infoMessage2 = "Skill Damage"
 					end
+					-- Infernal Legion is an always-active burning aura the minion emits.
+					-- When the minion is in Full DPS, evaluate its IL extra-skill ignite
+					-- (even when a different skill is selected) and feed it into the best
+					-- ignite, since only the strongest ignite can be on a target at once.
+					local ilSkill
+					for _, s in ipairs(usedEnv.minion.activeSkillList or {}) do
+						local ge = s.activeEffect and s.activeEffect.grantedEffect
+						if ge and ge.id == "InfernalLegion" and s ~= usedEnv.minion.mainSkill then ilSkill = s break end
+					end
+					if ilSkill then
+						usedEnv.minion.mainSkill = ilSkill
+						calcs.offence(usedEnv, usedEnv.minion, ilSkill)
+						if usedEnv.minion.output.IgniteDPS and usedEnv.minion.output.IgniteDPS > fullDPS.igniteDPS then
+							fullDPS.igniteDPS = usedEnv.minion.output.IgniteDPS
+							igniteSource = skillName .. " (Infernal Legion)"
+						end
+					end
 				end
 
 				if activeSkill.mirage then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1771,6 +1771,12 @@ Huge sets the radius to 11.
 	{ var = "conditionEnemyIgnited", type = "check", label = "Is the enemy ^xB97123Ignited?", ifEnemyCond = "Ignited", implyCond = "Burning", tooltip = "This also implies that the enemy is ^xB97123Burning.", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Condition:Ignited", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
 	end },
+	{ var = "conditionIgniteAggravated", type = "check", label = "Is the ^xB97123Ignite^7 Aggravated?", ifEnemyCond = "Ignited", tooltip = "^xB97123Ignite ^7that has been Aggravated deals 100% extra damage.\nAggravated by sources such as Saitha's Spear.", apply = function(val, modList, enemyModList)
+		enemyModList:NewMod("Condition:IgniteAggravated", "FLAG", true, "Config", { type = "Condition", var = "Effective" })
+	end },
+	{ var = "multiplierFrostBombExposurePulse", type = "count", label = "# of ^x7FBFFFFrost Bomb^7 Exposure pulses:", ifMult = "FrostBombExposureCap", defaultPlaceholderState = 20, tooltip = "^x7FBFFFFrost Bomb^7's Elemental Exposure starts at 20% and compounds by 2% per pulse on the enemy, up to its cap.\nSet how many pulses have landed on the enemy.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:FrostBombExposurePulse", "BASE", val, "Config")
+	end },
 	{ var = "multiplierIgniteOnEnemy", type = "count", label = "# of ^xB97123Ignites^7 on enemy (if not average):", ifFlag = "IgniteCanStack", implyCond = "Ignited", apply = function(val, modList, enemyModList)
 		enemyModList:NewMod("Multiplier:IgniteStacks", "BASE", val, "Config", { type = "Condition", var = "Effective" })
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -801,6 +801,7 @@ local modNameList = {
 	["effect of poisons you inflict"] = { "AilmentEffect", keywordFlags = KeywordFlag.Poison },
 	["magnitude of ailments"] = "AilmentMagnitude",
 	["magnitude of ailments you inflict"] = "AilmentMagnitude",
+	["magnitude of damaging ailments"] = { "AilmentMagnitude", keywordFlags = bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite) },
 	["magnitude of damaging ailments you inflict"] = { "AilmentMagnitude", keywordFlags = bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite) },
 	["effect of lightning ailments"] = "EnemyShockMagnitude",
 	["effect of chill and shock on you"] = { "SelfChillEffect", "SelfShockEffect" },
@@ -4413,6 +4414,7 @@ local specialModList = {
 	["(%d+)%% chance to inflict withered for two seconds on hit if there are (%d+) or fewer withered debuffs on enemy"] = { flag("Condition:CanWither") },
 	["inflict withered for (%d+) seconds on hit with this weapon"] = { flag("Condition:CanWither") },
 	["minions have (%d+)%% chance to inflict withered on hit"] = { flag("Condition:CanWither") },
+	["withered you inflict also increases fire damage taken"] = { flag("WitherIncreasesFireDamageTaken") }, -- Blackflame
 	["enemies take (%d+)%% increased elemental damage from your hits for each withered you have inflicted on them"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("ElementalDamageTaken", "INC", num, { type = "Multiplier", var = "WitheredStack", limit = 15 }) }) } end,
 	["enemies you apply incision to take (%d+)%% increased physical damage per incision"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("PhysicalDamageTaken", "INC", num, { type = "Multiplier", var = "IncisionStack" }) }) } end,
 	["your hits cannot penetrate or ignore elemental resistances"] = { flag("CannotElePenIgnore") },


### PR DESCRIPTION
### Description of the problem being solved:
Path of Building had no model for **Infernal Legion** ignite minion builds or the ignite-scaling mechanics around them. This adds:

- **Infernal Legion** — the always-active minion ignite, modelled as a pseudo-hit that ignites "as though dealing X% of the minion's max life as fire". Added/gained non-fire damage folds into the ignite only when a matching `<Type>CanIgnite` source is present (e.g. Xoph's Pyre, Catha's). Its crit is seeded only by the enemy's Critical Weakness, with the minion's *increased* crit chance and crit damage at half effectiveness and a 50% base crit bonus — fit to in-game ignite-crit timing tests.
- **Stormfire** — shocked enemies take part of the Ignite as extra Lightning; scans all active skills so it applies cross-skill and to minion Ignite.
- **Blackflame** — "Withered you inflict also increases Fire Damage taken".
- **Frost Bomb** — models compounding Elemental Exposure via a pulse-count config.
- **Catha's Brilliance / Scouring Flame / Infernal Legion support** — wired to the IL ignite model.
- **"Is the Ignite Aggravated?" config** (100% more Ignite damage).
- Minion "increased Magnitude of Damaging Ailments" gear now flows into the minion's ignite.

### Steps taken to verify a working solution:
- Added `spec/System/TestInfernalLegion_spec.lua` (9 tests): minion ailment-magnitude propagation (parse + end-to-end), the pseudo-hit (no hit DPS, and no Poison seeded), the 50% base / half-effective crit damage, Aggravated Ignite doubling, and Full-DPS stability.
- Confirmed existing `TestAilments`/`TestAttacks` still pass (normal hits/ailments untouched).
- **Extensively tested in-game with OtterJones to pin down IL's crit scaling: the
  collected numbers only lined up with the minion's increased crit applying at
  half effectiveness (together with the rolling-ignite over-stack model).**

### Link to a build that showcases this PR:
- moons_army (Moonlife): https://poe.ninja/poe2/profile/darmousseh-4737/runesofaldur/character/moons_army
- BigLichMommy (1HundredGrade): https://poe.ninja/poe2/profile/traize784-7234/runesofaldur/character/BigLichMommy

### Before screenshot:
Existing PoB — IL's ignite is unmodelled (Best Ignite DPS 1,662, Full DPS 277,055):

![Before — existing PoB](https://raw.githubusercontent.com/turlockmike/PathOfBuilding-PoE2/pr-assets/screenshots/before_existing_pob.png)

### After screenshot:
This PR — IL's ignite is modelled (Best Ignite DPS 4,293,499, Full DPS 4,706,882):

![After — this PR](https://raw.githubusercontent.com/turlockmike/PathOfBuilding-PoE2/pr-assets/screenshots/after_this_pr.png)
