### PR TITLE
Fix Time-Lost jewel bonuses applying across weapon sets

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -160,11 +160,11 @@ function calcs.buildModListForNode(env, node, incSmallPassiveSkill, includeKeyst
 					refreshJewelStatCache(env)
 				end
 				if node.type == "Normal" and node.isAttribute and cache and #cache.attributeModList > 0 then
-					modList:AddList(cache.attributeModList)
+					modList:CopyList(cache.attributeModList)
 				elseif node.type == "Normal" and not node.isAttribute and cache and #cache.smallModList > 0 then
-					modList:AddList(cache.smallModList)
+					modList:CopyList(cache.smallModList)
 				elseif node.type == "Notable" and cache and #cache.notableModList > 0 then
-					modList:AddList(cache.notableModList)
+					modList:CopyList(cache.notableModList)
 				end
 				break
 			end


### PR DESCRIPTION
Fixes #2330 .

### Description of the problem being solved:
Time-Lost jewel bonuses were incorrectly applying to notables allocated 
in weapon set 2 even when viewing weapon set 1.

### Steps taken to verify a working solution:
- Re-allocated passives on each weapon sets with a timeless jewel to check change in stats

### Link to a build that showcases this PR:

### Before screenshot:
<img width="1891" height="402" alt="614851415-7a493ad6-3f07-499e-be76-bdc215bdf9d6" src="https://github.com/user-attachments/assets/9032604c-69ca-4956-9c1b-dad4fa0673a4" />

### After screenshot:
<img width="2293" height="298" alt="image" src="https://github.com/user-attachments/assets/c4906c05-0933-474a-9891-e9bb7e216312" />
