### PR TITLE
Fix colour of Fractured crafted mods on items

### DIFF
--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -53,7 +53,7 @@ function itemLib.formatValue(value, baseValueScalar, valueScalar, precision, dis
 	elseif displayPrecision then
 		return tostring(value, displayPrecision)
 	else
-		return tostring(roundSymmetric(value,  precision and m_min(2, m_floor(math.log(precision, 10) + 0.001)) or 2)) -- max decimals ingame is 2 
+		return tostring(roundSymmetric(value,  precision and m_min(2, m_floor(math.log(precision, 10) + 0.001)) or 2)) -- max decimals ingame is 2
 	end
 end
 
@@ -117,7 +117,7 @@ function itemLib.applyRange(line, range, valueScalar, baseValueScalar)
 					modifiedLine = replaceNthInstance(modifiedLine, "#", values[i], i - substituted)
 					substituted = substituted + 1
 				end
-	
+
 				-- Check if the modified line matches any scalability data
 				local key = modifiedLine:gsub("+#", "#")
 				if data.modScalability[key] then
@@ -339,7 +339,7 @@ function itemLib.formatModLine(modLine, dbMode)
 			line = line .. "   ^1'" .. modLine.extra .. "'"
 		end
 	else
-		colorCode = (modLine.crafted and colorCodes.CRAFTED) or (modLine.enchant and colorCodes.ENCHANTED) or (modLine.fractured and colorCodes.FRACTURED) or (modLine.mutated and colorCodes.MUTATED) or (modLine.custom and (not modLine.desecrated and colorCodes.CUSTOM)) or colorCodes.MAGIC
+		colorCode = (modLine.fractured and colorCodes.FRACTURED) or (modLine.crafted and colorCodes.CRAFTED) or (modLine.enchant and colorCodes.ENCHANTED) or (modLine.mutated and colorCodes.MUTATED) or (modLine.custom and (not modLine.desecrated and colorCodes.CUSTOM)) or colorCodes.MAGIC
 	end
 	return colorCode..line
 end


### PR DESCRIPTION
### Description of the problem being solved:
Mods that are both crafted and fractured should be the fractured color in the tooltip.

### After screenshot:
<img width="393" height="314" alt="image" src="https://github.com/user-attachments/assets/61fcaa09-ed29-4dbc-b935-0c6eec10d7da" />
<img width="477" height="358" alt="image" src="https://github.com/user-attachments/assets/a6b89096-8af6-4366-807e-18ce72174cfb" />
