### PR TITLE
Add support for Gemling's additional quality Stats

### DIFF
--- a/spec/System/TestSkillsTab_spec.lua
+++ b/spec/System/TestSkillsTab_spec.lua
@@ -321,7 +321,7 @@ describe("TestSkillsTab", function()
 					label = "Test Group",
 					enabled = true,
 					gemList = {
-						{ nameSpec = "TestGem", level = 20, quality = 0, qualityId = "Default", enabled = true, count = 1 }
+						{ nameSpec = "TestGem", level = 20, quality = 0, enabled = true, count = 1 }
 					}
 				}
 

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -63,6 +63,45 @@ describe("TestSkills", function()
 		assertGemSupportLevel("Apocalypse", 3, 4)
 	end)
 
+	it("applies Advanced Thaumaturgy quality stats only when enabled", function()
+		local advancedThaumaturgy = build.spec.nodes[14429]
+		assert.is_not_nil(advancedThaumaturgy)
+		assert.True(advancedThaumaturgy.modList:Flag(nil, "GemlingQuality"))
+
+		local grantedEffect = data.skills["AlchemistsBoonPlayer"]
+		local statSet = grantedEffect.statSets[1]
+		local skillInstance = {
+			level = 20,
+			quality = 20,
+		}
+
+		local stats = calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet)
+		assert.is_not_nil(stats["skill_alchemists_boon_generate_x_charges_for_any_flask_per_minute"])
+		assert.is_nil(stats["alchemists_boon_attack_speed_granted_+%_during_life_flask"])
+		assert.is_nil(stats["alchemists_boon_cast_speed_granted_+%_during_mana_flask"])
+
+		stats = calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet, true)
+		assert.are.equals(20, stats["alchemists_boon_attack_speed_granted_+%_during_life_flask"])
+		assert.are.equals(20, stats["alchemists_boon_cast_speed_granted_+%_during_mana_flask"])
+	end)
+
+	it("describes quality stats from secondary skill stat sets", function()
+		local grantedEffect = data.skills["ExplosiveSpearPlayer"]
+		local qualityStat = grantedEffect.qualityStats[1]
+		local stats = {
+			active_skill_base_area_of_effect_radius = 4,
+		}
+
+		assert.same({ 1, 2 }, qualityStat[3])
+		local firstDescriptions = build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope, true)
+		local qualityStatSet = grantedEffect.statSets[qualityStat[3][1] + 1]
+		local qualityDescriptions = build.data.describeStats(stats, qualityStatSet.statDescriptionScope, true)
+
+		assert.are.equals(0, #firstDescriptions)
+		assert.is_true(#qualityDescriptions > 0)
+		assert.matches("Explosion radius", qualityDescriptions[1])
+	end)
+
 
 	it("uses granted effect minion list when active skill minion list is missing", function()
 		local srcInstance = { statSet = { }, skillPart = { }, nameSpec = "Spectre: Test" }

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2973,7 +2973,6 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 							nameSpec = cGem.nameSpec,
 							level = cGem.level,
 							quality = cGem.quality,
-							qualityId = cGem.qualityId,
 							enabled = cGem.enabled,
 							grantedEffect = cGem.grantedEffect,
 							gemData = cGem.gemData,

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -471,6 +471,7 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 				-- Rebuilding this tooltip runs a full build calculation, so only rebuild when the hovered gem or the underlying build changes
 				if self.tooltip:CheckForUpdate(gemData, self.skillsTab.build.outputRevision, self.skillsTab.displayGroup, self.skillsTab.sortGemsByDPSField,
 						self.skillsTab.defaultGemLevel, self.skillsTab.defaultGemQuality, self.skillsTab.defaultCorruptionLevel, self.skillsTab.defaultCorruptionState) then
+					self.tooltip.maxWidth = 500
 					-- No fastCalcOptions here: the tooltip's stat compare shows defensive stats too, so it needs the full (unaccelerated) calc
 					local output = self:CalcOutputWithThisGem(calcFunc, gemData, self.skillsTab.sortGemsByDPSField == "FullDPS")
 					local gemInstance = {

--- a/src/Classes/GemTooltip.lua
+++ b/src/Classes/GemTooltip.lua
@@ -11,7 +11,7 @@ local function getFontSizes()
 	return main.showFlavourText and 18 or 16, main.showFlavourText and 24 or 20
 end
 
-local function addDescriptionLine(tooltip, build, statSet, line, stat, index)
+local function addDescriptionLine(tooltip, build, statSet, line, stat, index, colorCode)
 	local fontSizeBig = getFontSizes()
 	local source = statSet.statMap[stat] or build.data.skillStatMap[stat]
 	local bg = (index % 2 == 0) and "GemHoverModBg" or nil
@@ -26,7 +26,7 @@ local function addDescriptionLine(tooltip, build, statSet, line, stat, index)
 			end
 			line = line .. " ^2" .. devText
 		end
-		tooltip:AddLine(fontSizeBig, colorCodes.MAGIC .. line, "FONTIN SC", bg)
+		tooltip:AddLine(fontSizeBig, (colorCode or colorCodes.MAGIC) .. line, "FONTIN SC", bg)
 	else
 		if launch.devModeAlt then
 			line = line .. " ^1" .. stat
@@ -206,6 +206,7 @@ end
 local function addStatSetInfo(tooltip, build, gemInstance, grantedEffect, statSet, noLabel, index, levelRange)
 	local fontSizeBig, fontSizeTitle = getFontSizes()
 	local displayInstance = getDisplayInstance(gemInstance)
+	local includeAltQualityStats = build.calcsTab.mainEnv.modDB:Flag(nil, "GemlingQuality")
 	local statSetLevel = statSet.levels[levelRange and gemInstance.level or displayInstance.level] or statSet.levels[1] or { }
 	if not (index == 1 and statSet.label == grantedEffect.name) and statSet.label ~= "" and not noLabel then
 		tooltip:AddSeparator(10)
@@ -226,18 +227,25 @@ local function addStatSetInfo(tooltip, build, gemInstance, grantedEffect, statSe
 			local copiedInstance = copyTable(gemInstance, true)
 			copiedInstance.quality = 0
 			copiedInstance.level = 20
-			local statsLevel20 = calcLib.buildSkillInstanceStats(copiedInstance, grantedEffect, statSet)
+			local statsLevel20 = calcLib.buildSkillInstanceStats(copiedInstance, grantedEffect, statSet, includeAltQualityStats)
 			copiedInstance.level = 1
-			stats = calcLib.buildSkillInstanceStats(copiedInstance, grantedEffect, statSet)
+			stats = calcLib.buildSkillInstanceStats(copiedInstance, grantedEffect, statSet, includeAltQualityStats)
 			for statName, min in pairs(stats) do
 				stats[statName] = { min = min, max = statsLevel20[statName] or min }
 			end
 		else
-			stats = calcLib.buildSkillInstanceStats(displayInstance, grantedEffect, statSet)
+			stats = calcLib.buildSkillInstanceStats(displayInstance, grantedEffect, statSet, includeAltQualityStats)
 		end
 		local descriptions, lineMap = build.data.describeStats(stats, statSet.statDescriptionScope)
+		local altQualityStatColor = { }
+		if includeAltQualityStats then
+			for _, stat in ipairs(grantedEffect.altQualityStats or { }) do
+				altQualityStatColor[stat[1]] = colorCodes.ENCHANTED
+			end
+		end
 		for i, line in ipairs(descriptions) do
-			addDescriptionLine(tooltip, build, statSet, line, lineMap[line], i)
+			local stat = lineMap[line]
+			addDescriptionLine(tooltip, build, statSet, line, stat, i, stat and altQualityStatColor[stat])
 		end
 	end
 end
@@ -248,19 +256,29 @@ local function addEffectStats(tooltip, build, gemInstance, grantedEffect, noLabe
 	end
 end
 
-local function addQualityRangeInfo(tooltip, build, grantedEffect, addedHeader)
+local function addQualityRangeInfo(tooltip, build, grantedEffect, addedHeader, includeAltQualityStats)
 	-- Quality ranges are tree-only. SkillsTab shows the 20 quality value separately, but tree nodes need the 0-20 range inline.
-	if not grantedEffect.qualityStats or #grantedEffect.qualityStats == 0 then
+	local qualityStats = { }
+	for _, stat in ipairs(grantedEffect.qualityStats or { }) do
+		qualityStats[#qualityStats + 1] = { stat = stat[1], value = stat[2], statSetIndexes = stat[3], color = colorCodes.MAGIC }
+	end
+	if includeAltQualityStats then
+		for _, stat in ipairs(grantedEffect.altQualityStats or { }) do
+			qualityStats[#qualityStats + 1] = { stat = stat[1], value = stat[2], statSetIndexes = stat[3], color = colorCodes.ENCHANTED }
+		end
+	end
+	if #qualityStats == 0 then
 		return addedHeader
 	end
 	local fontSizeBig = getFontSizes()
 	local lineIndex = 1
-	for _, stat in ipairs(grantedEffect.qualityStats) do
-		if stat[1] and stat[2] then
-			local stats = { [stat[1]] = 20 * stat[2] }
-			local descriptions, lineMap = build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope, true)
+	for _, stat in ipairs(qualityStats) do
+		if stat.stat and stat.value then
+			local stats = { [stat.stat] = 20 * stat.value }
+			local statSet = grantedEffect.statSets[(stat.statSetIndexes[1] or 0) + 1] or grantedEffect.statSets[1]
+			local descriptions, lineMap = build.data.describeStats(stats, statSet.statDescriptionScope, true)
 			for _, line in ipairs(descriptions) do
-				local statName = lineMap[line] or stat[1]
+				local statName = lineMap[line] or stat.stat
 				if not addedHeader then
 					tooltip:AddLine(fontSizeBig, "\n^7Additional Effects From Quality:", "FONTIN SC")
 					addedHeader = true
@@ -273,7 +291,7 @@ local function addQualityRangeInfo(tooltip, build, grantedEffect, addedHeader)
 					end
 					return "(0-" .. value .. ")"
 				end, 1)
-				addDescriptionLine(tooltip, build, grantedEffect.statSets[1], line, statName, lineIndex)
+				addDescriptionLine(tooltip, build, statSet, line, statName, lineIndex, stat.color)
 				lineIndex = lineIndex + 1
 			end
 		end
@@ -343,9 +361,10 @@ function GemTooltip.AddGemTooltip(tooltip, build, gemInstance, options)
 
 	if options.includeQualityRange then
 		local addedHeader
-		addedHeader = addQualityRangeInfo(tooltip, build, grantedEffect, addedHeader)
+		local includeAltQualityStats = build.calcsTab.mainEnv.modDB:Flag(nil, "GemlingQuality")
+		addedHeader = addQualityRangeInfo(tooltip, build, grantedEffect, addedHeader, includeAltQualityStats)
 		for _, effect in ipairs(additionalEffects or { }) do
-			addedHeader = addQualityRangeInfo(tooltip, build, effect, addedHeader)
+			addedHeader = addQualityRangeInfo(tooltip, build, effect, addedHeader, includeAltQualityStats)
 		end
 	end
 

--- a/src/Classes/GemTooltip.lua
+++ b/src/Classes/GemTooltip.lua
@@ -4,6 +4,7 @@
 -- Shared renderer for gem-style tooltips.
 
 local m_max = math.max
+local m_min = math.min
 
 local GemTooltip = { }
 
@@ -306,6 +307,7 @@ function GemTooltip.AddGemTooltip(tooltip, build, gemInstance, options)
 	tooltip.center = false
 	tooltip.color = colorCodes.GEM
 	tooltip.minWidth = 600
+	tooltip.maxWidth = m_min(tooltip.maxWidth or 600, 600)
 	tooltip.tooltipHeader = "GEM"
 	tooltip.gemIcon = gemInstance.gemData.grantedEffect.icon
 	tooltip.gemBackground = gemInstance.gemData.grantedEffect.id

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -890,6 +890,25 @@ function SkillsTabClass:CreateGemSlot(index)
 		if not gemData then
 			return
 		end
+		local includeAltQualityStats = self.build.calcsTab.mainEnv.modDB:Flag(nil, "GemlingQuality")
+		local hasQualityStats = function(grantedEffect)
+			return grantedEffect and (
+				(grantedEffect.qualityStats and #grantedEffect.qualityStats > 0) or
+				(includeAltQualityStats and grantedEffect.altQualityStats and #grantedEffect.altQualityStats > 0)
+			)
+		end
+		local getQualityStats = function(grantedEffect)
+			local qualityStats = { }
+			for _, stat in ipairs(grantedEffect.qualityStats or { }) do
+				qualityStats[#qualityStats + 1] = { stat = stat[1], value = stat[2], statSetIndexes = stat[3], color = colorCodes.MAGIC }
+			end
+			if includeAltQualityStats then
+				for _, stat in ipairs(grantedEffect.altQualityStats or { }) do
+					qualityStats[#qualityStats + 1] = { stat = stat[1], value = stat[2], statSetIndexes = stat[3], color = colorCodes.ENCHANTED }
+				end
+			end
+			return qualityStats
+		end
 		-- Function for both granted effect and secondary such as vaal
 		local addQualityLines = function(qualityList, grantedEffect)
 			if #qualityList > 0 then
@@ -900,17 +919,19 @@ function SkillsTabClass:CreateGemSlot(index)
 				end
 				-- Hardcoded to use 20% quality instead of grabbing from gem, this is for consistency and so we always show something
 				tooltip:AddLine(16, colorCodes.NORMAL.."At +20% Quality:")
-				for k, qual in pairs(qualityList) do
+				for _, qual in ipairs(qualityList) do
 					-- Do the stats one at a time because we're not guaranteed to get the descriptions in the same order we look at them here
 					local stats = { }
-					stats[qual[1]] = qual[2] * 20
-					local descriptions = self.build.data.describeStats(stats, grantedEffect.statSets[1].statDescriptionScope, true)
+					stats[qual.stat] = qual.value * 20
+					local statSet = grantedEffect.statSets[(qual.statSetIndexes[1] or 0) + 1] or grantedEffect.statSets[1]
+					local descriptions, lineMap = self.build.data.describeStats(stats, statSet.statDescriptionScope, true)
 					-- line may be nil if the value results in no line due to not being enough quality
 					for _, line in ipairs(descriptions) do
 						if line then
+							local statName = lineMap[line] or qual.stat
 							-- Check if we have a handler for the mod in the gem's statMap or in the shared stat map for skills
-							if grantedEffect.statSets[1].statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
-								tooltip:AddLine(16, colorCodes.MAGIC..line)
+							if statSet.statMap[statName] or self.build.data.skillStatMap[statName] then
+								tooltip:AddLine(16, qual.color..line)
 							else
 								local line = colorCodes.UNSUPPORTED..line
 								line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
@@ -921,24 +942,22 @@ function SkillsTabClass:CreateGemSlot(index)
 				end
 			end
 		end
-		-- Check if there is a quality of this type for the effect
-		-- Currently only checks the first 2 additionalGrantedEffects. Will need to fix if gems ever add more
-		if gemData and gemData.grantedEffect.qualityStats and #gemData.grantedEffect.qualityStats > 0 then
-			local qualityTable = gemData.grantedEffect.qualityStats
-			addQualityLines(qualityTable, gemData.grantedEffect)
+		local qualityStatsShown = false
+		if hasQualityStats(gemData.grantedEffect) then
+			addQualityLines(getQualityStats(gemData.grantedEffect), gemData.grantedEffect)
+			qualityStatsShown = true
 		end
-		if gemData and gemData.additionalGrantedEffects[1] and gemData.additionalGrantedEffects[1].qualityStats and #gemData.additionalGrantedEffects[1].qualityStats > 0 then
-			local qualityTable = gemData.additionalGrantedEffects[1].qualityStats
-			tooltip:AddSeparator(10)
-			addQualityLines(qualityTable, gemData.additionalGrantedEffects[1])
-		end
-		if gemData and gemData.additionalGrantedEffects[2] and gemData.additionalGrantedEffects[2].qualityStats and #gemData.additionalGrantedEffects[2].qualityStats > 0  then
-			local qualityTable = gemData.additionalGrantedEffects[2].qualityStats
-			tooltip:AddSeparator(10)
-			addQualityLines(qualityTable, gemData.additionalGrantedEffects[2])
+		for _, effect in ipairs(gemData.additionalGrantedEffects or { }) do
+			if hasQualityStats(effect) then
+				if qualityStatsShown then
+					tooltip:AddSeparator(10)
+				end
+				addQualityLines(getQualityStats(effect), effect)
+				qualityStatsShown = true
+			end
 		end
 		-- Add stat comparisons for hovered quality (based on set quality)
-		if gemData and (gemData.grantedEffect.qualityStats or (gemData.additionalGrantedEffects[1] and gemData.additionalGrantedEffects[1].qualityStats or gemData.additionalGrantedEffects[2] and gemData.additionalGrantedEffects[2].qualityStats)) and self.displayGroup.gemList[index] then
+		if qualityStatsShown and self.displayGroup.gemList[index] then
 			local calcFunc, calcBase = self.build.calcsTab:GetMiscCalculator(self.build)
 			if calcFunc then
 				local storedQuality = self.displayGroup.gemList[index].quality

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5680,7 +5680,7 @@ c["Gain no inherent bonuses from Attributes"]={{[1]={flags=0,keywordFlags=0,name
 c["Gain the benefits of Bonded modifiers on Runes and Idols"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanUseBondedModifiers",type="FLAG",value=true}},nil}
 c["Gains 0.18 Charges per Second"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesGenerated",type="BASE",value=0.18}},nil}
 c["Gains 0.20 Charges per Second"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesGenerated",type="BASE",value=0.2}},nil}
-c["Gem Quality grants Socketed Skills an additional effect"]={nil,"Gem Quality grants Socketed Skills an additional effect "}
+c["Gem Quality grants Socketed Skills an additional effect"]={{[1]={flags=0,keywordFlags=0,name="GemlingQuality",type="FLAG",value=true}},nil}
 c["Giant's Blood"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Giant's Blood"}},nil}
 c["Glancing Blows"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Glancing Blows"}},nil}
 c["Glorifying the defilement of 4050 souls in tribute to Ulaman"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="conqueredBy",value={conqueror={id=5,type="abyss"},id=4050}}}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -352,6 +352,9 @@ return {
 ["support_deliberation_movement_speed_penalty_+%_final_while_performing_action"] = {
 	mod("MovementSpeedPenalty", "MORE", nil),
 },
+["movement_speed_penalty_+%_while_performing_action"] = {
+	mod("MovementSpeedPenalty", "INC", nil),
+},
 --
 -- Defensive modifiers
 --
@@ -792,6 +795,9 @@ return {
 ["chance_for_extra_damage_roll_%"] = {
 	mod("LuckyHitsChance", "BASE", nil)
 },
+["chance_for_extra_damage_roll_with_lightning_damage_%"] = {
+	mod("LightningLuckyHitsChance", "BASE", nil)
+},
 ["chance_to_deal_double_damage_%"] = {
 	mod("DoubleDamageChance", "BASE", nil)
 },
@@ -925,6 +931,9 @@ return {
 },
 ["active_skill_damage_+%_final_vs_immobilised_enemies"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Immobilised" }),
+},
+["active_skill_damage_+%_final_vs_burning_enemies"] = {
+	mod("Damage", "MORE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Burning" }),
 },
 ["base_reduce_enemy_fire_resistance_%"] = {
 	mod("FirePenetration", "BASE", nil),
@@ -1078,7 +1087,10 @@ return {
 	mod("PhysicalDamageGainAsLightning", "BASE", nil),
 },
 ["active_skill_base_physical_damage_%_to_gain_as_cold"] = {
-	mod("SkillPhysicalDamageGainAsCold", "BASE", nil),
+	mod("PhysicalDamageGainAsCold", "BASE", nil),
+},
+["active_skill_base_physical_damage_%_to_gain_as_fire"] = {
+	mod("PhysicalDamageGainAsFire", "BASE", nil),
 },
 ["physical_damage_%_to_add_as_cold"] = {
 	mod("PhysicalDamageGainAsCold", "BASE", nil),
@@ -1104,14 +1116,29 @@ return {
 ["lightning_damage_%_to_add_as_chaos"] = {
 	mod("LightningDamageGainAsChaos", "BASE", nil),
 },
+["active_skill_base_all_damage_%_to_gain_as_physical"] = {
+	mod("DamageGainAsPhysical", "BASE", nil),
+},
+["active_skill_base_all_damage_%_to_gain_as_lightning"] = {
+	mod("DamageGainAsLightning", "BASE", nil),
+},
 ["non_skill_base_all_damage_%_to_gain_as_lightning"] = {
 	mod("DamageGainAsLightning", "BASE", nil),
+},
+["active_skill_base_all_damage_%_to_gain_as_cold"] = {
+	mod("DamageGainAsCold", "BASE", nil),
 },
 ["non_skill_base_all_damage_%_to_gain_as_cold"] = {
 	mod("DamageGainAsCold", "BASE", nil),
 },
+["active_skill_base_all_damage_%_to_gain_as_fire"] = {
+	mod("DamageGainAsFire", "BASE", nil),
+},
 ["non_skill_base_all_damage_%_to_gain_as_fire"] = {
 	mod("DamageGainAsFire", "BASE", nil),
+},
+["active_skill_base_all_damage_%_to_gain_as_chaos"] = {
+	mod("DamageGainAsChaos", "BASE", nil),
 },
 ["non_skill_base_all_damage_%_to_gain_as_chaos"] = {
 	mod("DamageGainAsChaos", "BASE", nil),
@@ -2763,6 +2790,9 @@ return {
 ["base_reservation_efficiency_+%"] = {
 	mod("ReservationEfficiency", "INC", nil)
 },
+["base_spirit_reservation_efficiency_+%"] = {
+	mod("SpiritReservationEfficiency", "INC", nil)
+},
 -- Brand
 ["sigil_attached_target_damage_+%_final"] = {
 	mod("Damage", "MORE", nil, 0, 0, { type = "MultiplierThreshold", var = "BrandsAttachedToEnemy", threshold = 1 }),
@@ -2960,6 +2990,9 @@ return {
 ["minions_deal_no_damage"] = {
 	mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil) }),
 	value = -100,
+},
+["minion_damage_taken_+%"] = {
+	mod("MinionModifier", "LIST", { mod = mod("DamageTaken", "INC", nil) }),
 },
 ["base_cannot_be_stunned"] = {
 	flag("StunImmune"),

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -1547,7 +1547,9 @@ return {
 ["active_skill_pins_as_though_dealt_damage_+%_final"] = {
 	mod("EnemyPinBuildup", "MORE", nil),
 },
-
+["hit_damage_immobilisation_multiplier_+%"] = {
+	mod("EnemyImmobilisationBuildup", "INC", nil),
+},
 -- Global flags
 ["never_ignite"] = {
 	flag("CannotIgnite"),

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -74,6 +74,12 @@ skills["AlchemistsBoonPlayer"] = {
 					mod("FlaskChargesGenerated", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }),
 					div = 60,
 				},
+				["alchemists_boon_attack_speed_granted_+%_during_life_flask"] = {
+					mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }, { type = "Condition", var = "UsingLifeFlask" }),
+				},
+				["alchemists_boon_cast_speed_granted_+%_during_mana_flask"] = {
+					mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }, { type = "Condition", var = "UsingManaFlask" }),
+				},
 				--["recovery_from_flasks_applies_to_allies_in_presence_%"] = {
 				-- how to apply this in calc perform?
 					--mod("FlasksApplyToMinionPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
@@ -1562,6 +1568,12 @@ skills["ElectrocutingArrowPlayer"] = {
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "electrocuting_arrow",
 			statMap = {
+				["electrocuting_arrow_%_damage_gained_as_extra_lightning_on_debuffed_target"] = {
+					mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+				},
+				["electrocuting_arrow_damage_taken_+%"] = {
+					mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }),
+				},
 				["quality_display_base_skill_effect_duration_is_gem"] = {
 					-- Display only
 				},
@@ -3569,6 +3581,9 @@ skills["HeraldOfThunderPlayer"] = {
 				["herald_of_thunder_storm_max_hits"] = {
 					mod("HeraldOfThunderHits", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Thunder" }),
 				},
+				["herald_of_thunder_lightning_damage_+%"] = {
+					mod("LightningDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Thunder" }),
+				},
 			},
 			baseFlags = {
 			},
@@ -5518,6 +5533,9 @@ skills["PlagueBearerPlayer"] = {
 				["plague_bearer_maximum_stored_poison_damage"] = {
 					mod("PlagueBearerMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Plague Bearer" }),
 				},
+				["poison_effect_+%_vs_non_poisoned_enemies"] = {
+					mod("AilmentMagnitude", "INC", nil, 0, KeywordFlag.Poison, { type = "GlobalEffect", effectType = "Buff", effectName = "Plague Bearer" }, { type = "MultiplierThreshold", actor = "enemy", var = "PoisonStacks", threshold = 1, upper = true }),
+				},
 			},
 			baseFlags = {
 			},
@@ -5760,6 +5778,11 @@ skills["PoisonBurstArrowPlayer"] = {
 			label = "Arrow",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "poison_burst_arrow",
+			statMap = {
+				["armour_break_for_%_of_poison_damage_over_poison_duration"] = {
+					flag("Condition:CanArmourBreak", { type = "GlobalEffect", effectType = "Buff", effectName = "ArmourBreak" }),
+				},
+			},
 			baseFlags = {
 				attack = true,
 				projectile = true,
@@ -7559,6 +7582,9 @@ skills["SnipersMarkPlayer"] = {
 			statMap = {
 				["enemy_additional_critical_strike_multiplier_against_self"] = {
 					mod("SelfCritMultiplier", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+				},
+				["gem_quality_marked_enemy_damage_dealt_+%_final"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
 				},
 			},
 			baseFlags = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -16,7 +16,11 @@ skills["AlchemistsBoonPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Aura] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_alchemists_boon_generate_x_charges_for_any_flask_per_minute", 0.1 },
+		{ "skill_alchemists_boon_generate_x_charges_for_any_flask_per_minute", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "alchemists_boon_attack_speed_granted_+%_during_life_flask", 1, {  } },
+		{ "alchemists_boon_cast_speed_granted_+%_during_mana_flask", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -145,7 +149,10 @@ skills["BarragePlayer"] = {
 	},
 	castTime = 0.7,
 	qualityStats = {
-		{ "empower_barrage_damage_-%_final_with_repeated_projectiles", -0.25 },
+		{ "empower_barrage_damage_-%_final_with_repeated_projectiles", -0.25, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 2, levelRequirement = 0, storedUses = 1, cost = { Mana = 11, }, },
@@ -298,7 +305,10 @@ skills["BloodHuntPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 1 } },
+	},
+	altQualityStats = {
+		{ "blood_hunt_explosion_%_blood_loss_to_deal_as_life_loss", 0.2, { 1 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -486,7 +496,9 @@ skills["BloodhoundsMarkPlayer"] = {
 	skillTypes = { [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Mark] = true, [SkillType.Limit] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMounted] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "hunters_mark_%_of_phys_damage_over_time_as_build_up", 2.5 },
+		{ "hunters_mark_%_of_phys_damage_over_time_as_build_up", 2.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 18, }, },
@@ -608,7 +620,10 @@ skills["BloodhoundsMarkExplosionPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Physical] = true, [SkillType.UseGlobalStats] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, [SkillType.NonWeaponAttack] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -736,7 +751,10 @@ skills["CombatFrenzyPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.GeneratesCharges] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "chance_to_gain_1_more_charge_%", 0.5 },
+		{ "chance_to_gain_1_more_charge_%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "skill_combat_frenzy_x_ms_cooldown", -50, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -855,7 +873,10 @@ skills["SummonBeastPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.Chains] = true, [SkillType.Duration] = true, [SkillType.SummonsTotem] = true, [SkillType.Trapped] = true, [SkillType.RemoteMined] = true, [SkillType.DamageOverTime] = true, [SkillType.Channel] = true, [SkillType.RangedAttack] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Cooldown] = true, [SkillType.Barrageable] = true, [SkillType.Cascadable] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_minion_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -981,7 +1002,10 @@ skills["CullTheWeakPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "chance_to_gain_1_more_charge_%", 1 },
+		{ "chance_to_gain_1_more_charge_%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_gain_1_more_random_charge_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.9, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -1107,7 +1131,10 @@ skills["DetonatingArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "detonating_arrow_max_number_of_stages", 0.05 },
+		{ "detonating_arrow_max_number_of_stages", 0.05, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_ignite_effect_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -55, baseMultiplier = 0.53, levelRequirement = 0, cost = { ManaPerMinute = 409, }, },
@@ -1283,7 +1310,10 @@ skills["DisengagePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "disengage_%_chance_for_additional_shockwave", 1 },
+		{ "disengage_%_chance_for_additional_shockwave", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "melee_range_+", 0.5, { 0 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.85, cooldown = 1.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 5, }, },
@@ -1479,7 +1509,10 @@ skills["ElectrocutingArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "electrocuting_arrow_%_damage_gained_as_extra_lightning_on_debuffed_target", 0.5 },
+		{ "electrocuting_arrow_%_damage_gained_as_extra_lightning_on_debuffed_target", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "electrocuting_arrow_damage_taken_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 10, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -1617,7 +1650,10 @@ skills["ElementalSunderingPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_critical_strike_chance_+%_final", 1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -45, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -1926,7 +1962,10 @@ skills["EscapeShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 6 },
+		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 6, {  } },
+	},
+	altQualityStats = {
+		{ "damage_+%_vs_frozen_enemies", 2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.65, levelRequirement = 0, cost = { Mana = 11, }, },
@@ -2052,6 +2091,8 @@ skills["EscapeShotIceFragmentPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.RangedAttack] = true, [SkillType.Projectile] = true, [SkillType.Attack] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.6, levelRequirement = 0, },
@@ -2182,7 +2223,10 @@ skills["ExplosiveSpearPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 1, 2 } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -2468,7 +2512,10 @@ skills["FangsOfFrostPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "chance_to_not_consume_parried_%", 0.75 },
+		{ "chance_to_not_consume_parried_%", 0.75, { 0 } },
+	},
+	altQualityStats = {
+		{ "melee_range_+", 0.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.95, levelRequirement = 0, cost = { Mana = 4, }, },
@@ -2667,7 +2714,10 @@ skills["FreezingSalvoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 2 },
+		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 2, {  } },
+	},
+	altQualityStats = {
+		{ "base_maximum_seals_for_skill", 0.2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.48, levelRequirement = 0, cost = { Mana = 15, }, },
@@ -2803,7 +2853,10 @@ skills["GasArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 0, 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 1, { 2 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.3, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -3086,7 +3139,10 @@ skills["GlacialLancePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 1.3, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -3323,7 +3379,10 @@ skills["HeraldOfPlaguePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "hinder_chance_%_on_spreading_poioson", 1 },
+		{ "hinder_chance_%_on_spreading_poioson", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -3454,7 +3513,10 @@ skills["HeraldOfThunderPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "herald_of_thunder_storm_max_hits", 0.1 },
+		{ "herald_of_thunder_storm_max_hits", 0.1, { 0 } },
+	},
+	altQualityStats = {
+		{ "herald_of_thunder_lightning_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -3632,7 +3694,10 @@ skills["IceShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_chill_effect_+%_final", 1.5 },
+		{ "active_skill_chill_effect_+%_final", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "movement_speed_penalty_+%_while_performing_action", -2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -10, baseMultiplier = 0.95, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -3833,7 +3898,10 @@ skills["IceTippedArrowsPlayer"] = {
 	},
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "shearing_bolts_number_of_empowered_attacks", 0.1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 12, levelRequirement = 0, storedUses = 1, cost = { Mana = 14, }, },
@@ -3948,6 +4016,8 @@ skills["IceTippedArrowsIceFragmentPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.RangedAttack] = true, [SkillType.Projectile] = true, [SkillType.Attack] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.6, cooldown = 0.15, levelRequirement = 0, storedUses = 1, },
@@ -4076,7 +4146,10 @@ skills["LightningArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_shock_chance_+%_final", 2 },
+		{ "active_skill_shock_chance_+%_final", 2, {  } },
+	},
+	altQualityStats = {
+		{ "chance_for_extra_damage_roll_with_lightning_damage_%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -10, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -4284,7 +4357,10 @@ skills["LightningRodPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "lightning_rod_%_chance_for_additional_burst_on_landing", 1 },
+		{ "lightning_rod_%_chance_for_additional_burst_on_landing", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, baseMultiplier = 0.26, levelRequirement = 0, cost = { Mana = 4, }, },
@@ -4414,7 +4490,10 @@ skills["LightningSpearPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.1 },
+		{ "base_number_of_projectiles", 0.1, { 1 } },
+	},
+	altQualityStats = {
+		{ "chance_%_to_double_effect_of_removing_charges", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -4635,7 +4714,10 @@ skills["MagneticSalvoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.2 },
+		{ "base_number_of_projectiles", 0.2, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_lightning_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -50, baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 24, }, },
@@ -4822,7 +4904,10 @@ skills["MetaMirageArcherPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
@@ -4929,6 +5014,8 @@ skills["SupportMirageArcherPlayer"] = {
 	excludeSkillTypes = { SkillType.HasUsageCondition, SkillType.Melee, SkillType.Meta, SkillType.Triggered, SkillType.Persistent, SkillType.UsedByProxy, SkillType.SupportedByMirageArcher, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5048,7 +5135,10 @@ skills["MirageArcherSpawnPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 2, { 0 } },
 	},
 	levels = {
 		[1] = { cooldown = 10, levelRequirement = 0, storedUses = 1, },
@@ -5167,7 +5257,9 @@ skills["PhantasmalArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_ignite_chance_+%_final", 5 },
+		{ "active_skill_ignite_chance_+%_final", 5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.2, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -5370,7 +5462,10 @@ skills["PlagueBearerPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "plague_bearer_gains_%_of_damage_from_inflicted_poisons", 0.1 },
+		{ "plague_bearer_gains_%_of_damage_from_inflicted_poisons", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "poison_effect_+%_vs_non_poisoned_enemies", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -5485,6 +5580,8 @@ skills["PlagueBearerNovaPlayer"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Nova] = true, [SkillType.Physical] = true, [SkillType.Chaos] = true, [SkillType.Damage] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5611,7 +5708,10 @@ skills["PoisonBurstArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_poison_effect_+%_final", 0.5 },
+		{ "active_skill_poison_effect_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "armour_break_for_%_of_poison_damage_over_poison_duration", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.88, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -5817,7 +5917,10 @@ skills["PrimalStrikesPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attack_speed_+%", 1 },
+		{ "attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_critical_strike_chance_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -6097,7 +6200,10 @@ skills["RainOfArrowsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "rain_of_arrows_arrow_speed_+%", 1 },
+		{ "rain_of_arrows_arrow_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 15, }, },
@@ -6243,7 +6349,10 @@ skills["RakePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_additional_damage_from_distance_+%_final", 1.5 },
+		{ "base_additional_damage_from_distance_+%_final", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_aggravate_bleeding_on_attack_hit_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -6379,7 +6488,10 @@ skills["RapidAssaultPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "rapid_assault_%_chance_to_attach_additional_spear", 1 },
+		{ "rapid_assault_%_chance_to_attach_additional_spear", 1, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_bleeding_effect_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -60, baseMultiplier = 0.25, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -6632,7 +6744,10 @@ skills["RhoaMountPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -6751,7 +6866,9 @@ skills["ShatteringSpitePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.25, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -6876,7 +6993,10 @@ skills["ShockchainArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_lightning_damage_+%_final", 1 },
+		{ "active_skill_lightning_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.7, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -7083,7 +7203,11 @@ skills["SnipePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 1, 2, 3 } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, { 0 } },
+		{ "perfect_timing_window_ms_+%", 1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -55, levelRequirement = 0, cost = { ManaPerMinute = 1053, }, },
@@ -7379,7 +7503,10 @@ skills["SnipersMarkPlayer"] = {
 	skillTypes = { [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.GeneratesCharges] = true, [SkillType.Mark] = true, [SkillType.Cooldown] = true, [SkillType.Limit] = true, [SkillType.UsableWhileMounted] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "enemy_additional_critical_strike_multiplier_against_self", 0.75 },
+		{ "enemy_additional_critical_strike_multiplier_against_self", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "gem_quality_marked_enemy_damage_dealt_+%_final", -0.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, cost = { Mana = 18, }, },
@@ -7509,7 +7636,10 @@ skills["SpearOfSolarisPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "chance_to_retain_40%_of_glory_on_use_%", 1.25 },
+		{ "chance_to_retain_40%_of_glory_on_use_%", 1.25, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, cost = { Mana = 13, }, },
@@ -7789,7 +7919,10 @@ skills["SpearfieldPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "hazard_rearm_%_chance", 0.5 },
+		{ "hazard_rearm_%_chance", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -7989,7 +8122,10 @@ skills["SpiralVolleyPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.2 },
+		{ "base_number_of_projectiles", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "chance_%_to_double_effect_of_removing_charges", 1.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.66, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -8127,7 +8263,10 @@ skills["StormLancePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_overcharged_spears_allowed", 0.05 },
+		{ "base_number_of_overcharged_spears_allowed", 0.05, { 1, 2 } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 0.6, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -8508,7 +8647,10 @@ skills["StormcallerArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "shock_duration_+%", 1.5 },
+		{ "shock_duration_+%", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.2, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -8712,7 +8854,10 @@ skills["TameBeastPlayer"] = {
 	skillTypes = { [SkillType.Minion] = true, [SkillType.Companion] = true, [SkillType.Duration] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 80 },
+		{ "base_skill_effect_duration", 80, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 22, }, },
@@ -8839,7 +8984,10 @@ skills["ThunderousLeapPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "thunderous_leap_%_chance_for_shocked_ground_when_detonating", 1.5 },
+		{ "thunderous_leap_%_chance_for_shocked_ground_when_detonating", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "slam_aftershock_chance_%", 2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 11, }, },
@@ -8963,7 +9111,10 @@ skills["TornadoShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "tornado_shot_projectile_damage_+%_final", 0.75 },
+		{ "tornado_shot_projectile_damage_+%_final", 0.75, { 1 } },
+	},
+	altQualityStats = {
+		{ "base_number_of_tornado_shots_allowed", 0.1, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 13, }, },
@@ -9182,7 +9333,10 @@ skills["ToxicDomainPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.15 },
+		{ "active_skill_base_area_of_effect_radius", 0.15, {  } },
+	},
+	altQualityStats = {
+		{ "toxic_domain_buff_linger_duration_ms", 100, { 0 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.38, cooldown = 11, levelRequirement = 0, storedUses = 1, cost = { Mana = 24, }, },
@@ -9387,8 +9541,11 @@ skills["ToxicGrowthPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.05 },
-		{ "number_of_poisonbloom_arrow_bloom_allowed", 0.05 },
+		{ "base_number_of_projectiles", 0.05, { 0 } },
+		{ "number_of_poisonbloom_arrow_bloom_allowed", 0.05, { 0 } },
+	},
+	altQualityStats = {
+		{ "base_poison_duration_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -9611,6 +9768,8 @@ skills["TrailOfCaltropsPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -9722,7 +9881,10 @@ skills["TriggeredTrailOfCaltropsPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Projectile] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.Hazard] = true, [SkillType.Duration] = true, [SkillType.CannotChain] = true, [SkillType.Attack] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "maximum_caltrops_allowed", 0.25 },
+		{ "maximum_caltrops_allowed", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.35, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -9857,7 +10019,10 @@ skills["TwisterPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "twister_%_chance_for_additional_twister", 1 },
+		{ "twister_%_chance_for_additional_twister", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_projectile_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 4, }, },
@@ -10004,7 +10169,10 @@ skills["VineArrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "poison_vine_arrow_vine_stored_poison_damage_+%_final", 0.5 },
+		{ "poison_vine_arrow_vine_stored_poison_damage_+%_final", 0.5, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 2, { 1 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.7, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -10212,7 +10380,10 @@ skills["VoltaicMarkPlayer"] = {
 	skillTypes = { [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Mark] = true, [SkillType.Lightning] = true, [SkillType.Limit] = true, [SkillType.UsableWhileMounted] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "thaumaturgist_mark_hit_damage_electrocute_multiplier_+%", 1 },
+		{ "thaumaturgist_mark_hit_damage_electrocute_multiplier_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 18, }, },
@@ -10344,7 +10515,10 @@ skills["WhirlingSlashPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "sandstorm_swipe_storm_damage_+%_final_per_stage", 2 },
+		{ "sandstorm_swipe_storm_damage_+%_final_per_stage", 2, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 0.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.7, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -10557,7 +10731,10 @@ skills["WhirlwindLancePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "sandstorm_swipe_storm_damage_+%_final_per_stage", 2 },
+		{ "sandstorm_swipe_storm_damage_+%_final_per_stage", 2, { 1 } },
+	},
+	altQualityStats = {
+		{ "windstorm_gain_all_damage_%_as_corresponding_element_if_empowered", 2.5, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -10790,6 +10967,8 @@ skills["WindDancerPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -10923,7 +11102,10 @@ skills["TriggeredWindDancerPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "wind_dancer_damage_+%_final_per_stage", 2.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, cooldown = 0.25, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -11059,7 +11241,10 @@ skills["WindSerpentsFuryPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_knockback_distance_+%_final", 1.5 },
+		{ "active_skill_knockback_distance_+%_final", 1.5, { 0, 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_all_damage_%_to_gain_as_chaos", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -60, baseMultiplier = 1.65, levelRequirement = 0, cost = { Mana = 10, }, },

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2114,6 +2114,11 @@ skills["MetaCastOnCritPlayer"] = {
 			label = "Cast on Critical",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "skill_stat_descriptions",
+			statMap = {
+				["cast_on_crit_global_critical_hit_chance_granted_+%"] = {
+					mod("CritChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -3185,6 +3190,9 @@ skills["ChargeRegulationPlayer"] = {
 					mod("Armour", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 					mod("Evasion", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 					mod("EnergyShield", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
+				},
+				["charge_regulation_damage_per_charge_granted_+%"] = {
+					mod("Damage", "INC", nil, 0, 0, { type = "Multiplier", var = "TotalCharges" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 				},
 			},
 			baseFlags = {
@@ -8526,6 +8534,9 @@ skills["FlameblastPlayer"] = {
 				["flameblast_maximum_stages"] = {
 					mod("Multiplier:FlameblastMaxStages", "BASE", nil),
 				},
+				["gem_quality_flameblast_damaging_ailment_effect_per_stage_+%_final"] = {
+					mod("AilmentMagnitude", "MORE", nil, 0, bit.bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite), { type = "Multiplier", var = "FlameblastStage" }),
+				},
 			},
 			baseFlags = {
 				spell = true,
@@ -11795,6 +11806,9 @@ skills["HeraldOfIcePlayer"] = {
 			statMap = {
 				["display_herald_of_ice_behaviour"] = {
 					flag("Condition:EnemiesExplode", { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ice" }),
+				},
+				["herald_of_ice_cold_damage_+%"] = {
+					mod("ColdDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ice" }),
 				},
 			},
 			baseFlags = {
@@ -15127,6 +15141,11 @@ skills["ManaRemnantsPlayer"] = {
 			incrementalEffectiveness = 0.050000000745058,
 			damageIncrementalEffectiveness = 0.0089999996125698,
 			statDescriptionScope = "mana_remnants",
+			statMap = {
+				["mana_remnants_global_mana_regeneration_rate_granted_+%"] = {
+					mod("ManaRegen", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {
@@ -17269,6 +17288,9 @@ skills["SacrificePlayer"] = {
 			statMap = {
 				["harvester_minion_resummon_speed_+%_final"] = {
 					mod("MinionRevivalSpeed", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+				},
+				["sacrifice_minion_life_granted_+%"] = {
+					mod("MinionModifier", "LIST", { mod = mod("Life", "INC", nil) }, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 				},
 			},
 			baseFlags = {
@@ -21832,6 +21854,9 @@ skills["TrinityPlayer"] = {
 				["trinity_loss_per_hit"] = {
 					-- Display only
 				},
+				["trinity_%_physical_damage_to_convert_to_random_element_granted"] = {
+					mod("PhysicalDamageConvertToRandom", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Trinity" } )
+				},
 			},
 			baseFlags = {
 				buff = true,
@@ -22781,6 +22806,11 @@ skills["WaveOfFrostPlayer"] = {
 			label = "Wave of Frost",
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "wave_of_frost",
+			statMap = {
+				["frozen_monsters_take_increased_damage"] = {
+					mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Condition", var = "Frozen" }),
+				},
+			},
 			baseFlags = {
 				attack = true,
 				area = true,
@@ -23040,6 +23070,11 @@ skills["GaleStrikePlayer"] = {
 			label = "Wind Blast",
 			incrementalEffectiveness = 0.092720001935959,
 			statDescriptionScope = "wind_blast",
+			statMap = {
+				["wind_blast_damage_+%_final_from_distance"] = {
+					mod("Damage", "MORE", nil, 0, 0, { type = "DistanceRamp", ramp = {{15,1},{40,0}} }),
+				},
+			},
 			baseFlags = {
 				attack = true,
 				area = true,

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -15,7 +15,10 @@ skills["ArcPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Chains] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1.1,
 	qualityStats = {
-		{ "number_of_chains", 0.1 },
+		{ "number_of_chains", 0.1, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_projectile_damage_+%_final_for_each_remaining_chain", 0.15, {  } },
 	},
 	levels = {
 		[1] = { PvPDamageMultiplier = -25, critChance = 9, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -67,8 +70,8 @@ skills["ArcPlayer"] = {
 			damageIncrementalEffectiveness = 0.0082000000402331,
 			statDescriptionScope = "skill_stat_descriptions",
 			statMap = {
-				["arc_damage_+%_final_for_each_remaining_chain"] = {
-					mod("Damage", "MORE", nil, 0, 0, { type = "PerStat", stat = "ChainRemaining" }),
+				["active_skill_projectile_damage_+%_final_for_each_remaining_chain"] = {
+					mod("Damage", "MORE", nil, bit.bor(ModFlag.Projectile, ModFlag.Hit), 0, { type = "PerStat", stat = "ChainRemaining" }),
 				},
 				["quality_display_arc_is_gem"] = {
 					-- Display only
@@ -165,7 +168,11 @@ skills["ArchmagePlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Lightning] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "archmage_all_damage_%_to_gain_as_lightning_to_grant_to_non_channelling_spells_per_100_max_mana", 0.05, {  } },
+		{ "archmage_max_mana_permyriad_to_add_to_non_channelled_spell_mana_cost", 10, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -286,7 +293,10 @@ skills["ArcticArmourPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Cold] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Damage] = true, [SkillType.Sustained] = true, [SkillType.GainsStages] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "maximum_number_of_arctic_armour_stationary_stacks", 0.05 },
+		{ "maximum_number_of_arctic_armour_stationary_stacks", 0.05, {  } },
+	},
+	altQualityStats = {
+		{ "arctic_armour_armour_granted_+%_per_stage", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.25, critChance = 11, levelRequirement = 0, spiritReservationFlat = 30, storedUses = 1, },
@@ -404,7 +414,10 @@ skills["BallLightningPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Sustained] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Duration] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_projectile_speed_+%_final", -1.5, { 0 } },
 	},
 	levels = {
 		[1] = { PvPDamageMultiplier = -40, critChance = 9, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -706,7 +719,10 @@ skills["MetaBarrierInvocationPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Invocation] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "triggered_skill_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, spiritReservationFlat = 30, storedUses = 1, },
@@ -820,6 +836,8 @@ skills["SupportBarrierInvocationPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -930,7 +948,9 @@ skills["BlasphemyPlayer"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.AreaSpell] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Meta] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.IsBlasphemy] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1049,7 +1069,10 @@ skills["SupportBlasphemyPlayer"] = {
 	isTrigger = true,
 	ignoreMinionTypes = true,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "curse_effect_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1170,6 +1193,8 @@ skills["BlinkReservationPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 60, },
@@ -1277,7 +1302,10 @@ skills["BlinkPlayer"] = {
 	skillTypes = { [SkillType.UsableWhileMoving] = true, [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.Travel] = true, [SkillType.CanCancelActions] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "blink_travel_distance", 1.25, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 4.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -1393,7 +1421,9 @@ skills["BoneBlastPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Damage] = true, [SkillType.Cascadable] = true, [SkillType.CreatesGroundRune] = true, [SkillType.Necrotic] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 14, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1521,7 +1551,10 @@ skills["BoneCagePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Unleashable] = true, [SkillType.Nova] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.Necrotic] = true, [SkillType.Totemable] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_pins_as_though_dealt_damage_+%_final", 2.5 },
+		{ "active_skill_pins_as_though_dealt_damage_+%_final", 2.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_bleeding_effect_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -1656,7 +1689,10 @@ skills["BoneOfferingPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.Area] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "bone_offering_damage_taken_+%_final_after_shield_loss", -1.5 },
+		{ "bone_offering_damage_taken_+%_final_after_shield_loss", -1.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 25, }, },
@@ -1777,7 +1813,10 @@ skills["BonestormPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Channel] = true, [SkillType.Projectile] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.ConsumesCharges] = true, [SkillType.Damage] = true, [SkillType.SkillConsumesPowerChargesOnUse] = true, [SkillType.Necrotic] = true, [SkillType.Totemable] = true, },
 	castTime = 0.125,
 	qualityStats = {
-		{ "active_skill_cast_speed_+%_final", 0.5 },
+		{ "active_skill_cast_speed_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, cost = { ManaPerMinute = 355, }, },
@@ -2023,7 +2062,10 @@ skills["MetaCastOnCritPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "cast_on_crit_global_critical_hit_chance_granted_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -2138,6 +2180,8 @@ skills["SupportMetaCastOnCritPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2249,7 +2293,10 @@ skills["MetaCastOnDodgePlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "cast_on_dodge_dodge_roll_distance_granted_+", 0.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -2364,6 +2411,8 @@ skills["SupportMetaCastOnDodgePlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2474,7 +2523,10 @@ skills["MetaCastOnElementalAilmentPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -2591,6 +2643,8 @@ skills["SupportMetaCastOnElementalAilmentPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2701,7 +2755,10 @@ skills["MetaCastOnMinionDeathPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.Minion] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, [SkillType.Minion] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 1 },
+		{ "energy_generated_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "triggered_skill_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -2816,6 +2873,8 @@ skills["SupportMetaCastOnMinionDeathPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2927,7 +2986,9 @@ skills["WeaponGrantedChaosboltPlayer"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Chaos] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "base_projectile_speed_+%", 2 },
+		{ "base_projectile_speed_+%", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3059,7 +3120,10 @@ skills["ChargeRegulationPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "consume_frenzy_power_and_endurance_charge_every_x_ms", 120 },
+		{ "consume_frenzy_power_and_endurance_charge_every_x_ms", 120, {  } },
+	},
+	altQualityStats = {
+		{ "charge_regulation_damage_per_charge_granted_+%", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -3189,7 +3253,10 @@ skills["ChargedStaffPlayer"] = {
 	},
 	castTime = 0.75,
 	qualityStats = {
-		{ "skill_effect_duration_+%", 1 },
+		{ "skill_effect_duration_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 15, }, },
@@ -3320,6 +3387,8 @@ skills["ChargedStaffShockwavePlayer"] = {
 	castTime = 0.75,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.25, levelRequirement = 0, },
 		[2] = { baseMultiplier = 0.27, levelRequirement = 0, },
@@ -3436,7 +3505,9 @@ skills["CoilingBoltsPlayer"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Chaos] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "projectile_number_to_split", 0.1 },
+		{ "projectile_number_to_split", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3652,7 +3723,10 @@ skills["CometPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Invokable] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_spell_%_chance_to_echo", 0.5 },
+		{ "base_spell_%_chance_to_echo", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "damage_+%_vs_frozen_enemies", 2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 13, levelRequirement = 0, cost = { Mana = 17, }, },
@@ -3862,7 +3936,10 @@ skills["ContagionPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.DamageOverTime] = true, [SkillType.Chaos] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Mineable] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "contagion_number_of_additional_targets", 0.1 },
+		{ "contagion_number_of_additional_targets", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 8, }, },
@@ -3993,6 +4070,8 @@ skills["ConvalescencePlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -4098,7 +4177,10 @@ skills["ConvalescenceActivePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.Cooldown] = true, [SkillType.Spell] = true, [SkillType.AttackInPlace] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "base_skill_effect_duration", 25 },
+		{ "base_skill_effect_duration", 25, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_speed_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 30, levelRequirement = 0, storedUses = 1, cost = { Mana = 20, }, },
@@ -4224,7 +4306,9 @@ skills["CracklingPalmPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -4403,6 +4487,8 @@ skills["MetaCastCurseOnBlockPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -4518,6 +4604,8 @@ skills["SupportMetaCastCurseOnBlockPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -4629,7 +4717,10 @@ skills["DarkEffigyPlayer"] = {
 	skillTotemId = 24,
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_totems_allowed", 0.05, { 0 } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 13, }, },
@@ -4758,7 +4849,9 @@ skills["DarkEffigyProjectilePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Projectile] = true, [SkillType.Chaos] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.ProjectilesNumberModifiersNotApplied] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.UsedByTotem] = true, [SkillType.UsedByProxy] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_secondary_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_secondary_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
@@ -4891,8 +4984,10 @@ skills["CorpseCloudPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.AreaSpell] = true, [SkillType.Chaos] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Duration] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Limit] = true, [SkillType.TargetsDestructibleCorpses] = true, [SkillType.Fire] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
-		{ "base_secondary_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, { 0 } },
+		{ "base_secondary_skill_effect_duration", 50, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5103,7 +5198,10 @@ skills["DespairPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.Chaos] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "curse_effect_+%", 0.5 },
+		{ "curse_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 41, }, },
@@ -5234,7 +5332,10 @@ skills["DetonateDeadPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.Cascadable] = true, [SkillType.TargetsDestructibleCorpses] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Detonator] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_physical_damage_%_to_convert_to_fire", 3, {  } },
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -5367,7 +5468,9 @@ skills["DisciplinePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_buff_energy_shield_recharge_rate_+%_to_apply", 1 },
+		{ "base_skill_buff_energy_shield_recharge_rate_+%_to_apply", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5484,7 +5587,10 @@ skills["ElementalConfluxPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.Lightning] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_elemental_conflux_active_element_damage_+%_final", 0.5 },
+		{ "skill_elemental_conflux_active_element_damage_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_skill_effect_duration", 200, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
@@ -5604,7 +5710,10 @@ skills["MetaElementalInvocationPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Invocation] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "generic_ongoing_trigger_maximum_energy", 5 },
+		{ "generic_ongoing_trigger_maximum_energy", 5, {  } },
+	},
+	altQualityStats = {
+		{ "triggered_skill_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, spiritReservationFlat = 60, storedUses = 1, },
@@ -5720,6 +5829,8 @@ skills["SupportElementalInvocationPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -5830,7 +5941,10 @@ skills["ElementalWeaknessPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.Lightning] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "curse_effect_+%", 0.5 },
+		{ "curse_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "curse_delay_+%", -2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 41, }, },
@@ -5960,7 +6074,11 @@ skills["EmberFusilladePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Fire] = true, [SkillType.Projectile] = true, [SkillType.Duration] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Triggerable] = true, [SkillType.Totemable] = true, },
 	castTime = 0.4,
 	qualityStats = {
-		{ "ember_fusillade_damage_+%_final_per_ember_fired", 0.1 },
+		{ "ember_fusillade_damage_+%_final_per_ember_fired", 0.1, { 1, 2 } },
+	},
+	altQualityStats = {
+		{ "skill_effect_duration_+%", -2, { 0 } },
+		{ "active_skill_cast_speed_+%_final", -1, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 3, }, },
@@ -6254,7 +6372,10 @@ skills["EnfeeblePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Necrotic] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "curse_effect_+%", 0.5 },
+		{ "curse_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 41, }, },
@@ -6388,7 +6509,10 @@ skills["EssenceDrainPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Duration] = true, [SkillType.Totemable] = true, [SkillType.Multicastable] = true, [SkillType.DamageOverTime] = true, [SkillType.Chaos] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Unleashable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, { 1 } },
+	},
+	altQualityStats = {
+		{ "number_of_chains", 0.2, { 0, 1 } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -6606,7 +6730,9 @@ skills["ExsanguinatePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Chains] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Physical] = true, [SkillType.Unleashable] = true, [SkillType.DamageOverTime] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "blood_tendrils_beam_count", 0.05 },
+		{ "blood_tendrils_beam_count", 0.05, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -6810,7 +6936,10 @@ skills["EyeOfWinterPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Projectile] = true, [SkillType.ProjectileSpiral] = true, [SkillType.Damage] = true, [SkillType.SingleMainProjectile] = true, [SkillType.Cold] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Trappable] = true, [SkillType.Triggerable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cooldown] = true, [SkillType.InteractsWithElementalGround] = true, },
 	castTime = 1.4,
 	qualityStats = {
-		{ "base_projectile_speed_+%", 1.5 },
+		{ "base_projectile_speed_+%", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "projectile_return_%_chance", 2.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 12, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -6950,7 +7079,10 @@ skills["FallingThunderPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "lightning_strike_damage_+%_final_per_power_charge", 1 },
+		{ "lightning_strike_damage_+%_final_per_power_charge", 1, { 1 } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 1.4, levelRequirement = 0, cost = { Mana = 11, }, },
@@ -7119,7 +7251,9 @@ skills["FeastOfFleshPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.Unleashable] = true, [SkillType.Buff] = true, [SkillType.TargetsDestructibleCorpses] = true, },
 	castTime = 1.3,
 	qualityStats = {
-		{ "feast_of_flesh_number_of_corpses", 0.15 },
+		{ "feast_of_flesh_number_of_corpses", 0.15, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -7238,7 +7372,10 @@ skills["FireballPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1.2,
 	qualityStats = {
-		{ "spell_skills_fire_2_additional_projectiles_final_chance_%", 0.5 },
+		{ "spell_skills_fire_2_additional_projectiles_final_chance_%", 0.5, { 0 } },
+	},
+	altQualityStats = {
+		{ "spell_skill_%_chance_to_fire_8_additional_projectiles_in_nova", 0.5, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -7526,7 +7663,9 @@ skills["FireboltPlayer"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.9,
 	qualityStats = {
-		{ "active_skill_ignite_chance_+%_final", 1 },
+		{ "active_skill_ignite_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -7736,7 +7875,10 @@ skills["FirestormPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, [SkillType.Storm] = true, },
 	castTime = 1.4,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_not_consume_infusion_%", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -8084,7 +8226,10 @@ skills["FlameWallPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.DamageOverTime] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.Totemable] = true, [SkillType.Fire] = true, [SkillType.Unleashable] = true, [SkillType.Multicastable] = true, [SkillType.Cascadable] = true, [SkillType.CausesBurning] = true, [SkillType.Wall] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Damage] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_ignite_chance_+%_final", 1 },
+		{ "active_skill_ignite_chance_+%_final", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 2, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -8314,7 +8459,10 @@ skills["FlameblastPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Fire] = true, [SkillType.Channel] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.UsableWhileMoving] = true, [SkillType.GainsStages] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.25,
 	qualityStats = {
-		{ "active_skill_cast_speed_+%_final", 1 },
+		{ "active_skill_cast_speed_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "gem_quality_flameblast_damaging_ailment_effect_per_stage_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 8, levelRequirement = 0, storedUses = 1, cost = { ManaPerMinute = 337, }, },
@@ -8463,7 +8611,10 @@ skills["FlickerStrikePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_critical_strike_chance_+%_final", 1 },
+		{ "active_skill_critical_strike_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { PvPDamageMultiplier = -30, attackSpeedMultiplier = -50, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -8599,7 +8750,10 @@ skills["FreezingMarkPlayer"] = {
 	skillTypes = { [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Mark] = true, [SkillType.Cold] = true, [SkillType.Limit] = true, [SkillType.UsableWhileMounted] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "freezing_mark_hit_damage_freeze_multiplier_+%_final", 1 },
+		{ "freezing_mark_hit_damage_freeze_multiplier_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 18, }, },
@@ -8734,7 +8888,9 @@ skills["FreezingShardsPlayer"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.Invokable] = true, [SkillType.Cold] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1.2,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.05 },
+		{ "base_number_of_projectiles", 0.05, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -8864,7 +9020,10 @@ skills["FrostBombPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Cold] = true, [SkillType.Damage] = true, [SkillType.Multicastable] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, [SkillType.Orb] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.GeneratesInfusion] = true, [SkillType.GeneratesRemnants] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Limit] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_all_elemental_exposure_compounding_magnitude_cap", 0.5 },
+		{ "active_skill_all_elemental_exposure_compounding_magnitude_cap", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_maximum_number_of_frost_bombs", 0.15, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 6, critChance = 13, levelRequirement = 0, storedUses = 1, cost = { Mana = 9, }, },
@@ -9002,7 +9161,10 @@ skills["FrostDartsPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Cold] = true, [SkillType.Projectile] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Triggerable] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "spell_skills_fire_2_additional_projectiles_final_chance_%", 0.5 },
+		{ "spell_skills_fire_2_additional_projectiles_final_chance_%", 0.5, { 0 } },
+	},
+	altQualityStats = {
+		{ "number_of_additional_forks_base", 0.1, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 13, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -9294,7 +9456,10 @@ skills["FrostWallPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Cascadable] = true, [SkillType.Cooldown] = true, [SkillType.Invokable] = true, [SkillType.Area] = true, [SkillType.Wall] = true, [SkillType.UsableWhileMoving] = true, [SkillType.IceCrystal] = true, [SkillType.ToggleSpawnedObjectTargetable_DefaultOff] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "ice_crystal_maximum_life_+%", 20, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 11, levelRequirement = 0, storedUses = 3, cost = { Mana = 7, }, },
@@ -9521,7 +9686,10 @@ skills["FrostboltPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Triggerable] = true, [SkillType.Unleashable] = true, [SkillType.Area] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_projectile_damage_+%_final_if_pierced_enemy", 1 },
+		{ "active_skill_projectile_damage_+%_final_if_pierced_enemy", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_projectile_speed_+%_final", 2, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 12, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -9733,7 +9901,10 @@ skills["FrozenLocusPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_chill_effect_+%_final", 1 },
+		{ "active_skill_chill_effect_+%_final", 1, { 1 } },
+	},
+	altQualityStats = {
+		{ "base_number_of_frozen_locus_allowed", 0.05, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -9935,7 +10106,9 @@ skills["FulminationPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.Damage] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.Lightning] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "skill_wrath_aura_shared_damage_+%_to_other_shocked_enemies_in_presence", 0.25 },
+		{ "skill_wrath_aura_shared_damage_+%_to_other_shocked_enemies_in_presence", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -10050,7 +10223,9 @@ skills["GalvanicFieldBuffPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.Lightning] = true, [SkillType.Chains] = true, [SkillType.Orb] = true, [SkillType.Triggerable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, },
 	castTime = 0.65,
 	qualityStats = {
-		{ "number_of_chains", 0.1 },
+		{ "number_of_chains", 0.1, { 1 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10262,7 +10437,10 @@ skills["GatheringStormPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "perfect_timing_window_ms_+%", 1 },
+		{ "perfect_timing_window_ms_+%", 1, { 1 } },
+	},
+	altQualityStats = {
+		{ "chance_for_extra_damage_roll_with_lightning_damage_%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, cost = { ManaPerMinute = 474, }, },
@@ -10620,7 +10798,10 @@ skills["GhostDancePlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.AffectedByCooldownRate] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 1 },
+		{ "base_reservation_efficiency_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "ghost_dance_max_stacks", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -10739,7 +10920,10 @@ skills["GlacialCascadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_physical_damage_%_to_gain_as_cold", 0.75 },
+		{ "active_skill_base_physical_damage_%_to_gain_as_cold", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -10945,7 +11129,10 @@ skills["GrimFeastPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AffectsPresence] = true, [SkillType.RemnantCannotBeShared] = true, [SkillType.AttackInPlace] = true, [SkillType.Minion] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "grim_remnant_health_stored_in_globe_%", 0.25 },
+		{ "grim_remnant_health_stored_in_globe_%", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "remnant_pickup_range_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -11060,6 +11247,8 @@ skills["GrimFeastResummonPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.AttackInPlace] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, [SkillType.Minion] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -11176,6 +11365,8 @@ skills["HandOfChayulaPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -11, baseMultiplier = 0.67, levelRequirement = 0, cost = { Mana = 11, }, },
@@ -11294,8 +11485,11 @@ skills["SupportHandOfChayulaPlayer"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	qualityStats = {
-		{ "base_curse_duration_+%", 1 },
-		{ "mark_effect_+%", 0.5 },
+		{ "base_curse_duration_+%", 1, {  } },
+		{ "mark_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -11406,7 +11600,9 @@ skills["HeartOfIcePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.Cold] = true, [SkillType.Spell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_chill_effect_+%_final", 1 },
+		{ "active_skill_chill_effect_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, },
@@ -11544,7 +11740,10 @@ skills["HeraldOfIcePlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 1 } },
+	},
+	altQualityStats = {
+		{ "herald_of_ice_cold_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -11722,7 +11921,10 @@ skills["HexblastPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Chaos] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Cascadable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "hexblast_damage_+%_final_per_second_remaining_curse_duration", 0.5 },
+		{ "hexblast_damage_+%_final_per_second_remaining_curse_duration", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_critical_strike_chance_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -11851,7 +12053,9 @@ skills["HisFoulEmergencePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Physical] = true, [SkillType.Chaos] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Invokable] = true, [SkillType.Cooldown] = true, [SkillType.Duration] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 15, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -11989,7 +12193,9 @@ skills["ScatteringCalamityPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Lightning] = true, [SkillType.Projectile] = true, [SkillType.Duration] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.4,
 	qualityStats = {
-		{ "ember_fusillade_damage_+%_final_per_ember_fired", 0.1 },
+		{ "ember_fusillade_damage_+%_final_per_ember_fired", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12200,7 +12406,9 @@ skills["VileDisruptionPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Physical] = true, [SkillType.AreaSpell] = true, [SkillType.Multicastable] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Necrotic] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "impale_magnitude_+%", 0.5 },
+		{ "impale_magnitude_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12337,7 +12545,9 @@ skills["HisWinnowingFlamePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Fire] = true, [SkillType.DamageOverTime] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.SkillConsumesIgnite] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_cast_speed_+%", 0.5 },
+		{ "base_cast_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12466,6 +12676,8 @@ skills["TriggeredHisWinnowingFlamePillarPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12583,7 +12795,10 @@ skills["IceNovaPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cascadable] = true, [SkillType.Duration] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_vs_chilled_enemies", 1 },
+		{ "active_skill_damage_+%_final_vs_chilled_enemies", 1, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_not_consume_infusion_%", 2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 12, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -12803,7 +13018,10 @@ skills["IceStrikePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attack_speed_+%", 1 },
+		{ "attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_critical_strike_chance_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 40, baseMultiplier = 0.6, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -12987,7 +13205,9 @@ skills["IcestormPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, [SkillType.SkillConsumesFreeze] = true, [SkillType.Storm] = true, },
 	castTime = 1.2,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -13219,7 +13439,9 @@ skills["ImpurityPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Chaos] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_buff_chaos_damage_resistance_%_to_apply", 0.3 },
+		{ "base_skill_buff_chaos_damage_resistance_%_to_apply", 0.3, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = -100, reservationMultiplier = -100, },
@@ -13339,7 +13561,10 @@ skills["IncineratePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Totemable] = true, [SkillType.Fire] = true, [SkillType.Channel] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Sustained] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.DamageOverTime] = true, },
 	castTime = 0.25,
 	qualityStats = {
-		{ "active_skill_ignite_duration_+%_final", 1 },
+		{ "active_skill_ignite_duration_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "incinerate_maximum_fuel", 100, {  } },
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -13591,7 +13816,10 @@ skills["KillingPalmPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "recover_%_maximum_mana_on_cull", 0.2 },
+		{ "recover_%_maximum_mana_on_cull", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "recover_%_maximum_life_on_cull", 0.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.9, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -13719,7 +13947,9 @@ skills["LightningBoltPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Cascadable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.85,
 	qualityStats = {
-		{ "active_skill_shock_chance_+%_final", 2 },
+		{ "active_skill_shock_chance_+%_final", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -13847,6 +14077,8 @@ skills["UniqueBreachLightningBoltPlayer"] = {
 	castTime = 0.85,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.5, critChance = 10, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
 		[2] = { cooldown = 0.5, critChance = 10, levelRequirement = 3, storedUses = 5, cost = { Mana = 0, }, },
@@ -13972,7 +14204,10 @@ skills["LightningConduitPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Multicastable] = true, [SkillType.Lightning] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_lightning_damage_+%_final", 1 },
+		{ "active_skill_lightning_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "lightning_conduit_x_additional_strikes_if_consumed_a_shock", 0.2, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -14101,7 +14336,10 @@ skills["LightningWarpPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.AreaSpell] = true, [SkillType.Multicastable] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.GeneratesInfusion] = true, [SkillType.Movement] = true, [SkillType.GeneratesRemnants] = true, [SkillType.GamepadDoNotForceSkillAtLocation] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "shock_effect_+%", 0.5 },
+		{ "shock_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_cast_speed_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -14231,7 +14469,10 @@ skills["LingeringIllusionPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.GeneratesCharges] = true, [SkillType.Duration] = true, [SkillType.GeneratesRemnants] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_spirit_reservation_efficiency_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -14337,7 +14578,9 @@ skills["LingeringIllusionSpawnPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, [SkillType.GeneratesRemnants] = true, [SkillType.GeneratesCharges] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "chance_%_to_create_additional_remnant", 1 },
+		{ "chance_%_to_create_additional_remnant", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 10, }, },
@@ -14456,7 +14699,11 @@ skills["LivingBombPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.AreaSpell] = true, [SkillType.Limit] = true, [SkillType.Fire] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Duration] = true, [SkillType.GeneratesInfusion] = true, [SkillType.GeneratesRemnants] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_ignite_chance_+%_final", 1 },
+		{ "active_skill_ignite_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 2.5, {  } },
+		{ "living_bomb_damage_threshold_%_of_ailment_threshold", 10, {  } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -14587,7 +14834,9 @@ skills["MalicePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -14707,7 +14956,9 @@ skills["ManaDrainPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.85,
 	qualityStats = {
-		{ "mana_drain_base_mana_leech_amount", 4.5 },
+		{ "mana_drain_base_mana_leech_amount", 4.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -14822,7 +15073,10 @@ skills["ManaRemnantsPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.TotemCastsAlone] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "mana_remnants_mana_gain_per_globe", 2 },
+		{ "mana_remnants_mana_gain_per_globe", 2, {  } },
+	},
+	altQualityStats = {
+		{ "mana_remnants_global_mana_regeneration_rate_granted_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -14938,7 +15192,10 @@ skills["ManaTempestPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Cooldown] = true, [SkillType.Lightning] = true, [SkillType.InstantNoRepeatWhenHeld] = true, [SkillType.InstantShiftAttackForLeftMouse] = true, [SkillType.UsableWhileMoving] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.Storm] = true, [SkillType.IndeterminateEmpowermentAmount] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "mana_tempest_effects_linger_X_ms", 100 },
+		{ "mana_tempest_effects_linger_X_ms", 100, {  } },
+	},
+	altQualityStats = {
+		{ "mana_tempest_mana_cost_%_to_add_to_cost_per_second", -0.4, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { ManaPercentPerMinute = 60, }, },
@@ -15066,7 +15323,10 @@ skills["MantraOfDestructionPlayer"] = {
 	},
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_required_number_of_combo_stacks", -0.05 },
+		{ "active_skill_required_number_of_combo_stacks", -0.05, {  } },
+	},
+	altQualityStats = {
+		{ "base_secondary_skill_effect_duration", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -15191,7 +15451,9 @@ skills["MirrorOfRefractionPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.Limit] = true, [SkillType.AffectedByCooldownRate] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.1 },
+		{ "base_number_of_projectiles", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -15308,7 +15570,10 @@ skills["OrbOfStormsPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Lightning] = true, [SkillType.Area] = true, [SkillType.Chains] = true, [SkillType.Triggerable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Totemable] = true, [SkillType.AreaSpell] = true, [SkillType.Orb] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Duration] = true, [SkillType.Sustained] = true, [SkillType.GeneratesInfusion] = true, [SkillType.GeneratesRemnants] = true, [SkillType.Unleashable] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "number_of_chains", 0.15 },
+		{ "number_of_chains", 0.15, {  } },
+	},
+	altQualityStats = {
+		{ "orb_of_storms_maximum_number_of_hits", 0.3, {  } },
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -15445,7 +15710,10 @@ skills["PainOfferingPlayer"] = {
 	minionSkillTypes = { [SkillType.Aura] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 1.2 },
+		{ "active_skill_base_area_of_effect_radius", 1.2, {  } },
+	},
+	altQualityStats = {
+		{ "pain_offering_attack_and_cast_speed_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 25, }, },
@@ -15579,7 +15847,9 @@ skills["PowerSiphonPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Damage] = true, [SkillType.GeneratesCharges] = true, [SkillType.Physical] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "chance_to_gain_1_more_charge_%", 0.5 },
+		{ "chance_to_gain_1_more_charge_%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -15704,7 +15974,10 @@ skills["ProfaneRitualPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Chaos] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.DamageOverTime] = true, [SkillType.Multicastable] = true, [SkillType.Cascadable] = true, [SkillType.Triggerable] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.TargetsDestructibleCorpses] = true, [SkillType.Limit] = true, [SkillType.GeneratesCharges] = true, [SkillType.CreatesGroundRune] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_chance_to_not_consume_corpse_%", 0.5 },
+		{ "base_chance_to_not_consume_corpse_%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 6, }, },
@@ -15830,7 +16103,9 @@ skills["PurityOfFirePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Fire] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_buff_fire_damage_resistance_%_to_apply", 0.4 },
+		{ "base_skill_buff_fire_damage_resistance_%_to_apply", 0.4, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = -100, reservationMultiplier = -100, },
@@ -15951,7 +16226,9 @@ skills["PurityOfIcePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Cold] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_buff_cold_damage_resistance_%_to_apply", 0.4 },
+		{ "base_skill_buff_cold_damage_resistance_%_to_apply", 0.4, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = -100, reservationMultiplier = -100, },
@@ -16072,7 +16349,9 @@ skills["PurityOfLightningPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Lightning] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_buff_lightning_damage_resistance_%_to_apply", 0.4 },
+		{ "base_skill_buff_lightning_damage_resistance_%_to_apply", 0.4, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = -100, reservationMultiplier = -100, },
@@ -16196,7 +16475,10 @@ skills["RagingSpiritsPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, [SkillType.Fire] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_raging_spirits_allowed", 0.1 },
+		{ "base_number_of_raging_spirits_allowed", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_minion_damage_+%_final", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -16318,7 +16600,10 @@ skills["RaiseZombiePlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "raise_zombie_empowerment_effect_+%", 1.25 },
+		{ "raise_zombie_empowerment_effect_+%", 1.25, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_zombies_allowed", 0.2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 10, }, },
@@ -16447,7 +16732,10 @@ skills["RavenousSwarmPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Chaos] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.5 },
+		{ "active_skill_base_area_of_effect_radius", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_modifiable_repeat_interval_ms", -100, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -16568,7 +16856,9 @@ skills["ReapPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Physical] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1.2,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 14, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -16695,7 +16985,10 @@ skills["MetaReapersInvocationPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Invocation] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 1 },
+		{ "energy_generated_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "triggered_skill_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, spiritReservationFlat = 30, storedUses = 1, },
@@ -16809,6 +17102,8 @@ skills["SupportReapersInvocationPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -16919,7 +17214,10 @@ skills["SacrificePlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Minion] = true, [SkillType.ReserveInAllSets] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "harvester_minion_resummon_speed_+%_final", 0.25 },
+		{ "harvester_minion_resummon_speed_+%_final", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "sacrifice_minion_life_granted_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
@@ -17038,7 +17336,10 @@ skills["ShatteringPalmPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_critical_strike_chance_+%_final", 1 },
+		{ "active_skill_critical_strike_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.35, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -17160,7 +17461,10 @@ skills["ShatteringPalmExplosionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_critical_strike_chance_+%_final", 1 },
+		{ "active_skill_critical_strike_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
@@ -17282,7 +17586,9 @@ skills["SigilOfPowerPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, [SkillType.Totemable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.GainsStages] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.4 },
+		{ "active_skill_base_area_of_effect_radius", 0.4, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -17417,9 +17723,12 @@ skills["SiphonElementsPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.TotemCastsAlone] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.GeneratesRemnants] = true, [SkillType.GeneratesInfusion] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "infusion_remnants_%_chance_to_spawn_cold_infusion_on_freezing_an_enemy", 0.1 },
-		{ "infusion_remnants_%_chance_to_spawn_fire_infusion_on_igniting_an_enemy", 0.1 },
-		{ "infusion_remnants_%_chance_to_spawn_lightning_infusion_on_shocking_an_enemy", 0.1 },
+		{ "infusion_remnants_%_chance_to_spawn_cold_infusion_on_freezing_an_enemy", 0.1, {  } },
+		{ "infusion_remnants_%_chance_to_spawn_fire_infusion_on_igniting_an_enemy", 0.1, {  } },
+		{ "infusion_remnants_%_chance_to_spawn_lightning_infusion_on_shocking_an_enemy", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "remnant_pickup_range_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -17536,7 +17845,10 @@ skills["SiphoningStrikePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_chance_to_daze_%", 2.5 },
+		{ "base_chance_to_daze_%", 2.5, { 0, 1 } },
+	},
+	altQualityStats = {
+		{ "chance_to_gain_1_more_charge_%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.75, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -17727,7 +18039,10 @@ skills["SummonSkeletalArsonistsPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.Area] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 90, },
@@ -17848,7 +18163,10 @@ skills["SummonSkeletalBrutesPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Cold] = true, [SkillType.Warcry] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_hit_damage_stun_multiplier_+%_final", 2 },
+		{ "active_skill_minion_hit_damage_stun_multiplier_+%_final", 2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_minion_life_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 165, },
@@ -17969,7 +18287,10 @@ skills["SummonSkeletalClericsPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "skeletal_cleric_revived_skeletons_immune_for_X_ms", 150 },
+		{ "skeletal_cleric_revived_skeletons_immune_for_X_ms", 150, {  } },
+	},
+	altQualityStats = {
+		{ "minion_damage_taken_+%", -2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
@@ -18090,7 +18411,10 @@ skills["SummonSkeletalFrostMagesPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Cascadable] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_damage_+%_final", 1 },
+		{ "active_skill_minion_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_spirit_reservation_efficiency_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 120, },
@@ -18211,7 +18535,10 @@ skills["SummonSkeletalReaversPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "minion_rage_effect_+%", 1 },
+		{ "minion_rage_effect_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "armour_break_physical_damage_%_dealt_as_armour_break", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 90, },
@@ -18334,7 +18661,9 @@ skills["SummonSkeletalSnipersPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_damage_+%_final", 1 },
+		{ "active_skill_minion_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 90, },
@@ -18455,7 +18784,10 @@ skills["SummonSkeletalStormMagesPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Chains] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Duration] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "minion_maximum_life_%_to_gain_as_maximum_energy_shield", 1 },
+		{ "minion_maximum_life_%_to_gain_as_maximum_energy_shield", 1, {  } },
+	},
+	altQualityStats = {
+		{ "minion_cast_speed_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 120, },
@@ -18577,7 +18909,9 @@ skills["SummonSkeletalWarriorsPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },
@@ -18697,7 +19031,10 @@ skills["SnapPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.Lightning] = true, [SkillType.Cascadable] = true, [SkillType.AreaSpell] = true, [SkillType.SkillConsumesFreeze] = true, [SkillType.SkillConsumesIgnite] = true, [SkillType.SkillConsumesShock] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Unleashable] = true, [SkillType.GeneratesRemnants] = true, [SkillType.GeneratesInfusion] = true, [SkillType.Cooldown] = true, [SkillType.ManualCooldownConsumption] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "chance_%_to_spawn_another_infusion_remnant", 0.5 },
+		{ "chance_%_to_spawn_another_infusion_remnant", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_speed_+%", 5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 4, critChance = 13, levelRequirement = 0, storedUses = 1, cost = { Mana = 8, }, },
@@ -18999,7 +19336,9 @@ skills["SolarOrbPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Fire] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Totemable] = true, [SkillType.AreaSpell] = true, [SkillType.Orb] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, [SkillType.Unleashable] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_vs_burning_enemies", 1 },
+		{ "active_skill_damage_+%_final_vs_burning_enemies", 1, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -19207,7 +19546,10 @@ skills["SoulOfferingPlayer"] = {
 	skillTypes = { [SkillType.Offering] = true, [SkillType.Minion] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Triggerable] = true, [SkillType.CreatesMinion] = true, [SkillType.Limit] = true, [SkillType.Buff] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
+		{ "power_offering_buff_spell_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 32, }, },
@@ -19332,7 +19674,9 @@ skills["SoulrendPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Projectile] = true, [SkillType.DamageOverTime] = true, [SkillType.Damage] = true, [SkillType.Chaos] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Totemable] = true, [SkillType.Unleashable] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_skill_effect_duration", 5 },
+		{ "base_skill_effect_duration", 5, { 1 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 13, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -19537,7 +19881,10 @@ skills["SparkPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_projectile_speed_+%", 1.5 },
+		{ "base_projectile_speed_+%", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -19761,7 +20108,10 @@ skills["SummonSpectrePlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.Chains] = true, [SkillType.Duration] = true, [SkillType.SummonsTotem] = true, [SkillType.Trapped] = true, [SkillType.RemoteMined] = true, [SkillType.DamageOverTime] = true, [SkillType.Channel] = true, [SkillType.RangedAttack] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Cooldown] = true, [SkillType.Barrageable] = true, [SkillType.Cascadable] = true, },
 	castTime = 0.85,
 	qualityStats = {
-		{ "active_skill_minion_damage_+%_final", 1 },
+		{ "active_skill_minion_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 50, },
@@ -19882,7 +20232,9 @@ skills["MetaSpellslingerPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Invocation] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, storedUses = 1, },
@@ -19999,6 +20351,8 @@ skills["SupportSpellslingerPlayer"] = {
 	ignoreMinionTypes = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -20114,7 +20468,9 @@ skills["SummonSpiralingConspiracyPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Rain] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesNumberModifiersNotApplied] = true, [SkillType.Cooldown] = true, [SkillType.CannotChain] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.Physical] = true, [SkillType.Chaos] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_area_of_effect_+%", 1 },
+		{ "base_skill_area_of_effect_+%", 1, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -20239,6 +20595,8 @@ skills["CommandMadFlightPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -20359,6 +20717,8 @@ skills["StaggeringPalmPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -20483,7 +20843,10 @@ skills["StaggeringPalmProjectilePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attacks_chance_to_blind_on_hit_%", 2 },
+		{ "attacks_chance_to_blind_on_hit_%", 2, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, },
@@ -20604,7 +20967,10 @@ skills["StormWavePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_secondary_area_of_effect_radius", 0.5 },
+		{ "active_skill_base_secondary_area_of_effect_radius", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -20730,7 +21096,10 @@ skills["TempestBellPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "tempest_bell_damage_+%_final_per_time_hit", 0.15 },
+		{ "tempest_bell_damage_+%_final_per_time_hit", 0.15, { 2 } },
+	},
+	altQualityStats = {
+		{ "bell_hit_limit", 0.5, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 14, }, },
@@ -21003,7 +21372,10 @@ skills["TempestFlurryPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "melee_range_+", 0.2 },
+		{ "melee_range_+", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "final_strike_number_of_spirit_strikes", 0.1, { 2 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 40, baseMultiplier = 0.45, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -21256,7 +21628,10 @@ skills["TemporalChainsPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "curse_effect_+%", 0.5 },
+		{ "curse_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "curse_delay_+%", -2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 41, }, },
@@ -21390,7 +21765,10 @@ skills["TrinityPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Lightning] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "trinity_skill_speed_+%_while_all_resonance_is_at_least_250_to_grant", 0.75 },
+		{ "trinity_skill_speed_+%_while_all_resonance_is_at_least_250_to_grant", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "trinity_%_physical_damage_to_convert_to_random_element_granted", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -21527,8 +21905,11 @@ skills["UnearthPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 0.95,
 	qualityStats = {
-		{ "base_skill_effect_duration", 250 },
-		{ "minion_movement_speed_+%", 2.5 },
+		{ "base_skill_effect_duration", 250, {  } },
+		{ "minion_movement_speed_+%", 2.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_minion_attack_speed_+%_final", 2.5, {  } },
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -21663,7 +22044,9 @@ skills["UnleashPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, [SkillType.ModifiesNextSkill] = true, [SkillType.Duration] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -21785,7 +22168,10 @@ skills["VaultingImpactPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "broken_stance_hit_limit", 0.1 },
+		{ "broken_stance_hit_limit", 0.1, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_damage_+%_final_against_heavy_stunned_enemies", 2.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.6, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -21933,7 +22319,9 @@ skills["VolatileDeadPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Fire] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.TargetsDestructibleCorpses] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_chance_to_not_consume_corpse_%", 0.5 },
+		{ "base_chance_to_not_consume_corpse_%", 0.5, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { PvPDamageMultiplier = -80, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -22205,7 +22593,10 @@ skills["VulnerabilityPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "curse_effect_+%", 0.5 },
+		{ "curse_effect_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_mana_cost_-%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 41, }, },
@@ -22338,7 +22729,10 @@ skills["WaveOfFrostPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_reduce_enemy_cold_resistance_%", 1 },
+		{ "base_reduce_enemy_cold_resistance_%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "frozen_monsters_take_increased_damage", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -45, baseMultiplier = 0.65, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -22461,7 +22855,10 @@ skills["WhirlingAssaultPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attack_speed_+%", 1 },
+		{ "attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 18, }, },
@@ -22591,7 +22988,10 @@ skills["GaleStrikePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "wind_blast_damage_+%_final_from_distance", 1 },
+		{ "wind_blast_damage_+%_final_from_distance", 1, {  } },
+	},
+	altQualityStats = {
+		{ "armour_break_physical_damage_%_dealt_as_armour_break", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.85, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -22720,6 +23120,8 @@ skills["WitherPlayer"] = {
 	castTime = 0.25,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 0, }, },
@@ -22843,7 +23245,10 @@ skills["WitheringPresencePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.Chaos] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
+		{ "skill_withering_presence_frequency_ms", -25, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -30,7 +30,10 @@ skills["AncestralCryPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "ancestral_cry_duration_+%_final_per_removable_endurance_charge", 1 },
+		{ "ancestral_cry_duration_+%_final_per_removable_endurance_charge", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "gem_quality_ancestral_cry_global_fire_damage_granted_+%_final", 0.5, { 0 } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 10, }, },
@@ -160,6 +163,8 @@ skills["AncestralCryShockwavePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.6, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 0.66, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -275,6 +280,8 @@ skills["AncestralCryProjectilePlayer"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.CannotChain] = true, [SkillType.Fire] = true, [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.8, cooldown = 0.4, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -399,7 +406,10 @@ skills["AncestralWarriorTotemPlayer"] = {
 	skillTotemId = 15,
 	castTime = 0.5,
 	qualityStats = {
-		{ "base_totem_duration", 100 },
+		{ "base_totem_duration", 100, {  } },
+	},
+	altQualityStats = {
+		{ "totem_life_+%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, manaMultiplier = 100, cost = { Mana = 13, }, },
@@ -527,6 +537,8 @@ skills["SupportAncestralWarriorTotemPlayer"] = {
 	ignoreMinionTypes = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -645,7 +657,10 @@ skills["WolfArcticHowlPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "wolf_warcry_buff_freeze_buildup_+%", 1 },
+		{ "wolf_warcry_buff_freeze_buildup_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "chance_for_exerted_attacks_to_not_reduce_count_%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -791,7 +806,10 @@ skills["ArmourBreakerPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "armour_break_amount_+%", 1 },
+		{ "armour_break_amount_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 5, }, },
@@ -915,7 +933,10 @@ skills["ArtilleryBallistaPlayer"] = {
 	skillTotemId = 22,
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_totems_allowed", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 14, }, },
@@ -1047,7 +1068,9 @@ skills["ArtilleryBallistaProjectilePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_pins_as_though_dealt_damage_+%_final", 10 },
+		{ "active_skill_pins_as_though_dealt_damage_+%_final", 10, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -75, baseMultiplier = 0.15, levelRequirement = 0, },
@@ -1175,7 +1198,10 @@ skills["AttritionPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_attrition_culling_strike_at_x_or_more_stacks", -0.25 },
+		{ "skill_attrition_culling_strike_at_x_or_more_stacks", -0.25, {  } },
+	},
+	altQualityStats = {
+		{ "presence_area_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -1300,7 +1326,10 @@ skills["BarkskinPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "barkskin_armour_to_gain_as_%_of_energy_shield_lost_to_enemy_hits", 0.25 },
+		{ "barkskin_armour_to_gain_as_%_of_energy_shield_lost_to_enemy_hits", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -1412,7 +1441,10 @@ skills["BerserkPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_base_rage_effect_+%_to_apply", 0.5 },
+		{ "skill_base_rage_effect_+%_to_apply", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "berserk_maximum_rage_granted_+", 0.4, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -1471,8 +1503,11 @@ skills["BerserkPlayer"] = {
 					div = 100,
 				},
 				["skill_base_rage_effect_+%_to_apply"] = {
-					mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
-				}
+					mod("RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+				},
+				["berserk_maximum_rage_granted_+"] = {
+					mod("MaxRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+				},
 			},
 			baseFlags = {
 			},
@@ -1537,6 +1572,8 @@ skills["BlackPowderBlitzReservationPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.DodgeReplacement] = true, [SkillType.Detonator] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1646,7 +1683,9 @@ skills["BlackPowderBlitzPlayer"] = {
 	skillTypes = { [SkillType.UsableWhileMoving] = true, [SkillType.Cooldown] = true, [SkillType.Travel] = true, [SkillType.CanCancelActions] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Physical] = true, [SkillType.Fire] = true, [SkillType.Jumping] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 4.5, critChance = 15, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -1783,7 +1822,10 @@ skills["BoneshatterPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attack_speed_+%", 1 },
+		{ "attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 1, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -1974,7 +2016,10 @@ skills["BriarpatchPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, [SkillType.Physical] = true, [SkillType.Limit] = true, [SkillType.Plant] = true, [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Duration] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Sustained] = true, [SkillType.Damage] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "spells_chance_to_hinder_on_hit_%", 0.25 },
+		{ "spells_chance_to_hinder_on_hit_%", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 0.3, {  } },
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, spiritReservationFlat = 30, },
@@ -2101,7 +2146,9 @@ skills["HyenaCacklePlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2217,7 +2264,9 @@ skills["MetaCastOnBlockPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "cast_on_block_gain_X_centienergy_on_block", 0.25 },
+		{ "cast_on_block_gain_X_centienergy_on_block", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2334,6 +2383,8 @@ skills["SupportMetaCastOnBlockPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -2447,6 +2498,8 @@ skills["MetaCastOnMeleeKillPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[8] = { levelRequirement = 26, spiritReservationFlat = 60, },
 	},
@@ -2482,6 +2535,8 @@ skills["SupportMetaCastOnMeleeKillPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[8] = { cooldown = 0.2, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2516,6 +2571,8 @@ skills["MetaCastOnMeleeStunPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[8] = { levelRequirement = 26, spiritReservationFlat = 60, },
@@ -2553,6 +2610,8 @@ skills["SupportMetaCastOnMeleeStunPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[8] = { cooldown = 0.2, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2588,7 +2647,10 @@ skills["ClusterGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "skill_detonation_time_+%", -2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 1.2, cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 14, }, },
@@ -2819,6 +2881,8 @@ skills["CrossbowRequiemAmmoPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 22, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 25, }, },
@@ -2940,7 +3004,9 @@ skills["CrossbowRequiemPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 300, baseMultiplier = 3, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3069,7 +3135,9 @@ skills["StaffConsecratePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Triggerable] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.Cascadable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 1.25,
 	qualityStats = {
-		{ "base_cast_speed_+%", 0.5 },
+		{ "base_cast_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3190,7 +3258,10 @@ skills["WolfCrossSlashPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_secondary_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_secondary_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_physical_damage_%_to_convert_to_cold", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 10, baseMultiplier = 1.3, cooldown = 2, levelRequirement = 0, storedUses = 1, cost = { Mana = 10, }, },
@@ -3376,7 +3447,10 @@ skills["DefianceBannerReservationPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Banner] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -3482,6 +3556,8 @@ skills["DefianceBannerPlayer"] = {
 	skillTypes = { [SkillType.Banner] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Buff] = true, [SkillType.Aura] = true, [SkillType.HasUsageCondition] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3615,7 +3691,10 @@ skills["WyvernDevourPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "wyvern_devour_flask_charm_charge_gain_chance_%", 2.5 },
+		{ "wyvern_devour_flask_charm_charge_gain_chance_%", 2.5, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_gain_1_more_charge_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 70, baseMultiplier = 0.65, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -3742,7 +3821,10 @@ skills["DreadBannerReservationPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Banner] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -3848,6 +3930,8 @@ skills["DreadBannerPlayer"] = {
 	skillTypes = { [SkillType.Banner] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Buff] = true, [SkillType.Aura] = true, [SkillType.HasUsageCondition] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3984,7 +4068,10 @@ skills["EarthquakePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_earthquakes_allowed", 0.1 },
+		{ "base_number_of_earthquakes_allowed", 0.1, { 0 } },
+	},
+	altQualityStats = {
+		{ "gem_quality_earthquake_damaging_ailment_effect_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -4202,7 +4289,10 @@ skills["EarthshatterPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "earthshatter_damage_+%_final_per_spike", 0.3 },
+		{ "earthshatter_damage_+%_final_per_spike", 0.3, {  } },
+	},
+	altQualityStats = {
+		{ "slam_aftershock_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.45, levelRequirement = 0, cost = { Mana = 7, }, },
@@ -4387,7 +4477,10 @@ skills["EmergencyReloadPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "emergency_reload_damage_+%_final", 0.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 45, levelRequirement = 0, storedUses = 1, cost = { Mana = 12, }, },
@@ -4504,7 +4597,10 @@ skills["EntanglePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Unleashable] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Limit] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Sustained] = true, [SkillType.CreatesFissure] = true, [SkillType.Damage] = true, [SkillType.Plant] = true, [SkillType.Triggerable] = true, [SkillType.Totemable] = true, [SkillType.Trappable] = true, [SkillType.Nature] = true, },
 	castTime = 0.9,
 	qualityStats = {
-		{ "skill_additional_fissure_chance_%", 1 },
+		{ "skill_additional_fissure_chance_%", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "base_number_of_entangle_roots_allowed", 0.2, { 0 } },
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -4716,7 +4812,10 @@ skills["EternalRagePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Persistent] = true, [SkillType.ReserveInAllSets] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "ceaseless_rage_base_rage_regeneration_per_minute", 1.5 },
+		{ "ceaseless_rage_base_rage_regeneration_per_minute", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_spirit_reservation_efficiency_+%", 0.75, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 100, },
@@ -4836,7 +4935,10 @@ skills["ExplosiveGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 2.15, cooldown = 5, levelRequirement = 0, storedUses = 3, cost = { Mana = 10, }, },
@@ -4978,7 +5080,10 @@ skills["MetaFeralInvocationPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 1 },
+		{ "energy_generated_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_reservation_efficiency_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, spiritReservationFlat = 60, storedUses = 1, },
@@ -5093,6 +5198,8 @@ skills["SupportFeralInvocationPlayer"] = {
 	addSkillTypes = { SkillType.UsedByClone, SkillType.UsedByProxy, SkillType.SupportedByFeralInvocation, },
 	excludeSkillTypes = { SkillType.Meta, SkillType.HasUsageCondition, SkillType.Triggered, SkillType.Persistent, SkillType.UsedByProxy, SkillType.SupportedByFeralInvocation, SkillType.NOT, SkillType.AND, },
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5212,7 +5319,9 @@ skills["FerociousRoarMetaPlayer"] = {
 	},
 	castTime = 1.1,
 	qualityStats = {
-		{ "bear_warcry_gain_X_centirage_per_enemy_power", 5 },
+		{ "bear_warcry_gain_X_centirage_per_enemy_power", 5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -5331,7 +5440,10 @@ skills["SupportFerociousRoarPlayer"] = {
 	isTrigger = true,
 	ignoreMinionTypes = true,
 	qualityStats = {
-		{ "warcry_grant_damage_+%_to_exerted_attacks", 1.5 },
+		{ "warcry_grant_damage_+%_to_exerted_attacks", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_speed_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5448,7 +5560,10 @@ skills["WyvernFlameBreathPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "channelled_skill_suppress_ongoing_rage_cost_for_first_X_ms", 50 },
+		{ "channelled_skill_suppress_ongoing_rage_cost_for_first_X_ms", 50, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 700, baseMultiplier = 0.3, cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 23, RagePerMinute = 360, }, },
@@ -5583,7 +5698,11 @@ skills["FlashGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_all_damage_%_to_gain_as_lightning", 0.5, {  } },
+		{ "active_skill_base_all_damage_%_to_gain_as_cold", 0.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, cooldown = 5, levelRequirement = 0, storedUses = 1, cost = { Mana = 7, }, },
@@ -5721,7 +5840,10 @@ skills["ForgeHammerPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_all_damage_%_to_gain_as_fire", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 1.85, cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Mana = 9, }, },
@@ -5923,7 +6045,10 @@ skills["FortifyingCryPlayer"] = {
 	skillTypes = { [SkillType.Warcry] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Damage] = true, [SkillType.ConsumesCharges] = true, [SkillType.Cooldown] = true, [SkillType.Physical] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.UsableWhileMoving] = true, [SkillType.SkillConsumesEnduranceChargesOnUse] = true, [SkillType.Nova] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "fortifying_cry_guard_gained_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -6049,7 +6174,10 @@ skills["FortifyingCryShockwavePlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.InbuiltTrigger] = true, [SkillType.NonWeaponAttack] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "base_secondary_skill_effect_duration", 2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -6182,7 +6310,10 @@ skills["FuriousSlamPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_stun_threshold_+%_while_performing_action", 2 },
+		{ "active_skill_stun_threshold_+%_while_performing_action", 2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.7, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -6376,7 +6507,10 @@ skills["BearFuryOfTheMountainPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "gain_x_rage_on_attack_hit", 0.1 },
+		{ "gain_x_rage_on_attack_hit", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.55, levelRequirement = 0, cost = { ManaPerMinute = 600, }, },
@@ -6506,7 +6640,10 @@ skills["ToxicGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 1, { 2 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.4, cooldown = 3, levelRequirement = 0, storedUses = 3, cost = { Mana = 12, }, },
@@ -6805,7 +6942,9 @@ skills["GeminiSurgePlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.15 },
+		{ "active_skill_base_area_of_effect_radius", 0.15, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, },
@@ -6993,7 +7132,10 @@ skills["HammerOfTheGodsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_not_consume_glory_%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -50, baseMultiplier = 5.8, levelRequirement = 0, cost = { Mana = 10, }, },
@@ -7134,7 +7276,10 @@ skills["HeraldOfAshPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "herald_of_ash_burning_%_overkill_damage_per_minute", 15 },
+		{ "herald_of_ash_burning_%_overkill_damage_per_minute", 15, { 1 } },
+	},
+	altQualityStats = {
+		{ "herald_of_ash_fire_damage_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -7325,7 +7470,10 @@ skills["HeraldOfBloodPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "skill_herald_bleeding_enemies_explode_for_%_blood_loss_as_unscalable_physical_damage", 0.2 },
+		{ "skill_herald_bleeding_enemies_explode_for_%_blood_loss_as_unscalable_physical_damage", 0.2, { 1 } },
+	},
+	altQualityStats = {
+		{ "herald_of_blood_global_physical_damage_granted_+%", 0.75, { 0 } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -7513,7 +7661,10 @@ skills["InfernalCryPlayer"] = {
 	skillTypes = { [SkillType.Warcry] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Fire] = true, [SkillType.Cooldown] = true, [SkillType.ConsumesCharges] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.UsableWhileMoving] = true, [SkillType.SkillConsumesEnduranceChargesOnUse] = true, [SkillType.Nova] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "infernal_cry_exerted_attack_all_damage_%_to_gain_as_fire_%", 0.5 },
+		{ "infernal_cry_exerted_attack_all_damage_%_to_gain_as_fire_%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 1.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -7644,6 +7795,8 @@ skills["InfernalCryCorpseExplosionPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 		[2] = { critChance = 7, levelRequirement = 0, },
@@ -7771,6 +7924,8 @@ skills["IronWardPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -7878,7 +8033,10 @@ skills["IronWardNovaPlayer"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Nova] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_hit_damage_stun_multiplier_+%_final", 2.5 },
+		{ "active_skill_hit_damage_stun_multiplier_+%_final", 2.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -8002,7 +8160,10 @@ skills["LeapSlamPlayer"] = {
 	},
 	castTime = 1.4,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_vs_fully_broken_armour", 1 },
+		{ "active_skill_damage_+%_final_vs_fully_broken_armour", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -8138,6 +8299,8 @@ skills["ArmourPiercingBoltsAmmoPlayer"] = {
 	castTime = 0.6,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 8, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 9, }, },
@@ -8254,7 +8417,10 @@ skills["ArmourPiercingBoltsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "armour_break_amount_+%", 1 },
+		{ "armour_break_amount_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 325, baseMultiplier = 0.25, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -8391,7 +8557,10 @@ skills["ExplosiveShotAmmoPlayer"] = {
 	},
 	castTime = 1.5,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_crossbow_bolts", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 9, }, },
@@ -8510,7 +8679,9 @@ skills["ExplosiveShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_ignite_effect_+%_final", 1.5 },
+		{ "active_skill_ignite_effect_+%_final", 1.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 1.3, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -8730,7 +8901,10 @@ skills["FragmentationRoundsAmmoPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_reload_speed_+%_final", 5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 7, }, },
@@ -8848,7 +9022,9 @@ skills["FragmentationRoundsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.1 },
+		{ "base_number_of_projectiles", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -9085,7 +9261,10 @@ skills["GalvanicShardsAmmoPlayer"] = {
 	},
 	castTime = 0.6,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_crossbow_bolts", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 6, }, },
@@ -9204,7 +9383,9 @@ skills["GalvanicShardsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.1 },
+		{ "base_number_of_projectiles", 0.1, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.15, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -9423,7 +9604,9 @@ skills["GlacialBoltAmmoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_crossbow_bolts", 0.1 },
+		{ "base_number_of_crossbow_bolts", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 7, }, },
@@ -9541,7 +9724,10 @@ skills["GlacialBoltPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 0.5, { 1 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -9769,7 +9955,9 @@ skills["HailstormRoundsAmmoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_crossbow_bolts", 0.25 },
+		{ "base_number_of_crossbow_bolts", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 28, }, },
@@ -9892,7 +10080,10 @@ skills["HailstormRoundsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_reduce_enemy_cold_resistance_%", 3, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -45, baseMultiplier = 0.63, levelRequirement = 0, cost = { Mana = 24, }, },
@@ -10026,6 +10217,8 @@ skills["HighVelocityRoundsAmmoPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 6, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 8, }, },
@@ -10142,7 +10335,10 @@ skills["HighVelocityRoundsPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_projectile_damage_+%_final_if_pierced_enemy", 1 },
+		{ "active_skill_projectile_damage_+%_final_if_pierced_enemy", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.6, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10370,6 +10566,8 @@ skills["IceShardsAmmoPlayer"] = {
 	castTime = 0.6,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 12, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 14, }, },
@@ -10486,7 +10684,10 @@ skills["IceShardsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_chill_as_though_damage_+%_final", 5 },
+		{ "active_skill_chill_as_though_damage_+%_final", 5, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 10, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 450, baseMultiplier = 0.08, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10718,6 +10919,8 @@ skills["IncendiaryShotAmmoPlayer"] = {
 	castTime = 0.8,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 6, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 7, }, },
@@ -10834,7 +11037,10 @@ skills["IncendiaryShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "ignite_duration_+%_per_shotgun_pellet_hit", 0.75 },
+		{ "ignite_duration_+%_per_shotgun_pellet_hit", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.2, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.1, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10983,7 +11189,10 @@ skills["PermafrostBoltsAmmoPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_reload_speed_+%_final", 5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 6, }, },
@@ -11101,7 +11310,9 @@ skills["PermafrostBoltsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.1 },
+		{ "base_number_of_projectiles", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.17, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -11246,6 +11457,8 @@ skills["PlasmaBlastAmmoPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 18, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 21, }, },
@@ -11363,7 +11576,10 @@ skills["PlasmaBlastPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_shock_duration_+%_final", 1.5 },
+		{ "active_skill_shock_duration_+%_final", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, { 0 } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 8.3, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -11585,6 +11801,8 @@ skills["RapidShotAmmoPlayer"] = {
 	castTime = 1.2,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 27, }, },
 		[2] = { levelRequirement = 3, cost = { Mana = 31, }, },
@@ -11702,7 +11920,10 @@ skills["RapidShotPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "maximum_number_of_crossbow_heat_stacks", 0.75 },
+		{ "maximum_number_of_crossbow_heat_stacks", 0.75, {  } },
+	},
+	altQualityStats = {
+		{ "maximum_number_of_crossbow_heat_stacks", 1.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 450, baseMultiplier = 0.26, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -11841,7 +12062,9 @@ skills["ShockburstRoundsAmmoPlayer"] = {
 	},
 	castTime = 0.8,
 	qualityStats = {
-		{ "base_number_of_crossbow_bolts", 0.2 },
+		{ "base_number_of_crossbow_bolts", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 14, }, },
@@ -11961,7 +12184,10 @@ skills["ShockburstRoundsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1.5, { 1 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 300, baseMultiplier = 0.1, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12180,7 +12406,10 @@ skills["SiegeCascadeAmmoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_crossbow_bolts", 0.15, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 12, }, },
@@ -12300,7 +12529,10 @@ skills["SiegeCascadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_vs_immobilised_enemies", 2 },
+		{ "active_skill_damage_+%_final_vs_immobilised_enemies", 2, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_crossbow_bolts", 0.005, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12516,7 +12748,10 @@ skills["StormblastBoltsAmmoPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_crossbow_bolts", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 9, }, },
@@ -12636,7 +12871,9 @@ skills["StormblastBoltsPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_reduce_enemy_lightning_resistance_%", 1 },
+		{ "base_reduce_enemy_lightning_resistance_%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -12840,7 +13077,10 @@ skills["LunarAssaultPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_physical_damage_%_to_gain_as_cold", 0.5 },
+		{ "active_skill_base_physical_damage_%_to_gain_as_cold", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_reduce_enemy_cold_resistance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 10, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -12960,7 +13200,10 @@ skills["WolfLunarBlessingPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "wolf_lunar_blessing_all_damage_%_to_gain_as_cold_damage", 0.5 },
+		{ "wolf_lunar_blessing_all_damage_%_to_gain_as_cold_damage", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_speed_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 22, levelRequirement = 0, storedUses = 1, cost = { Mana = 24, }, },
@@ -13079,6 +13322,8 @@ skills["WolfLunarBlessingBeamAttackPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.65, cooldown = 1, levelRequirement = 0, storedUses = 1, },
@@ -13200,7 +13445,10 @@ skills["MagmaBarrierPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Fire] = true, [SkillType.Persistent] = true, [SkillType.GeneratesCharges] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "skill_igneous_shield_grants_block_chance_+%", 0.25 },
+		{ "skill_igneous_shield_grants_block_chance_+%", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "magma_barrier_maximum_block_chance_granted_%", 0.25, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -13317,6 +13565,8 @@ skills["MagmaSprayPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.InbuiltTrigger] = true, [SkillType.NonWeaponAttack] = true, [SkillType.NoAttackOrCastTime] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.7, critChance = 5, levelRequirement = 0, },
@@ -13446,7 +13696,10 @@ skills["MoltenBlastPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "inflict_exposure_on_hit_%_chance", 1.5 },
+		{ "inflict_exposure_on_hit_%_chance", 1.5, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_projectiles", 0.1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.65, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -13650,7 +13903,9 @@ skills["MoltenCrashPlayer"] = {
 	},
 	castTime = 1.4,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -13848,7 +14103,10 @@ skills["MetaMortarCannonPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "totem_skill_area_of_effect_+%", 1 },
+		{ "totem_skill_area_of_effect_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_totems_allowed", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 18, }, },
@@ -13977,6 +14235,8 @@ skills["SupportMortarCannonPlayer"] = {
 	addSkillTypes = { SkillType.UsedByTotem, SkillType.UsedByProxy, SkillType.SupportedByMortarTotem, },
 	excludeSkillTypes = { SkillType.Meta, SkillType.HasUsageCondition, SkillType.Triggered, SkillType.Persistent, SkillType.UsedByProxy, SkillType.SupportedByMortarTotem, SkillType.NOT, SkillType.AND, },
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -14110,7 +14370,10 @@ skills["OilBarragePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "skill_base_oil_exposure_-_to_total_elemental_resistance", 0.25 },
+		{ "skill_base_oil_exposure_-_to_total_elemental_resistance", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "charge_skip_consume_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 200, baseMultiplier = 0.9, levelRequirement = 0, cost = { Mana = 6, ManaPerMinute = 360, }, },
@@ -14401,7 +14664,10 @@ skills["OilGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "skill_base_oil_exposure_-_to_total_elemental_resistance", 0.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, cooldown = 4, levelRequirement = 0, storedUses = 3, cost = { Mana = 9, }, },
@@ -14622,7 +14888,9 @@ skills["OverwhelmingPresencePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "aura_effect_+%", 0.75 },
+		{ "aura_effect_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -14736,7 +15004,10 @@ skills["PerfectStrikePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_ignite_chance_+%_final", 1 },
+		{ "active_skill_ignite_chance_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -70, baseMultiplier = 1.1, levelRequirement = 0, cost = { ManaPerMinute = 372, }, },
@@ -14936,6 +15207,8 @@ skills["WolfPouncePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, cost = { Mana = 15, }, },
 		[2] = { baseMultiplier = 1.1, cooldown = 6, levelRequirement = 3, storedUses = 1, cost = { Mana = 17, }, },
@@ -15052,6 +15325,8 @@ skills["SupportWolfPouncePlayer"] = {
 	excludeSkillTypes = { SkillType.InbuiltTrigger, },
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -15157,8 +15432,10 @@ skills["WolfPounceMarkPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.Mark] = true, [SkillType.Limit] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, [SkillType.Wolf] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "skill_wolf_mark_damage_taken_+%_per_nearby_enemy", 0.05 },
-		{ "skill_wolf_mark_damage_taken_+%_cap", 0.75 },
+		{ "skill_wolf_mark_damage_taken_+%_per_nearby_enemy", 0.05, {  } },
+		{ "skill_wolf_mark_damage_taken_+%_cap", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -15290,7 +15567,10 @@ skills["WolfPounceSummonWolfPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "number_of_wolves_allowed", 0.2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -15412,7 +15692,10 @@ skills["BearRampagePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "channelled_skill_suppress_ongoing_rage_cost_for_first_X_ms", 50 },
+		{ "channelled_skill_suppress_ongoing_rage_cost_for_first_X_ms", 50, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0.75, levelRequirement = 0, cost = { Mana = 14, RagePerMinute = 300, }, },
@@ -15538,7 +15821,10 @@ skills["ResonatingShieldPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Physical] = true, [SkillType.Channel] = true, [SkillType.RequiresShield] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.Sustained] = true, [SkillType.NonWeaponAttack] = true, [SkillType.ActiveBlock] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "armour_break_amount_+%", 1 },
+		{ "armour_break_amount_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "stun_threshold_+%_while_channelling", 5, {  } },
 	},
 	levels = {
 		[1] = { attackTime = 800, baseMultiplier = 0.3, critChance = 5, levelRequirement = 0, cost = { ManaPerMinute = 417, }, },
@@ -15676,7 +15962,10 @@ skills["RollingMagmaPlayer"] = {
 	},
 	castTime = 0.7,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_per_time_chained", 0.5 },
+		{ "active_skill_damage_+%_final_per_time_chained", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "number_of_chains", 0.2, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -15814,7 +16103,10 @@ skills["RollingSlamPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_stun_threshold_+%_while_performing_action", 5 },
+		{ "active_skill_stun_threshold_+%_while_performing_action", 5, { 0, 1, 2 } },
+	},
+	altQualityStats = {
+		{ "armour_break_physical_damage_%_dealt_as_armour_break", 2, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 14, }, },
@@ -16076,6 +16368,8 @@ skills["SavageFuryPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -16186,7 +16480,10 @@ skills["SavageFuryActivePlayer"] = {
 	},
 	castTime = 0.6,
 	qualityStats = {
-		{ "wild_beast_damage_+%_final", 0.25 },
+		{ "wild_beast_damage_+%_final", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "wild_beast_energy_per_hit", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -16314,7 +16611,10 @@ skills["ScavengedPlatingPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Duration] = true, [SkillType.Persistent] = true, [SkillType.Physical] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, {  } },
+	},
+	altQualityStats = {
+		{ "scavenged_plating_armour_+%_final_per_stack", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -16446,7 +16746,10 @@ skills["SeismicCryPlayer"] = {
 	skillTypes = { [SkillType.Warcry] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.ConsumesCharges] = true, [SkillType.SkillConsumesEnduranceChargesOnUse] = true, [SkillType.Cooldown] = true, [SkillType.Physical] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Nova] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "seismic_cry_slam_skill_aftershock_damage_+%_final", 0.5 },
+		{ "seismic_cry_slam_skill_aftershock_damage_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_physical_damage_%_to_gain_as_fire", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Mana = 19, }, },
@@ -16584,7 +16887,10 @@ skills["ShardScavengerPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -16698,7 +17004,10 @@ skills["ShieldChargePlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RequiresShield] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Channel] = true, [SkillType.Travel] = true, [SkillType.NonWeaponAttack] = true, [SkillType.ActiveBlock] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_additional_damage_from_distance_+%_final", 2 },
+		{ "base_additional_damage_from_distance_+%_final", 2, {  } },
+	},
+	altQualityStats = {
+		{ "shield_charge_extra_distance", 1.5, {  } },
 	},
 	levels = {
 		[1] = { attackTime = 600, baseMultiplier = 0.3, critChance = 5, levelRequirement = 0, cost = { ManaPerMinute = 432, }, },
@@ -16945,7 +17254,10 @@ skills["ShieldWallPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Wall] = true, [SkillType.Duration] = true, [SkillType.RequiresShield] = true, [SkillType.Physical] = true, [SkillType.Area] = true, [SkillType.NonWeaponAttack] = true, [SkillType.Melee] = true, [SkillType.CanCreateStoneElementals] = true, [SkillType.Limit] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "shield_wall_damage_+%_final_when_slammed", 2 },
+		{ "shield_wall_damage_+%_final_when_slammed", 2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_physical_damage_%_to_gain_as_fire", 1, {  } },
 	},
 	levels = {
 		[1] = { attackTime = 1250, baseMultiplier = 0.65, critChance = 5, levelRequirement = 0, cost = { Mana = 13, }, },
@@ -17099,7 +17411,10 @@ skills["ShockwaveTotemPlayer"] = {
 	skillTotemId = 5,
 	castTime = 0.6,
 	qualityStats = {
-		{ "base_totem_duration", 200 },
+		{ "base_totem_duration", 200, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_totems_allowed", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 15, }, },
@@ -17240,6 +17555,8 @@ skills["ShockwaveTotemQuakePlayer"] = {
 	},
 	castTime = 0.6,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -50, baseMultiplier = 0.25, levelRequirement = 0, },
@@ -17424,7 +17741,10 @@ skills["SiegeBallistaPlayer"] = {
 	skillTotemId = 19,
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_totems_allowed", 0.05, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 18, }, },
@@ -17552,7 +17872,9 @@ skills["SiegeBallistaProjectilePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_area_of_effect_+%_final", 1 },
+		{ "active_skill_area_of_effect_+%_final", 1, { 1 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -75, baseMultiplier = 0.25, levelRequirement = 0, },
@@ -17754,7 +18076,9 @@ skills["SummonMetaTotemSpellTotemPlayer"] = {
 	skillTypes = { [SkillType.SummonsTotem] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Meta] = true, [SkillType.Limit] = true, [SkillType.HasUsageCondition] = true, [SkillType.RequiresCharges] = true, [SkillType.ConsumesCharges] = true, [SkillType.SkillConsumesEnduranceChargesOnUse] = true, [SkillType.SkillConsumesPowerChargesOnUse] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "base_totem_duration", 200 },
+		{ "base_totem_duration", 200, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 18, }, },
@@ -17887,7 +18211,10 @@ skills["SupportMetaTotemSpellTotemPlayer"] = {
 	excludeSkillTypes = { SkillType.Meta, SkillType.HasUsageCondition, SkillType.Cooldown, SkillType.Triggered, SkillType.Persistent, SkillType.UsedByProxy, SkillType.SupportedBySpellTotem, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "totems_spells_cast_speed_+%_per_active_totem", 0.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -18010,7 +18337,10 @@ skills["StampedePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "slam_aftershock_chance_%", 1 },
+		{ "slam_aftershock_chance_%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 9, }, },
@@ -18280,7 +18610,10 @@ skills["SunderPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "accuracy_range_penalty_+%", -2.5 },
+		{ "accuracy_range_penalty_+%", -2.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_attack_speed_+%_final", 1, { 0 } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -60, baseMultiplier = 1.6, levelRequirement = 0, cost = { Mana = 15, }, },
@@ -18481,7 +18814,10 @@ skills["SuperchargedSlamPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "channelled_slam_max_stages", 0.05 },
+		{ "channelled_slam_max_stages", 0.05, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_hit_damage_stun_multiplier_+%_final", 15, {  } },
 	},
 	levels = {
 		[1] = { attackTime = 850, baseMultiplier = 0.7, levelRequirement = 0, cost = { ManaPerMinute = 474, }, },
@@ -18708,7 +19044,10 @@ skills["ThrashingVinesPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.AreaSpell] = true, [SkillType.Sustained] = true, [SkillType.GamepadDeflectable] = true, [SkillType.Cascadable] = true, [SkillType.Plant] = true, [SkillType.Physical] = true, [SkillType.Duration] = true, [SkillType.Limit] = true, [SkillType.Triggerable] = true, [SkillType.Trappable] = true, [SkillType.Nature] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.25 },
+		{ "active_skill_base_area_of_effect_radius", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "impale_on_hit_%_chance", 1.5, {  } },
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 14, }, },
@@ -18845,7 +19184,9 @@ skills["MetaCastLightningSpellOnHitPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.Lightning] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -18962,6 +19303,8 @@ skills["SupportMetaCastLightningSpellOnHitPlayer"] = {
 	isTrigger = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -19074,8 +19417,11 @@ skills["ThunderstormPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Cascadable] = true, [SkillType.AreaSpell] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, [SkillType.Storm] = true, },
 	castTime = 0.9,
 	qualityStats = {
-		{ "thunderstorm_wet_debuff_shock_chance_on_+%_final", 0.5 },
-		{ "thunderstorm_wet_debuff_hit_damage_freeze_multiplier_+%_final", 0.25 },
+		{ "thunderstorm_wet_debuff_shock_chance_on_+%_final", 0.5, {  } },
+		{ "thunderstorm_wet_debuff_hit_damage_freeze_multiplier_+%_final", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 12, }, },
@@ -19229,7 +19575,10 @@ skills["TimeOfNeedPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, [SkillType.AffectedByCooldownRate] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_time_of_need_gain_x_life", 2 },
+		{ "skill_time_of_need_gain_x_life", 2, {  } },
+	},
+	altQualityStats = {
+		{ "time_of_need_global_life_regeneration_rate_granted_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -19341,7 +19690,10 @@ skills["TornadoPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Triggerable] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.Physical] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.DamageOverTime] = true, [SkillType.Storm] = true, [SkillType.Wind] = true, [SkillType.Limit] = true, [SkillType.InteractsWithElementalGround] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, {  } },
+	},
+	altQualityStats = {
+		{ "number_of_tornados_allowed", 0.1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 10, }, },
@@ -19474,7 +19826,9 @@ skills["ValakosChargePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Chains] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggered] = true, [SkillType.NoAttackOrCastTime] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "number_of_chains", 0.1 },
+		{ "number_of_chains", 0.1, { 1 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, critChance = 9, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -19669,7 +20023,10 @@ skills["VolcanicFissurePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "slam_aftershock_chance_%", 1 },
+		{ "slam_aftershock_chance_%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -20, baseMultiplier = 0.63, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -19790,7 +20147,10 @@ skills["VolcanoPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Duration] = true, [SkillType.Projectile] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Damage] = true, [SkillType.Channel] = true, [SkillType.Projectile] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.Sustained] = true, [SkillType.GamepadDeflectable] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_quality_duration_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, cost = { Mana = 7, ManaPerMinute = 360, }, },
@@ -20035,7 +20395,10 @@ skills["ShockGrenadePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_lightning_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 0.8, cooldown = 4, levelRequirement = 0, storedUses = 3, cost = { Mana = 10, }, },
@@ -20170,7 +20533,10 @@ skills["WarBannerReservationPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Banner] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_reservation_efficiency_+%", 0.5 },
+		{ "base_reservation_efficiency_+%", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_area_of_effect_+%_final", 1.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -20281,7 +20647,10 @@ skills["WalkingCalamityPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "walking_calamity_non_skill_base_all_damage_%_to_gain_as_fire", 0.5 },
+		{ "walking_calamity_non_skill_base_all_damage_%_to_gain_as_fire", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "chance_to_not_consume_glory_%", 2.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 0, levelRequirement = 0, cost = { Mana = 24, }, },
@@ -20407,6 +20776,8 @@ skills["WalkingCalamityMeteorPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
@@ -20589,6 +20960,8 @@ skills["WarBannerPlayer"] = {
 	castTime = 0.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -20721,7 +21094,10 @@ skills["WingBlastPlayer"] = {
 	},
 	castTime = 0.5,
 	qualityStats = {
-		{ "wing_blast_chance_to_gain_power_charge_on_stun_%", 0.25 },
+		{ "wing_blast_chance_to_gain_power_charge_on_stun_%", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_physical_damage_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.85, levelRequirement = 0, cost = { Mana = 8, }, },
@@ -20925,7 +21301,10 @@ skills["WolfPackPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_wolf_pack_size", 0.05 },
+		{ "skill_wolf_pack_size", 0.05, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_minion_attack_speed_+%_final", 1, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 60, },

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1261,6 +1261,9 @@ skills["AttritionPlayer"] = {
 				["skill_attrition_hit_damage_+%_final_vs_rare_or_unique_enemy_per_second_ever_in_presence_up_to_max"] = {
 					mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "Buff"}, { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limitVar = "AttritionMaxDamage", div = 2, limitTotal = true }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),
 				},
+				["presence_area_+%"] = {
+					mod("PresenceArea", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+				},
 			},
 			baseFlags = {
 			},
@@ -1506,7 +1509,7 @@ skills["BerserkPlayer"] = {
 					mod("RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 				},
 				["berserk_maximum_rage_granted_+"] = {
-					mod("MaxRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+					mod("MaximumRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 				},
 			},
 			baseFlags = {
@@ -4128,6 +4131,9 @@ skills["EarthquakePlayer"] = {
 				["skill_jagged_ground_base_duration_ms"] = {
 					skill("duration", nil),
 					div = 1000,
+				},
+				["gem_quality_earthquake_damaging_ailment_effect_+%_final"] = {
+					mod("AilmentMagnitude", "MORE", nil, 0, bit.bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite)),
 				},
 			},
 			baseFlags = {
@@ -7332,6 +7338,9 @@ skills["HeraldOfAshPlayer"] = {
 				["herald_of_ash_overkill_threshold_%"] = {
 					mod("HeraldOfAshBuff", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ash" }),
 				},
+				["herald_of_ash_fire_damage_+%"] = {
+					mod("FireDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ash" }),
+				},
 			},
 			baseFlags = {
 			},
@@ -7525,6 +7534,9 @@ skills["HeraldOfBloodPlayer"] = {
 			statMap = {
 				["display_herald_of_blood_behaviour"] = {
 					flag("Condition:EnemiesExplode", { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Blood" } ),
+				},
+				["herald_of_blood_global_physical_damage_granted_+%"] = {
+					mod("PhysicalDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Blood" }),
 				},
 			},
 			baseFlags = {
@@ -13501,6 +13513,9 @@ skills["MagmaBarrierPlayer"] = {
 				["skill_igneous_shield_grants_block_chance_+%"] = {
 					mod("BlockChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Magma Barrier" }),
 				},
+				["magma_barrier_maximum_block_chance_granted_%"] = {
+					mod("BlockChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Magma Barrier" }),
+				},
 			},
 			baseFlags = {
 			},
@@ -18266,6 +18281,14 @@ skills["SupportMetaTotemSpellTotemPlayer"] = {
 			label = "SupportMetaTotemSpellTotemPlayer",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "meta_gem_stat_descriptions",
+			statMap = {
+				["support_spell_totem_cast_speed_+%_final"] = {
+					mod("Speed", "MORE", nil, ModFlag.Cast),
+				},
+				["totems_spells_cast_speed_+%_per_active_totem"] = {
+					mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "PerStat", stat = "TotemsSummoned" }),
+				},
+			},
 			baseFlags = {
 			},
 			baseMods = {
@@ -19627,6 +19650,11 @@ skills["TimeOfNeedPlayer"] = {
 			label = "Time of Need",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "time_of_need",
+			statMap = {
+				["time_of_need_global_life_regeneration_rate_granted_+%"] = {
+					mod("LifeRegen", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+				},
+			},
 			baseFlags = {
 				duration = true,
 			},

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -14,6 +14,8 @@ skills["MeleeAtAnimationSpeed"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -48,6 +50,8 @@ skills["MinionMelee"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -79,6 +83,8 @@ skills["MinionMeleeStep"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -114,6 +120,8 @@ skills["MinionMeleeBow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -152,7 +160,10 @@ skills["GasShotSkeletonSniperMinion"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Area] = true, [SkillType.ProjectileNumber] = true, [SkillType.ProjectileSpeed] = true, [SkillType.Rain] = true, [SkillType.DamageOverTime] = true, [SkillType.Cooldown] = true, [SkillType.Duration] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.MirageArcherCanUse] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0.001 },
+		{ "dummy_stat_display_nothing", 0.001, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_fire_damage_+%_final", 2.5, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, baseMultiplier = 0.8, cooldown = 6, levelRequirement = 0, storedUses = 1, },
@@ -260,6 +271,8 @@ skills["BoneshatterBruteMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, baseMultiplier = 1.8, cooldown = 4, levelRequirement = 0, storedUses = 1, },
 	},
@@ -316,6 +329,8 @@ skills["ShatteringRoarSkeletalBruteMinion"] = {
 	skillTypes = { [SkillType.Warcry] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Cold] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Nova] = true, [SkillType.Minion] = true, [SkillType.AttackInPlace] = true, [SkillType.SkillConsumesFreeze] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 12, levelRequirement = 0, storedUses = 1, },
@@ -400,6 +415,8 @@ skills["ArcSkeletonMageMinion"] = {
 	castTime = 1.25,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, },
 	},
@@ -445,6 +462,8 @@ skills["DeathStormSkeletonStormMageMinion"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Lightning] = true, [SkillType.Area] = true, [SkillType.Cooldown] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 10, levelRequirement = 0, storedUses = 1, },
@@ -493,6 +512,8 @@ skills["FrostBoltSkeletonMageMinion"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Multicastable] = true, [SkillType.Cold] = true, [SkillType.Unleashable] = true, [SkillType.Area] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.25,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, },
@@ -576,6 +597,8 @@ skills["IceArmourSkeletonMageMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 12, levelRequirement = 0, storedUses = 1, },
 	},
@@ -653,6 +676,8 @@ skills["HealSkeletonClericMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -724,6 +749,8 @@ skills["FireBombSkeletonMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -793,7 +820,9 @@ skills["DestructiveLinkSkeletonBombadierMinion"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Cooldown] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Damage] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "arsonist_destructive_link_%_of_life_as_fire_damage", 0.2 },
+		{ "arsonist_destructive_link_%_of_life_as_fire_damage", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 3, cooldown = 3, levelRequirement = 0, storedUses = 1, },
@@ -915,6 +944,8 @@ skills["EnrageSkeletonReaverMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 4, levelRequirement = 0, storedUses = 1, },
 	},
@@ -952,6 +983,8 @@ skills["GAAncestralJadeHulkLeapImpact"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
@@ -993,6 +1026,8 @@ skills["TCAncestralLeagueKaruiHulk"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 7, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1025,6 +1060,8 @@ skills["MPSAncestralTotemSpiritSoulCasterProjectile"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -1103,6 +1140,8 @@ skills["GAAnimateWeaponMaceSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -50, baseMultiplier = 1.8, cooldown = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1132,6 +1171,8 @@ skills["DTTAnimateWeaponSpearDashStabImpact"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.8, levelRequirement = 0, },
@@ -1164,6 +1205,8 @@ skills["GAAnimateWeaponQuarterstaffSweep"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.9, cooldown = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1193,6 +1236,8 @@ skills["RavenousSwarmAttack"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Melee] = true, [SkillType.Chaos] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1303,6 +1348,8 @@ skills["LivingLightningZap"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.25, critChance = 9, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1341,6 +1388,8 @@ skills["DeathFromAboveDaemonMinion"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Rain] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesNumberModifiersNotApplied] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 7.63, cooldown = 10, levelRequirement = 0, storedUses = 1, },
@@ -1391,6 +1440,8 @@ skills["HyenaCompanionMelee"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -1425,6 +1476,8 @@ skills["MeleeAtAnimationSpeedWolfCompanion"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1470,6 +1523,8 @@ skills["WolfLeapAttackMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 25, cooldown = 7, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1504,6 +1559,8 @@ skills["CorpseBeetleExplode"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 15, levelRequirement = 0, },
@@ -1552,7 +1609,9 @@ skills["WaterBubbleWaterDjinn"] = {
 	skillTypes = { [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
-		{ "water_djinn_water_bubble_absorb_damage_%_enemy_outside_bubble", 0.5 },
+		{ "water_djinn_water_bubble_absorb_damage_%_enemy_outside_bubble", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 15, levelRequirement = 0, storedUses = 1, },
@@ -1599,8 +1658,10 @@ skills["ChilledGroundBurstWaterDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Cold] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.2,
 	qualityStats = {
-		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 2 },
-		{ "active_skill_chill_as_though_damage_+%_final", 2 },
+		{ "active_skill_hit_damage_freeze_multiplier_+%_final", 2, {  } },
+		{ "active_skill_chill_as_though_damage_+%_final", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 12, levelRequirement = 0, storedUses = 1, },
@@ -1647,7 +1708,9 @@ skills["ESRechargeForceRestartWaterDjinn"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.1,
 	qualityStats = {
-		{ "djinn_granted_energy_shield_recharge_rate_+%", 1 },
+		{ "djinn_granted_energy_shield_recharge_rate_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 12, levelRequirement = 0, storedUses = 1, },
@@ -1684,7 +1747,9 @@ skills["ChilledGroundOasisConvertWaterDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Buff] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.8,
 	qualityStats = {
-		{ "oasis_x_charges_for_life_and_mana_flasks_per_minute", 0.6 },
+		{ "oasis_x_charges_for_life_and_mana_flasks_per_minute", 0.6, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -1725,7 +1790,9 @@ skills["PassiveTriggeredManaWaveWaterDjinn"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "water_djinn_mana_wave_mana_regeneration_rate_+%", 1 },
+		{ "water_djinn_mana_wave_mana_regeneration_rate_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1763,7 +1830,9 @@ skills["LivingBombFireDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Fire] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Limit] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_damage_+%_final_vs_burning_enemies", 1 },
+		{ "active_skill_damage_+%_final_vs_burning_enemies", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
@@ -1812,7 +1881,9 @@ skills["FireRuneFireDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Hazard] = true, [SkillType.Cooldown] = true, [SkillType.Duration] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Fire] = true, [SkillType.Projectile] = true, [SkillType.SingleMainProjectile] = true, [SkillType.CannotChain] = true, [SkillType.CannotTerrainChain] = true, [SkillType.Limit] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, { 1, 2 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -1937,7 +2008,9 @@ skills["MeteorFireDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Fire] = true, [SkillType.Cooldown] = true, [SkillType.Cascadable] = true, [SkillType.Detonator] = true, },
 	castTime = 2.3,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 12, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -2016,7 +2089,9 @@ skills["MassFusilladeFireDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.Spell] = true, [SkillType.Fire] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, },
 	castTime = 2.3,
 	qualityStats = {
-		{ "base_number_of_projectiles", 0.2 },
+		{ "base_number_of_projectiles", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 7, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -2102,7 +2177,9 @@ skills["FlameSliceFireDjinn"] = {
 	skillTypes = { [SkillType.Melee] = true, [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Cooldown] = true, [SkillType.MeleeSingleTarget] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "melee_range_+", 0.2 },
+		{ "melee_range_+", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 4.5, cooldown = 4, levelRequirement = 0, storedUses = 1, },
@@ -2142,7 +2219,9 @@ skills["KnifeThrowSandDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, [SkillType.Projectile] = true, [SkillType.CannotChain] = true, [SkillType.GroundTargetedProjectile] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "djinn_knife_throw_number_of_knives_created", 0.1 },
+		{ "djinn_knife_throw_number_of_knives_created", 0.1, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 15, levelRequirement = 0, storedUses = 2, },
@@ -2228,7 +2307,9 @@ skills["ExplosiveTeleportSandDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.8,
 	qualityStats = {
-		{ "djinn_damage_+%_final_per_teleport_in_sequence", 0.5 },
+		{ "djinn_damage_+%_final_per_teleport_in_sequence", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 15, levelRequirement = 0, storedUses = 3, },
@@ -2311,7 +2392,9 @@ skills["HandSlamSandDjinn"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, [SkillType.Channel] = true, [SkillType.Cooldown] = true, [SkillType.GainsStages] = true, },
 	castTime = 0.5,
 	qualityStats = {
-		{ "apply_X_stacks_of_critical_weakness_on_hit", 0.1 },
+		{ "apply_X_stacks_of_critical_weakness_on_hit", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 12, critChance = 15, levelRequirement = 0, storedUses = 1, },
@@ -2364,6 +2447,8 @@ skills["ApplyTangmazuSwarmAuraPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.Aura] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.AffectsPresence] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2453,6 +2538,8 @@ skills["TangmazuMadFlightMinion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 5.5, cooldown = 10, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2493,6 +2580,8 @@ skills["AzmerianSwarmAttack"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.75, levelRequirement = 0, },
 	},
@@ -2524,6 +2613,8 @@ skills["MeleeAtAnimationSpeedWolfPackleader"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2.5, levelRequirement = 0, },
@@ -2559,6 +2650,8 @@ skills["WolfPackleaderDashAttack"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 7, cooldown = 7.5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2592,6 +2685,8 @@ skills["WolfPackleaderLungeBite"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 3.5, cooldown = 3.5, levelRequirement = 0, storedUses = 1, },
@@ -2628,6 +2723,8 @@ skills["GreatHuntPackleaderMinion"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, },
 	castTime = 4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 50, baseMultiplier = 10, cooldown = 15, levelRequirement = 0, storedUses = 1, },
@@ -2668,6 +2765,8 @@ skills["CompanionBearMaul"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 20, levelRequirement = 0, },
 	},
@@ -2703,6 +2802,8 @@ skills["CompanionBearSlam"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Attack] = true, [SkillType.Slam] = true, [SkillType.Melee] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, levelRequirement = 0, storedUses = 1, },
@@ -2741,6 +2842,8 @@ skills["CompanionBearLeapImpact"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2781,6 +2884,8 @@ skills["GSWardboundMinionBlast"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -18,6 +18,8 @@ skills["TriggeredAbyssalApparitionPlayer"] = {
 	cannotBeSupported = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -132,7 +134,9 @@ skills["AcidicConcoctionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -351,7 +355,9 @@ skills["AlignFatePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.ReserveInAllSets] = true, [SkillType.AffectedByCooldownRate] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "spellflux_frequency_+%_final", 1 },
+		{ "spellflux_frequency_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -476,7 +482,9 @@ skills["AncestralSpiritsPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.Chains] = true, [SkillType.Duration] = true, [SkillType.DamageOverTime] = true, [SkillType.RangedAttack] = true, [SkillType.ProjectilesFromUser] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -602,7 +610,10 @@ skills["AnimusExchangePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cooldown] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "animus_exchange_gain_%_maximum_life_spent_as_ward", 0.25, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 4, levelRequirement = 0, storedUses = 1, cost = { Mana = 15, }, },
@@ -718,7 +729,10 @@ skills["MetaAnimusSplintersPlayer"] = {
 	skillTypes = { [SkillType.Meta] = true, [SkillType.Instant] = true, [SkillType.InstantNoRepeatWhenHeld] = true, [SkillType.Cooldown] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_cost_efficiency_+%", 1 },
+		{ "base_skill_cost_efficiency_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "skill_effect_duration_+%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Ward = 0, }, },
@@ -833,6 +847,8 @@ skills["SupportAnimusSplintersPlayer"] = {
 	ignoreMinionTypes = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -886,7 +902,9 @@ skills["ApocalypsePlayer"] = {
 	skillTypes = { [SkillType.Triggers] = true, [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.HasUsageCondition] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "unleash_the_elements_trigger_frequency_+%", 0.75 },
+		{ "unleash_the_elements_trigger_frequency_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 8, }, },
@@ -1006,6 +1024,8 @@ skills["ApocalypseColdPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Cold] = true, [SkillType.Storm] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 12, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1135,6 +1155,8 @@ skills["ApocalypseFirePlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1259,6 +1281,8 @@ skills["ApocalypseLightningPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Lightning] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1503,7 +1527,9 @@ skills["ArchonOfChayulaPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "archon_of_chayula_physical_and_chaos_damage_+%_final", 0.25 },
+		{ "archon_of_chayula_physical_and_chaos_damage_+%_final", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1639,6 +1665,8 @@ skills["ArchonOfChayulaTornadoPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 0.49, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1769,7 +1797,9 @@ skills["AzmerianSwarmPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "max_azmerian_swarms", 0.1 },
+		{ "max_azmerian_swarms", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1905,7 +1935,9 @@ skills["SummonAzmerianWolfPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2019,6 +2051,8 @@ skills["CommandPackleaderPlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 8, }, },
@@ -2136,7 +2170,10 @@ skills["BitterDeadPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.TargetsDestructibleCorpses] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "volatile_dead_base_number_of_corpses_to_consume", 0.05 },
+		{ "volatile_dead_base_number_of_corpses_to_consume", 0.05, {  } },
+	},
+	altQualityStats = {
+		{ "base_chance_to_not_consume_corpse_%", 0.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Ward = 11, }, },
@@ -2465,7 +2502,9 @@ skills["BleedingConcoctionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -2600,7 +2639,9 @@ skills["BloodBoilPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, [SkillType.DamageOverTime] = true, [SkillType.Area] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_effect_duration", 75 },
+		{ "base_skill_effect_duration", 75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2721,6 +2762,8 @@ skills["MeleeBowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -2918,7 +2961,9 @@ skills["ExplodingPoisonToadPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Chaos] = true, [SkillType.Physical] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.NonWeaponAttack] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.UseGlobalStats] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "trigger_toad_spawn_chance_%", 0.5 },
+		{ "trigger_toad_spawn_chance_%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2.25, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3041,7 +3086,9 @@ skills["MetaDeadeyeMarksPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.Triggers] = true, [SkillType.Area] = true, [SkillType.HasReservation] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3156,6 +3203,8 @@ skills["SupportMetaDeadeyeMarksPlayer"] = {
 	excludeSkillTypes = { },
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -3266,7 +3315,9 @@ skills["MetaCastOnCharmUsePlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3382,6 +3433,8 @@ skills["SupportMetaCastOnCharmUsePlayer"] = {
 	excludeSkillTypes = { SkillType.InbuiltTrigger, },
 	isTrigger = true,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3529,6 +3582,8 @@ skills["ChaosSpearTriggerChaosSurgePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, },
 		[2] = { baseMultiplier = 0.55, levelRequirement = 3, },
@@ -3646,8 +3701,11 @@ skills["ConductiveRunesPlayer"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Hazard] = true, [SkillType.Duration] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Limit] = true, [SkillType.UseGlobalStats] = true, [SkillType.NonWeaponAttack] = true, [SkillType.Lightning] = true, [SkillType.Totemable] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "rune_hazard_arming_time_ms", -5 },
-		{ "rune_hazard_detonate_time_ms", -5 },
+		{ "rune_hazard_arming_time_ms", -5, {  } },
+		{ "rune_hazard_detonate_time_ms", -5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 0.3, {  } },
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Ward = 15, }, },
@@ -3854,6 +3912,8 @@ skills["MeleeCrossbowPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 1.1, levelRequirement = 3, cost = { Mana = 0, }, },
@@ -3988,6 +4048,8 @@ skills["UnloadAmmoPlayer"] = {
 	castTime = 0.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -4107,7 +4169,9 @@ skills["CrushingFearPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_area_of_effect_+%_final", 0.5 },
+		{ "active_skill_area_of_effect_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 4, levelRequirement = 0, cost = { Mana = 6, }, },
@@ -4329,7 +4393,9 @@ skills["DemonFormPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Cooldown] = true, [SkillType.Shapeshift] = true, [SkillType.ManualCooldownConsumption] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "demon_form_grants_cast_speed_+%", 0.5 },
+		{ "demon_form_grants_cast_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 15, levelRequirement = 0, storedUses = 1, cost = { Mana = 6, }, },
@@ -4455,7 +4521,10 @@ skills["DetonateLivingPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.65,
 	qualityStats = {
-		{ "corpse_explosion_monster_life_permillage_physical", 1 },
+		{ "corpse_explosion_monster_life_permillage_physical", 1, { 1 } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 12, levelRequirement = 0, cost = { Ward = 11, }, },
@@ -4656,7 +4725,9 @@ skills["ElementalExpressionTriggeredPlayer"] = {
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Lightning] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.Projectile] = true, [SkillType.Area] = true, [SkillType.Chains] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.25, levelRequirement = 0, storedUses = 1, cost = { Mana = 3, }, },
@@ -4967,7 +5038,9 @@ skills["ElementalStormPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Orb] = true, [SkillType.AreaSpell] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Cooldown] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 3, levelRequirement = 0, storedUses = 1, cost = { Mana = 8, }, },
@@ -5341,7 +5414,9 @@ skills["AmazonTriggerElementalSurgePlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.CannotConsumeCharges] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.15 },
+		{ "active_skill_base_area_of_effect_radius", 0.15, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5587,7 +5662,9 @@ skills["EncaseInJadePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Guard] = true, [SkillType.Duration] = true, [SkillType.Physical] = true, },
 	castTime = 0.3,
 	qualityStats = {
-		{ "maximum_life_%_damage_absorbed_per_jade_consumed", 0.05 },
+		{ "maximum_life_%_damage_absorbed_per_jade_consumed", 0.05, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 15, }, },
@@ -5736,7 +5813,10 @@ skills["EternalMarchPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Minion] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, [SkillType.Instant] = true, [SkillType.Triggerable] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "skill_eternal_march_maximum_ward_cost", 10 },
+		{ "skill_eternal_march_maximum_ward_cost", 10, {  } },
+	},
+	altQualityStats = {
+		{ "base_cooldown_speed_+%", 2, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 4, levelRequirement = 0, storedUses = 1, },
@@ -5853,7 +5933,9 @@ skills["ExplosiveConcoctionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "explosive_concoction_number_of_secondary_projectiles", 0.1 },
+		{ "explosive_concoction_number_of_secondary_projectiles", 0.1, { 1 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5983,6 +6065,8 @@ skills["ExplosiveTransmutationPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -6090,7 +6174,10 @@ skills["TriggeredExplosiveTransmutationExplosionPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Cascadable] = true, [SkillType.Physical] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.Lightning] = true, [SkillType.Chaos] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Cooldown] = true, [SkillType.Damage] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "base_ward_cost_efficiency_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.5, critChance = 14, levelRequirement = 0, storedUses = 5, cost = { Ward = 7, }, },
@@ -6503,7 +6590,9 @@ skills["MetaCastFireSpellOnHitPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Meta] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.Fire] = true, [SkillType.CanHaveMultipleOngoingSkillInstances] = true, [SkillType.GeneratesEnergy] = true, [SkillType.Triggers] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "energy_generated_+%", 0.75 },
+		{ "energy_generated_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -6619,6 +6708,8 @@ skills["SupportMetaCastFireSpellOnHitPlayer"] = {
 	excludeSkillTypes = { SkillType.InbuiltTrigger, },
 	isTrigger = true,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -6779,6 +6870,8 @@ skills["TriggeredFistOfKalguurPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Ward = 0, }, },
 		[2] = { baseMultiplier = 1.32, cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Ward = 0, }, },
@@ -6906,7 +6999,10 @@ skills["FragmentsOfThePastPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
+		{ "base_skill_effect_duration", 50, {  } },
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -40, baseMultiplier = 0.5, levelRequirement = 0, cost = { Ward = 11, }, },
@@ -7024,7 +7120,9 @@ skills["FragmentsOfThePastFragmentPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.RangedAttack] = true, [SkillType.Projectile] = true, [SkillType.Attack] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, levelRequirement = 0, },
@@ -7152,7 +7250,10 @@ skills["FrostflameNovaPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cold] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.Invokable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cascadable] = true, [SkillType.Fire] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.5 },
+		{ "active_skill_base_area_of_effect_radius", 0.5, { 0 } },
+	},
+	altQualityStats = {
+		{ "damage_+%_vs_frozen_enemies", 1, { 1 } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Ward = 11, }, },
@@ -7342,7 +7443,9 @@ skills["FulminatingConcoctionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_shock_chance_+%_final", 2 },
+		{ "active_skill_shock_chance_+%_final", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, critChance = 8, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -7474,7 +7577,9 @@ skills["FuturePastPlayer"] = {
 	skillTypes = { [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_secondary_skill_effect_duration", 15 },
+		{ "base_secondary_skill_effect_duration", 15, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7595,6 +7700,8 @@ skills["GelidPalmPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7778,6 +7885,8 @@ skills["MeleeGrenadeLauncherPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.65, cooldown = 1, levelRequirement = 0, storedUses = 3, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 0.71, cooldown = 1, levelRequirement = 3, storedUses = 3, cost = { Mana = 0, }, },
@@ -7907,7 +8016,10 @@ skills["GrimPillarsPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Cold] = true, [SkillType.CreatesGroundEffect] = true, [SkillType.IceCrystal] = true, [SkillType.Area] = true, [SkillType.Nova] = true, [SkillType.Cascadable] = true, [SkillType.ToggleSpawnedObjectTargetable_DefaultOn] = true, [SkillType.Limit] = true, [SkillType.Totemable] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "grim_pillars_number_of_pillars_to_create", 0.1 },
+		{ "grim_pillars_number_of_pillars_to_create", 0.1, { 0 } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_secondary_area_of_effect_radius", 0.2, {  } },
 	},
 	levels = {
 		[1] = { critChance = 12, levelRequirement = 0, cost = { Ward = 15, }, },
@@ -8123,6 +8235,8 @@ skills["HarbingerOfMadnessPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -8254,7 +8368,9 @@ skills["UniqueAtziriHeraldPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Herald] = true, [SkillType.UseGlobalStats] = true, [SkillType.Area] = true, [SkillType.Attack] = true, [SkillType.Physical] = true, [SkillType.SkillConsumesBleeding] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, [SkillType.NonWeaponAttack] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_damage_+%_final", 0.5 },
+		{ "active_skill_damage_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8514,7 +8630,9 @@ skills["HollowFocusPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_secondary_area_of_effect_radius", -0.2 },
+		{ "active_skill_base_secondary_area_of_effect_radius", -0.2, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8716,7 +8834,9 @@ skills["MetaHollowFormPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_power_charge_skip_consume_chance_%", 0.5 },
+		{ "base_power_charge_skip_consume_chance_%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, levelRequirement = 0, },
@@ -8839,6 +8959,8 @@ skills["SupportHollowFormPlayer"] = {
 	excludeSkillTypes = { SkillType.HasUsageCondition, SkillType.Meta, SkillType.Triggered, SkillType.Persistent, SkillType.Channel, SkillType.UsedByProxy, SkillType.SupportedByHollowForm, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8973,7 +9095,9 @@ skills["HollowResonancePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_hit_damage_stun_multiplier_+%_final", 1.5 },
+		{ "active_skill_hit_damage_stun_multiplier_+%_final", 1.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.6, cooldown = 0.5, levelRequirement = 0, storedUses = 3, },
@@ -9090,7 +9214,10 @@ skills["HollowShellPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Area] = true, [SkillType.Cascadable] = true, [SkillType.Nova] = true, [SkillType.Triggerable] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "skill_hollow_shell_spent_ward_%_to_grant_as_guard", 0.25 },
+		{ "skill_hollow_shell_spent_ward_%_to_grant_as_guard", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "base_skill_effect_duration", 100, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Ward = 3, }, },
@@ -9209,7 +9336,9 @@ skills["InevitableAgonyPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.25 },
+		{ "active_skill_base_area_of_effect_radius", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 2, levelRequirement = 0, storedUses = 1, cost = { Mana = 41, }, },
@@ -9332,7 +9461,9 @@ skills["IntoTheBreachPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "remnant_effect_+%", 0.75 },
+		{ "remnant_effect_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9455,7 +9586,9 @@ skills["CorpseBeetlesPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Physical] = true, [SkillType.Area] = true, [SkillType.Damage] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "maximum_corpse_beetles_allowed", 0.2 },
+		{ "maximum_corpse_beetles_allowed", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9571,6 +9704,8 @@ skills["CommandCorpseBeetleExplodePlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 7, }, },
@@ -9696,6 +9831,8 @@ skills["SummonSandDjinnPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -9808,6 +9945,8 @@ skills["CommandSandDjinnKnifeThrowPlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 3, }, },
@@ -9924,7 +10063,10 @@ skills["LeylinesPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, [SkillType.Area] = true, [SkillType.Duration] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "skill_leylines_spell_damage_+%_final", 0.5 },
+		{ "skill_leylines_spell_damage_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_base_area_of_effect_radius", 0.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -10044,7 +10186,9 @@ skills["LifeRemnantsPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "life_remnants_chance_to_spawn_orb_on_killing_enemy_%", 0.5 },
+		{ "life_remnants_chance_to_spawn_orb_on_killing_enemy_%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -10165,6 +10309,8 @@ skills["Melee1HMacePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 1.1, levelRequirement = 3, cost = { Mana = 0, }, },
@@ -10282,6 +10428,8 @@ skills["Melee2HMacePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10401,6 +10549,8 @@ skills["MeleeMaceMacePlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10536,7 +10686,9 @@ skills["ManifestWeaponPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "minion_attack_speed_+%", 1 },
+		{ "minion_attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -10668,7 +10820,9 @@ skills["BearMaulPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "gain_x_rage_on_attack_hit", 0.1 },
+		{ "gain_x_rage_on_attack_hit", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.8, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -10787,7 +10941,9 @@ skills["MeditatePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Channel] = true, [SkillType.Cooldown] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "meditate_energy_shield_recharge_rate_+%_final", 0.5 },
+		{ "meditate_energy_shield_recharge_rate_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 7, levelRequirement = 0, storedUses = 1, },
@@ -10938,7 +11094,9 @@ skills["MidnightStarPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, [SkillType.Cold] = true, [SkillType.IceCrystal] = true, [SkillType.Area] = true, [SkillType.Limit] = true, [SkillType.Damage] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "midnight_star_max_ice_crystals", 0.1 },
+		{ "midnight_star_max_ice_crystals", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, },
@@ -11142,6 +11300,8 @@ skills["MetaMirageDeadeyePlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -11251,6 +11411,8 @@ skills["SupportMirageDeadeyePlayer"] = {
 	excludeSkillTypes = { SkillType.HasUsageCondition, SkillType.Melee, SkillType.Meta, SkillType.Triggered, SkillType.Persistent, SkillType.UsedByProxy, SkillType.SupportedByMirageDeadeye, SkillType.NOT, SkillType.AND, },
 	ignoreMinionTypes = true,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -11371,7 +11533,9 @@ skills["MirageDeadeyeSpawnPlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, levelRequirement = 0, storedUses = 1, },
@@ -11488,7 +11652,9 @@ skills["SummonMistRavenPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.Duration] = true, [SkillType.Area] = true, [SkillType.Melee] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "chance_to_gain_1_more_frenzy_charge_%", 1 },
+		{ "chance_to_gain_1_more_frenzy_charge_%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -11603,6 +11769,8 @@ skills["CommandMistRavenPlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 8, }, },
@@ -11721,7 +11889,9 @@ skills["TriggeredMoltenShowerPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, [SkillType.Instant] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, cooldown = 0.25, levelRequirement = 0, storedUses = 3, cost = { Mana = 0, }, },
@@ -11842,7 +12012,9 @@ skills["MomentOfVulnerabilityPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Nova] = true, [SkillType.Area] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Damage] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.65,
 	qualityStats = {
-		{ "time_rip_damage_share_%", 1 },
+		{ "time_rip_damage_share_%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { Mana = 6, }, },
@@ -12009,6 +12181,8 @@ skills["TriggeredMorrigansInsightPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Ward = 0, }, },
 		[2] = { cooldown = 8, levelRequirement = 0, storedUses = 1, cost = { Ward = 0, }, },
@@ -12137,6 +12311,8 @@ skills["SummonWaterDjinnPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -12249,6 +12425,8 @@ skills["CommandWaterDjinnBubblePlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 7, }, },
@@ -12437,6 +12615,8 @@ skills["ParryPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackTime = 750, baseMultiplier = 0.65, critChance = 5, levelRequirement = 0, cost = { Mana = 0, ManaPerMinute = 0, }, },
 	},
@@ -12508,7 +12688,9 @@ skills["PinnacleOfPowerPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Duration] = true, [SkillType.ConsumesCharges] = true, [SkillType.SkillConsumesPowerChargesOnUse] = true, [SkillType.Instant] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.HasUsageCondition] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "elemental_power_elemental_damage_+%_final_per_power_charge", 0.1 },
+		{ "elemental_power_elemental_damage_+%_final_per_power_charge", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[20] = { cooldown = 4, levelRequirement = 0, storedUses = 1, cost = { Mana = 93, }, },
@@ -12561,7 +12743,10 @@ skills["PoweredByVerisiumPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.GeneratesInfusion] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Unleashable] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "verisium_infusion_duration_+%", 2.5 },
+		{ "verisium_infusion_duration_+%", 2.5, {  } },
+	},
+	altQualityStats = {
+		{ "additional_infusion_gain_chance_%", 1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 7, levelRequirement = 0, storedUses = 1, cost = { Ward = 20, }, },
@@ -12670,7 +12855,9 @@ skills["PrimalBountyPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.ModifiesNextSkill] = true, [SkillType.Instant] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.Buff] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "multishot_empowered_projectile_speed_+%", 1.5 },
+		{ "multishot_empowered_projectile_speed_+%", 1.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -12820,6 +13007,8 @@ skills["MeleeUnarmedPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 1.1, levelRequirement = 3, cost = { Mana = 0, }, },
@@ -12937,6 +13126,8 @@ skills["MeleeQuarterstaffPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -13067,7 +13258,9 @@ skills["RainOfBladesPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Ward = 11, }, },
@@ -13196,7 +13389,10 @@ skills["RainOfBladesTriggeredPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 1 },
+		{ "base_cooldown_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
+		{ "hit_damage_immobilisation_multiplier_+%", 1.5, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.8, cooldown = 0.3, levelRequirement = 0, storedUses = 5, cost = { Ward = 5, }, },
@@ -13315,6 +13511,8 @@ skills["ShieldBlockPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackTime = 550, baseMultiplier = 0.8, critChance = 5, levelRequirement = 0, cost = { Mana = 0, ManaPerMinute = 0, }, },
 	},
@@ -13371,7 +13569,10 @@ skills["RefutationPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.Triggerable] = true, [SkillType.Unleashable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Cooldown] = true, },
 	castTime = 0.65,
 	qualityStats = {
-		{ "runic_fortress_stun_threshold_+%_final", 1 },
+		{ "runic_fortress_stun_threshold_+%_final", 1, {  } },
+	},
+	altQualityStats = {
+		{ "base_skill_effect_duration", 50, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 11.9, levelRequirement = 0, storedUses = 1, cost = { Ward = 3, }, },
@@ -13496,8 +13697,11 @@ skills["MetaRemnantsOfKalguurPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.AttackInPlace] = true, [SkillType.GeneratesRemnants] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "ward_remnants_chance_to_spawn_orb_on_killing_enemy_%", 0.25 },
-		{ "ward_remnants_chance_to_spawn_remnant_on_stun_%", 0.25 },
+		{ "ward_remnants_chance_to_spawn_orb_on_killing_enemy_%", 0.25, {  } },
+		{ "ward_remnants_chance_to_spawn_remnant_on_stun_%", 0.25, {  } },
+	},
+	altQualityStats = {
+		{ "ward_remnants_spawn_remnant_on_stun_cooldown_ms", -2.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
@@ -13616,7 +13820,9 @@ skills["WyvernRendPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "wyvern_devour_base_all_damage_%_to_gain_as_lightning", 0.5 },
+		{ "wyvern_devour_base_all_damage_%_to_gain_as_lightning", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -10, baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -13797,6 +14003,8 @@ skills["CurseOfRepulsionPlayer"] = {
 	castTime = 0.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Ward = 15, }, },
 		[2] = { levelRequirement = 3, cost = { Ward = 18, }, },
@@ -13917,7 +14125,10 @@ skills["CurseOfRepulsionShockwavePlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Physical] = true, [SkillType.UseGlobalStats] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, [SkillType.NonWeaponAttack] = true, [SkillType.Cooldown] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_hit_damage_stun_multiplier_+%_final", 2 },
+		{ "active_skill_hit_damage_stun_multiplier_+%_final", 2, {  } },
+	},
+	altQualityStats = {
+		{ "active_skill_damage_+%_final_vs_immobilised_enemies", 1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, cooldown = 0.5, critChance = 6, levelRequirement = 0, storedUses = 5, cost = { Ward = 0, }, },
@@ -14047,7 +14258,9 @@ skills["RighteousDescentPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Physical] = true, [SkillType.Lightning] = true, [SkillType.Area] = true, [SkillType.Movement] = true, [SkillType.Cooldown] = true, [SkillType.Spear] = true, [SkillType.ManualCooldownConsumption] = true, [SkillType.Slam] = true, [SkillType.Travel] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.1 },
+		{ "active_skill_base_area_of_effect_radius", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 4, cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -14235,7 +14448,9 @@ skills["SacredGroundPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.Cooldown] = true, [SkillType.Totemable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Limit] = true, [SkillType.GainsStages] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.4 },
+		{ "active_skill_base_area_of_effect_radius", 0.4, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -14362,7 +14577,9 @@ skills["RitualSacrificePlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.TargetsDestructibleRareCorpses] = true, },
 	castTime = 5,
 	qualityStats = {
-		{ "base_skill_effect_duration", 1000 },
+		{ "base_skill_effect_duration", 1000, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 20, }, },
@@ -14511,6 +14728,8 @@ skills["TriggeredRuneforgedBladesPlayer"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.SkillGrantedBySupport] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, cost = { Ward = 7, }, },
@@ -14691,7 +14910,10 @@ skills["RunicReprievePlayer"] = {
 	skillTypes = { [SkillType.Channel] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Spell] = true, [SkillType.ActiveBlock] = true, [SkillType.CanCancelActions] = true, },
 	castTime = 0.12,
 	qualityStats = {
-		{ "active_skill_stun_threshold_+%_while_performing_action", 2 },
+		{ "active_skill_stun_threshold_+%_while_performing_action", 2, {  } },
+	},
+	altQualityStats = {
+		{ "rune_ward_block_%_damage_taken", 0.5, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { WardPerMinute = 180, }, },
@@ -14820,6 +15042,8 @@ skills["RunicTemperingPlayer"] = {
 	castTime = 1.125,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 5, levelRequirement = 0, storedUses = 1, cost = { ManaPerMinute = 174, }, },
 		[2] = { cooldown = 5, levelRequirement = 3, storedUses = 1, cost = { ManaPerMinute = 201, }, },
@@ -14946,6 +15170,8 @@ skills["SummonFireDjinnPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -15059,6 +15285,8 @@ skills["CommandFireDjinnLivingBombPlayer"] = {
 	skillTypes = { [SkillType.CommandsMinions] = true, [SkillType.UsableWhileMoving] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 0.4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 2, }, },
@@ -15176,7 +15404,9 @@ skills["SanguineRevelryPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.TotemCastsAlone] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "sanguine_revelry_rage_gain_per_pickup", 0.1 },
+		{ "sanguine_revelry_rage_gain_per_pickup", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -15368,7 +15598,9 @@ skills["ShatteringConcoctionPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "freeze_duration_+%", 1 },
+		{ "freeze_duration_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 0.7, critChance = 11, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -15504,7 +15736,9 @@ skills["WolfShredPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "attack_speed_+%", 1 },
+		{ "attack_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = 100, baseMultiplier = 0.4, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -15767,6 +16001,8 @@ skills["IceFragmentsPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, levelRequirement = 0, },
 		[2] = { baseMultiplier = 0.49, levelRequirement = 3, },
@@ -15893,7 +16129,10 @@ skills["SkyfallPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.Area] = true, [SkillType.Cold] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_spell_%_chance_to_echo", 0.5 },
+		{ "base_spell_%_chance_to_echo", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "damage_+%_vs_frozen_enemies", 1, {  } },
 	},
 	levels = {
 		[1] = { critChance = 14, levelRequirement = 0, cost = { Ward = 25, }, },
@@ -16137,6 +16376,8 @@ skills["SmashToSmithereensPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.3, cooldown = 0.5, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 1.43, cooldown = 0.5, levelRequirement = 3, storedUses = 1, cost = { Mana = 0, }, },
@@ -16255,7 +16496,9 @@ skills["NightfallSoaringMidnightPlayer"] = {
 	skillTypes = { [SkillType.ManualCooldownConsumption] = true, [SkillType.Cooldown] = true, [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.RequiresShield] = true, [SkillType.Travel] = true, [SkillType.Physical] = true, [SkillType.Cold] = true, [SkillType.NonWeaponAttack] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "projectile_base_number_of_targets_to_pierce", 0.1 },
+		{ "projectile_base_number_of_targets_to_pierce", 0.1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackTime = 1000, baseMultiplier = 0.5, cooldown = 4, critChance = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -16389,6 +16632,8 @@ skills["NightfallEmbraceTheFallPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackTime = 650, critChance = 15, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { attackTime = 650, baseMultiplier = 1.1, critChance = 15, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -16515,7 +16760,9 @@ skills["SorceryWardPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Aegis] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.Buff] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.HasReservation] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "aegis_unique_shield_max_value_from_%_armour_evasion", 0.25 },
+		{ "aegis_unique_shield_max_value_from_%_armour_evasion", 0.25, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -16641,6 +16888,8 @@ skills["MeleeSpearOffHandPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 1.1, levelRequirement = 3, cost = { Mana = 0, }, },
@@ -16758,6 +17007,8 @@ skills["MeleeSpearPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -16877,6 +17128,8 @@ skills["SpearThrowPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -30, baseMultiplier = 1.25, levelRequirement = 0, },
@@ -17068,7 +17321,9 @@ skills["SpiritVesselPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -17184,6 +17439,8 @@ skills["SpiritVesselSupport"] = {
 	ignoreMinionTypes = true,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -17297,7 +17554,9 @@ skills["StarbornOnslaughtPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "empyrean_descent_number_of_explosions", 0.2 },
+		{ "empyrean_descent_number_of_explosions", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -17579,7 +17838,9 @@ skills["SummonInfernalHoundPlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Area] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -17701,7 +17962,9 @@ skills["SupportingFirePlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.Rain] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesNumberModifiersNotApplied] = true, [SkillType.Cooldown] = true, [SkillType.CannotChain] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.ProjectileNoCollision] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_damage_+%_final", 1 },
+		{ "active_skill_minion_damage_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -17882,7 +18145,9 @@ skills["TemperWeaponPlayer"] = {
 	},
 	castTime = 1.125,
 	qualityStats = {
-		{ "skill_speed_+%", 1 },
+		{ "skill_speed_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, levelRequirement = 0, storedUses = 1, cost = { ManaPerMinute = 174, }, },
@@ -18020,6 +18285,8 @@ skills["TemperWeaponCombustionPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { baseMultiplier = 1.1, levelRequirement = 0, },
@@ -18137,7 +18404,9 @@ skills["TemporalRiftPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.HasReservation] = true, [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.OngoingSkill] = true, [SkillType.PersistentShowsCastTime] = true, [SkillType.FixedCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0.1,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 7, levelRequirement = 0, storedUses = 1, },
@@ -18253,6 +18522,8 @@ skills["TheStarsAnswerPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.Physical] = true, [SkillType.UsableWhileShapeshifted] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 10000, }, },
@@ -18374,7 +18645,9 @@ skills["TheStarsAnswerCometPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.Physical] = true, [SkillType.Damage] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_area_of_effect_+%", 1 },
+		{ "base_skill_area_of_effect_+%", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -18588,7 +18861,9 @@ skills["TimeFreezePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0.7,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 65, levelRequirement = 0, storedUses = 1, cost = { Mana = 20, }, },
@@ -18704,7 +18979,9 @@ skills["TimeSnapPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0.6,
 	qualityStats = {
-		{ "base_cooldown_speed_+%", 0.5 },
+		{ "base_cooldown_speed_+%", 0.5, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 40, levelRequirement = 0, storedUses = 1, cost = { Mana = 20, }, },
@@ -18845,6 +19122,8 @@ skills["TriggeredFracturedSelfPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -18956,7 +19235,10 @@ skills["TriskelionCascadePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Cooldown] = true, [SkillType.Buff] = true, [SkillType.ModifiesNextSkill] = true, [SkillType.Duration] = true, [SkillType.EmpowersOtherSkill] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 0.45,
 	qualityStats = {
-		{ "triskelion_cascade_next_skill_damage_+%_final", 0.5 },
+		{ "triskelion_cascade_next_skill_damage_+%_final", 0.5, {  } },
+	},
+	altQualityStats = {
+		{ "triskelion_cascade_next_skill_area_of_effect_+%_final", 0.25, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { Ward = 20, }, },
@@ -19112,7 +19394,9 @@ skills["UnboundAvatarPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Cooldown] = true, [SkillType.Instant] = true, [SkillType.Fire] = true, [SkillType.Cold] = true, [SkillType.Lightning] = true, [SkillType.InstantNoRepeatWhenHeld] = true, [SkillType.InstantShiftAttackForLeftMouse] = true, [SkillType.Duration] = true, [SkillType.HasUsageCondition] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "base_skill_effect_duration", 50 },
+		{ "base_skill_effect_duration", 50, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 12, levelRequirement = 0, storedUses = 1, },
@@ -19309,8 +19593,10 @@ skills["VirtuousBarrierPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.OngoingSkill] = true, [SkillType.Persistent] = true, [SkillType.ReserveInAllSets] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "gem_barrier_blue_grants_life_regeneration_rate_+%", 0.125 },
-		{ "gem_barrier_blue_grants_mana_regeneration_rate_+%", 0.125 },
+		{ "gem_barrier_blue_grants_life_regeneration_rate_+%", 0.125, {  } },
+		{ "gem_barrier_blue_grants_mana_regeneration_rate_+%", 0.125, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -19451,6 +19737,8 @@ skills["VerisiumManifestationPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, spiritReservationFlat = 30, },
 		[2] = { levelRequirement = 3, spiritReservationFlat = 30, },
@@ -19560,7 +19848,10 @@ skills["TriggeredManifestRunePlayer"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "base_skill_effect_duration", 100 },
+		{ "base_skill_effect_duration", 100, {  } },
+	},
+	altQualityStats = {
+		{ "base_number_of_verisium_runes_allowed", 0.1, {  } },
 	},
 	levels = {
 		[1] = { cooldown = 0.5, levelRequirement = 0, storedUses = 5, cost = { Ward = 7, }, },
@@ -19692,7 +19983,9 @@ skills["VividStampedePlayer"] = {
 	},
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.25 },
+		{ "active_skill_base_area_of_effect_radius", 0.25, { 0 } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.3, levelRequirement = 0, storedUses = 1, },
@@ -19834,6 +20127,8 @@ skills["VoidIllusionPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 3, },
@@ -19943,7 +20238,9 @@ skills["VoidIllusionSpawnPlayer"] = {
 	skillTypes = { [SkillType.OngoingSkill] = true, [SkillType.Buff] = true, [SkillType.Duration] = true, [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.Cooldown] = true, [SkillType.AttackInPlace] = true, [SkillType.UsedByClone] = true, [SkillType.UsedByProxy] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_base_area_of_effect_radius", 0.2 },
+		{ "active_skill_base_area_of_effect_radius", 0.2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 3.5, cooldown = 4, levelRequirement = 0, storedUses = 3, },
@@ -20073,7 +20370,9 @@ skills["VoltaicBarrierPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "skill_effect_duration_+%", 2 },
+		{ "skill_effect_duration_+%", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackTime = 750, baseMultiplier = 0.2, levelRequirement = 0, cost = { Ward = 20, }, },
@@ -20210,7 +20509,10 @@ skills["VoltaicBarrierTriggeredChainLightningPlayer"] = {
 	},
 	castTime = 1,
 	qualityStats = {
-		{ "dummy_stat_display_nothing", 0 },
+		{ "dummy_stat_display_nothing", 0, {  } },
+	},
+	altQualityStats = {
+		{ "number_of_chains", 0.1, {  } },
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.4, levelRequirement = 0, cost = { Ward = 0, }, },
@@ -20404,7 +20706,10 @@ skills["WardboundMinionsPlayer"] = {
 	minionSkillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Cold] = true, },
 	castTime = 0.75,
 	qualityStats = {
-		{ "wardbound_minion_maximum_number_of_casts", 0.1 },
+		{ "wardbound_minion_maximum_number_of_casts", 0.1, {  } },
+	},
+	altQualityStats = {
+		{ "base_skill_effect_duration", 250, {  } },
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Ward = 11, }, },
@@ -20528,8 +20833,10 @@ skills["WildProtectorPlayer"] = {
 	minionSkillTypes = { [SkillType.Area] = true, [SkillType.Warcry] = true, [SkillType.Attack] = true, [SkillType.Slam] = true, [SkillType.Cooldown] = true, [SkillType.Duration] = true, [SkillType.Melee] = true, [SkillType.MeleeSingleTarget] = true, },
 	castTime = 0,
 	qualityStats = {
-		{ "active_skill_minion_damage_+%_final", 1 },
-		{ "active_skill_minion_life_+%_final", 1 },
+		{ "active_skill_minion_damage_+%_final", 1, {  } },
+		{ "active_skill_minion_life_+%_final", 1, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -20642,7 +20949,9 @@ skills["AncientGiftsPlayer"] = {
 	skillTypes = { [SkillType.Buff] = true, [SkillType.Persistent] = true, [SkillType.OngoingSkill] = true, [SkillType.HasReservation] = true, [SkillType.GeneratesRemnants] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "remnant_effect_+%", 0.75 },
+		{ "remnant_effect_+%", 0.75, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },

--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -38,6 +38,8 @@ skills["ABTTProcessionBannerDrain"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -80,6 +82,8 @@ skills["AzmeriFabricationDespair"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -121,6 +125,8 @@ skills["AzmeriFabricationEnfeeble"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Necrotic] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -168,6 +174,8 @@ skills["AzmeriFabricationTemporalChains"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -208,6 +216,8 @@ skills["AzmeriPictBowRainOfSpores"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.25, cooldown = 7.5, levelRequirement = 0, storedUses = 1, },
@@ -258,6 +268,8 @@ skills["BloodMageBloodTendrils"] = {
 	castTime = 1.67,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.5, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -306,6 +318,8 @@ skills["BoneCultistZealotFirestorm"] = {
 	castTime = 3,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -348,6 +362,8 @@ skills["BoneCultistZealotLightningstorm"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -386,6 +402,8 @@ skills["BurdenedWretchSlam"] = {
 	castTime = 4.8,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 3, levelRequirement = 0, },
 	},
@@ -421,6 +439,8 @@ skills["BurdenedWretchSlamUnique"] = {
 	castTime = 4.8,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 3, levelRequirement = 0, },
 	},
@@ -454,6 +474,8 @@ skills["CGEBloodPriestBoilingBlood"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -493,6 +515,8 @@ skills["CGESanctifiedMonstrosityPusGround"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -531,6 +555,8 @@ skills["CoffinWretchBabySoulrend1"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Projectile] = true, [SkillType.DamageOverTime] = true, [SkillType.Chaos] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Trappable] = true, [SkillType.Mineable] = true, [SkillType.Totemable] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.3,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -577,6 +603,8 @@ skills["CultistBeastSunder"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 1.4, levelRequirement = 0, },
 	},
@@ -610,6 +638,8 @@ skills["DeathKnightSlamEAA"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2, cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -646,6 +676,8 @@ skills["DTTKaruiBloodFeverButcherLeap"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 6.75, levelRequirement = 0, storedUses = 1, },
 	},
@@ -678,6 +710,8 @@ skills["DTTHellscapeStabbySkyStab"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -717,6 +751,8 @@ skills["DTTMantisRatLeap"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 7, levelRequirement = 0, storedUses = 1, },
 	},
@@ -750,6 +786,8 @@ skills["EDSAbyssMorayClanFlamethrower"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 3, critChance = 6, levelRequirement = 0, storedUses = 1, },
@@ -793,6 +831,8 @@ skills["EDSGolemancerReapLeft"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.6, levelRequirement = 0, },
 	},
@@ -827,6 +867,8 @@ skills["EDSPyramidHandLightningLance"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -872,6 +914,8 @@ skills["EDSShellMonsterFlamethrower"] = {
 	castTime = 3,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 4.75, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -916,6 +960,8 @@ skills["EDSShellMonsterPoisonSpray"] = {
 	castTime = 3,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 11, levelRequirement = 0, storedUses = 1, },
 	},
@@ -955,6 +1001,8 @@ skills["ExpeditionGroundLaser"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 2, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -1002,6 +1050,8 @@ skills["FarudinWarlockBugRend"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -1043,6 +1093,8 @@ skills["FungalArtilleryMortar"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -1092,6 +1144,8 @@ skills["GADeathKnightOverheadslamforward"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.75, levelRequirement = 0, },
 	},
@@ -1126,6 +1180,8 @@ skills["GSArmourCasterVolatileExplode"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -1171,6 +1227,8 @@ skills["GSCenobiteBloaterOnDeath"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -1210,6 +1268,8 @@ skills["GSMercurialCasterBlast"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -1257,6 +1317,8 @@ skills["GACenobiteBloaterSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 2, cooldown = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1293,6 +1355,8 @@ skills["GADrownedCrawlerSwipe"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
 	},
@@ -1322,6 +1386,8 @@ skills["GAFigureheadSlamGhostFlame"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 4.8,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2, levelRequirement = 0, },
@@ -1357,6 +1423,8 @@ skills["GAFirebreatherFireSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1402,6 +1470,8 @@ skills["GAGullGoliathSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.45, cooldown = 6.5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1435,6 +1505,8 @@ skills["GAKaruiSpiritTurtleSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2, cooldown = 7, levelRequirement = 0, storedUses = 1, },
@@ -1471,6 +1543,8 @@ skills["GASaltGolemMelee"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -1499,6 +1573,8 @@ skills["GATwilightSoldierStab"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, cooldown = 4.5, levelRequirement = 0, storedUses = 1, },
@@ -1531,6 +1607,8 @@ skills["GATwilightOfficerSmite"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.15, cooldown = 5.5, levelRequirement = 0, storedUses = 1, },
@@ -1567,6 +1645,8 @@ skills["GATwilightOrderSoldierChargeImpact"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
@@ -1611,6 +1691,8 @@ skills["TCTwilghtOrderSoldierCharge"] = {
 	},
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -1662,6 +1744,8 @@ skills["TCExcavatorOrbCharge"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -1700,6 +1784,8 @@ skills["GSExcavatorOrbExplosion"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -1744,6 +1830,8 @@ skills["GSExcavatorOrbDonutExplosion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -1787,6 +1875,8 @@ skills["GAHellscapeFleshLeapImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.15, levelRequirement = 0, },
 	},
@@ -1822,6 +1912,8 @@ skills["GAHellscapePaleEliteSkyStab"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.25, levelRequirement = 0, },
 	},
@@ -1854,6 +1946,8 @@ skills["GAMantisRatDualStrike"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.05, levelRequirement = 0, },
 	},
@@ -1885,6 +1979,8 @@ skills["GAMediumBeetleChargedSunder"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 2, cooldown = 5.5, levelRequirement = 0, storedUses = 1, },
@@ -1922,6 +2018,8 @@ skills["GAMediumBeetleSunder"] = {
 	castTime = 2,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 1.35, cooldown = 5.5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -1954,6 +2052,8 @@ skills["GAMutewindWomanSpearStab1"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, },
 	},
@@ -1982,6 +2082,8 @@ skills["GATwoHeadedTitanSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2015,6 +2117,8 @@ skills["GATwoHeadedTitanStomp"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -2060,6 +2164,8 @@ skills["GoreChargerCharge"] = {
 	castTime = 0.8,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.43, cooldown = 4.5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2093,6 +2199,8 @@ skills["GraveyardGhostDashToTarget"] = {
 	castTime = 0.93,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 3, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2120,6 +2228,8 @@ skills["GraveyardSpookyGhostExplode"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -2161,6 +2271,8 @@ skills["GSAbyssPaleEliteBeam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -2204,6 +2316,8 @@ skills["MPSAbyssPaleEliteSnowBall"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -2246,6 +2360,8 @@ skills["MPSCrawGullSpit"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.75,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -2296,6 +2412,8 @@ skills["MPSKaruiCasterProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -2344,6 +2462,8 @@ skills["MPSGoblinMinerRockThrow"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -2387,6 +2507,8 @@ skills["MPSSpearfisherSpearThrow"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -2445,6 +2567,8 @@ skills["GPSPaleWalkerWave"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2490,6 +2614,8 @@ skills["GSAbyssPaleEliteSnowBallImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 	},
@@ -2529,6 +2655,8 @@ skills["GSAbyssPrimordialMonsterScreech"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -2571,6 +2699,8 @@ skills["GSDesertBatZap"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -2616,6 +2746,8 @@ skills["GSExpeditionBoneCultistEggExplosion"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
@@ -2664,6 +2796,8 @@ skills["GSHellscapeDemonEliteBeamNuke"] = {
 	castTime = 2,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 7, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2704,6 +2838,8 @@ skills["GSHellscapePaleEliteBoltImpact"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -2747,6 +2883,8 @@ skills["GSHellscapePaleEliteOmegaBeam"] = {
 	castTime = 2.333,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -2788,6 +2926,8 @@ skills["GSProwlingShadeIceBeam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 3.2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 8, levelRequirement = 0, storedUses = 1, },
@@ -2831,6 +2971,8 @@ skills["GSRagingFireSpiritsVolatileSanctum"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -2873,6 +3015,8 @@ skills["GSRagingTimeSpiritsVolatileSanctum"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -2914,6 +3058,8 @@ skills["GSShrikeScreech"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, },
@@ -2958,6 +3104,8 @@ skills["GSVaalConstructSkitterbotGrenadeExplode"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -2998,6 +3146,8 @@ skills["GSWarlockRaiseBugs"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 18, levelRequirement = 0, storedUses = 1, },
 	},
@@ -3027,6 +3177,8 @@ skills["HuhuGrubLarvaeMortar"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.3,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 2.5, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -3070,6 +3222,8 @@ skills["HellscapeDemonFodderFaceLaser"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, },
@@ -3116,6 +3270,8 @@ skills["HyenaCentaurMeleeStab"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.25, levelRequirement = 0, },
 	},
@@ -3149,6 +3305,8 @@ skills["HyenaCentaurMeleeSwipe"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.75, levelRequirement = 0, },
 	},
@@ -3177,6 +3335,8 @@ skills["HyenaCentaurSpearThrow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, cooldown = 4.5, levelRequirement = 0, storedUses = 1, },
@@ -3218,6 +3378,8 @@ skills["MASExtraAttackDistance6"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3254,6 +3416,8 @@ skills["MASExtraAttackDistance20"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3289,6 +3453,8 @@ skills["MASFireConvertAltArtFireArrow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3329,6 +3495,8 @@ skills["MASStatueWretchPush"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.1, levelRequirement = 0, },
 	},
@@ -3361,6 +3529,8 @@ skills["MASKelpDregCrossbow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3403,6 +3573,8 @@ skills["MeleeAtAnimationSpeedBow"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3439,6 +3611,8 @@ skills["MeleeAtAnimationSpeedUnique"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3477,6 +3651,8 @@ skills["MeleeAtAnimationSpeedComboTEMP"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3509,6 +3685,8 @@ skills["MeleeAtAnimationSpeedFire"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3546,6 +3724,8 @@ skills["MeleeAtAnimationSpeedCold"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3581,6 +3761,8 @@ skills["MeleeAtAnimationSpeedFireCombo35"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -3618,6 +3800,8 @@ skills["MeleeAtAnimationSpeedLightning"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -3653,6 +3837,8 @@ skills["MMSBaneSapling"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.77,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 2, levelRequirement = 0, storedUses = 1, },
@@ -3705,6 +3891,8 @@ skills["MMSBoneRabbleMortar"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -3755,6 +3943,8 @@ skills["MMSHellscapeDemonEliteTripleMortar"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -3810,6 +4000,8 @@ skills["MMSVaalGuardGrenade"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 4.4, cooldown = 2, levelRequirement = 0, storedUses = 1, },
 	},
@@ -3857,6 +4049,8 @@ skills["MMSVaalGuardOilTrap"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 11, levelRequirement = 0, storedUses = 1, },
 	},
@@ -3902,6 +4096,8 @@ skills["MPSAbyssPaleEliteFireball"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -3951,6 +4147,8 @@ skills["MPSAbyssPitArtillery"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -4003,6 +4201,8 @@ skills["GSAbyssPitArtilleryMortarImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -4044,6 +4244,8 @@ skills["MPSAbyssPaleWalker2Fireball"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -4090,6 +4292,8 @@ skills["MPSAbyssCocoon3BallSpit"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -4145,6 +4349,8 @@ skills["GSAbyssCocoon3BallSpitImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -4192,6 +4398,8 @@ skills["CGEAbyssCocoon3FlameGeyser"] = {
 	castTime = 3.532,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -4233,6 +4441,8 @@ skills["MPSAbyssCocoon3BallSpitSmall"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -4281,6 +4491,8 @@ skills["GSAbyssCocoon3BallSpitSmallImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -4322,6 +4534,8 @@ skills["MPSArmourCasterBasic"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.17,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -4372,6 +4586,8 @@ skills["MPSAzmeriPictStaffProj"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -4419,6 +4635,8 @@ skills["MPSAzmeriPictStaffProj2"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 5, critChance = 6, levelRequirement = 0, storedUses = 1, },
@@ -4471,6 +4689,8 @@ skills["MPSBloodMageBloodProjectile"] = {
 	castTime = 2.57,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 6, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -4518,6 +4738,8 @@ skills["MPSBoneRabbleBurningArrow"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -4557,6 +4779,8 @@ skills["MPSBoneCultistNecromancerLightning"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -4606,6 +4830,8 @@ skills["MPSBoneCultistZealotFire"] = {
 	castTime = 1.333,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -4651,6 +4877,8 @@ skills["MPSBoneCultistZealotLightning"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
@@ -4698,6 +4926,8 @@ skills["MPSBreachEliteBoneProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, },
 	},
@@ -4744,6 +4974,8 @@ skills["MPSBreachEliteFallenLunarisMonsterChaosSpark"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 10, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -4796,6 +5028,8 @@ skills["MPSChaosGodTriHeadLizardBasicProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -4847,6 +5081,8 @@ skills["MPSElectricStingRayProjectile"] = {
 	castTime = 1.47,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -4895,6 +5131,8 @@ skills["MPSExpeditionBoneCultistProjectiles"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
@@ -4945,6 +5183,8 @@ skills["MPSHellscapeDemonFodderProj"] = {
 	castTime = 1.25,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -4994,6 +5234,8 @@ skills["MPSHellscapeFleshEliteBasicProj"] = {
 	castTime = 1.166,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -5040,6 +5282,8 @@ skills["MPSHellscapePaleHammerhead"] = {
 	castTime = 1.166,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -5085,6 +5329,8 @@ skills["MPSMercurialCasterEnrage"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.33,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -5136,6 +5382,8 @@ skills["MPSRedSkeletonCaster"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 	},
@@ -5180,6 +5428,8 @@ skills["MPSSkeletonMancerBasicProj"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5230,6 +5480,8 @@ skills["MPSVaalBloodPriestProj"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -5276,6 +5528,8 @@ skills["MPSVaalConstructCannon"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -5326,6 +5580,8 @@ skills["MPAVaalHumanoidCannon"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -5367,6 +5623,8 @@ skills["MPSVaalHumanoidCannonNapalmMiniBlob"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5414,6 +5672,8 @@ skills["MPSVaalSunApparitionBasicProj"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -5465,6 +5725,8 @@ skills["MPWAzmeriPitifulFabricationSkullThrow"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.15, levelRequirement = 0, },
 	},
@@ -5503,6 +5765,8 @@ skills["MPWCleansedMonstrosityRailgun"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2.15, cooldown = 15, levelRequirement = 0, storedUses = 1, },
@@ -5543,6 +5807,8 @@ skills["MPWDrudgeExplosiveGrenade"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -5588,6 +5854,8 @@ skills["MPWExpeditionArbalestProjectile"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -5623,6 +5891,8 @@ skills["MPWExpeditionArbalestSnipe"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 2.65, cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -5661,6 +5931,8 @@ skills["MPWFarudinSpearThrow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 3,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.5, levelRequirement = 0, },
@@ -5704,6 +5976,8 @@ skills["MPWGoblinSpearThrow"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -5744,6 +6018,8 @@ skills["MPWKelpDregPuncture"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
 	},
@@ -5781,6 +6057,8 @@ skills["MPWVaalSavageBlowDart"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.75, levelRequirement = 0, },
@@ -5823,6 +6101,8 @@ skills["MutewindBanditWomanLeap"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -5854,6 +6134,8 @@ skills["QuillCrabSpikeBurst"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.7, levelRequirement = 0, },
@@ -5896,6 +6178,8 @@ skills["QuillCrabSpikeBurstPoison"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.7, levelRequirement = 0, },
 	},
@@ -5936,6 +6220,8 @@ skills["QuillCrabSpikeBurstTropical"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.6, levelRequirement = 0, },
@@ -5978,6 +6264,8 @@ skills["RisenArbalestBasicProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.25, levelRequirement = 0, },
 	},
@@ -6009,6 +6297,8 @@ skills["RisenArbalestSnipe"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, baseMultiplier = 2.65, cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -6051,6 +6341,8 @@ skills["RisenArbalestRainOfArrows"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -25, cooldown = 8, levelRequirement = 0, storedUses = 1, },
 	},
@@ -6082,6 +6374,8 @@ skills["SerpentClanCurse"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Cascadable] = true, [SkillType.AppliesCurse] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Physical] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6, levelRequirement = 0, storedUses = 1, },
@@ -6128,6 +6422,8 @@ skills["SerpentClanTailWhip"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.7, cooldown = 8, levelRequirement = 0, storedUses = 1, },
 		[2] = { baseMultiplier = 1.7, cooldown = 8, levelRequirement = 0, storedUses = 1, },
@@ -6167,6 +6463,8 @@ skills["ShellMonsterDeathMortar"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6217,6 +6515,8 @@ skills["ShellMonsterDeathMortarPoison"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -6266,6 +6566,8 @@ skills["ShellMonsterFirehose"] = {
 	castTime = 3,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, },
 	},
@@ -6309,6 +6611,8 @@ skills["ShellMonsterSprayMortar"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.5,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6361,6 +6665,8 @@ skills["ShellMonsterSprayMortarPoison"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -6410,6 +6716,8 @@ skills["SkelemancerSkelenado"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6463,6 +6771,8 @@ skills["SpookyGhostLightningBounce"] = {
 	castTime = 1.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -6510,6 +6820,8 @@ skills["SpookyWraithProjectileExplosionCold"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 	},
@@ -6550,6 +6862,8 @@ skills["TBAbyssCarrionWingBeam"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6593,6 +6907,8 @@ skills["GSAbyssCarrionWingBeamImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -6633,6 +6949,8 @@ skills["TBBreachElitePaleLightningBoltSpammableLeft"] = {
 	castTime = 1.333,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -6664,6 +6982,8 @@ skills["TBHellscapePaleLightningBoltSpammableLeft"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.333,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6707,6 +7027,8 @@ skills["TBVaalPyramidBeam"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6759,6 +7081,8 @@ skills["TCHellscapePaleElite2Charge"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.3, cooldown = 8, levelRequirement = 0, storedUses = 1, },
 	},
@@ -6788,6 +7112,8 @@ skills["UrchinSlingProjectile"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -24, levelRequirement = 0, },
@@ -6825,6 +7151,8 @@ skills["VaalBloodPriestDetonateDead"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.25,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6868,6 +7196,8 @@ skills["VaalBloodPriestExsanguinate"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Chains] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Physical] = true, [SkillType.Unleashable] = true, [SkillType.DamageOverTime] = true, [SkillType.Duration] = true, [SkillType.UsableWhileMoving] = true, },
 	castTime = 2.2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -6917,6 +7247,8 @@ skills["VaalBloodPriestSoulrend"] = {
 	castTime = 3.7,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -6957,6 +7289,8 @@ skills["VaalHumanoidShockRifle"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 4,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 9, critChance = 6, levelRequirement = 0, storedUses = 1, },
@@ -7003,6 +7337,8 @@ skills["VaalZealotLightningSpark"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Duration] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.Invokable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.2, critChance = 7, levelRequirement = 0, storedUses = 1, },
@@ -7054,6 +7390,8 @@ skills["VaalZealotLightningSparkNova"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 	},
@@ -7103,6 +7441,8 @@ skills["GSVaalZealotLightningBlast"] = {
 	castTime = 1.2,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, },
 	},
@@ -7148,6 +7488,8 @@ skills["JellyfishNettlerArc"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Chains] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 6, levelRequirement = 0, storedUses = 1, },
@@ -7195,6 +7537,8 @@ skills["SSMJellyfishNettlerMinions"] = {
 	castTime = 2,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 12, levelRequirement = 0, storedUses = 1, },
 	},
@@ -7231,6 +7575,8 @@ skills["MeleeGiantStarfishTentacle1"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
 	},
@@ -7263,6 +7609,8 @@ skills["MPSStarfishVomit"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7314,6 +7662,8 @@ skills["GSStarFishSpitImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -7351,6 +7701,8 @@ skills["CGEStarFishSpitCausticGround"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7390,6 +7742,8 @@ skills["MPSBrineMaidenIceProjectile"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -7440,6 +7794,8 @@ skills["GAKaruiTuataraTailSlam"] = {
 	castTime = 2.4,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, cooldown = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -7471,6 +7827,8 @@ skills["GSExcavatorRaptorTriangleSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5.5, levelRequirement = 0, },
@@ -7509,6 +7867,8 @@ skills["TBExcavatorSceptreErraticBeam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -7545,6 +7905,8 @@ skills["MASKelpDregCrossbow"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7589,6 +7951,8 @@ skills["MASKelpDregCrossbowPhys"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -7630,6 +7994,8 @@ skills["MASKelpDregCrossbowIce"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7673,6 +8039,8 @@ skills["MPWKelpDregPunctureIce"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
 	},
@@ -7712,6 +8080,8 @@ skills["MPWKelpDregPuncture"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
 	},
@@ -7750,6 +8120,8 @@ skills["MPSTwilightSorcerorFireball"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -7798,6 +8170,8 @@ skills["MPSTwilightClericProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -7843,6 +8217,8 @@ skills["MPSRaptorDefenderExplosiveShot"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 5.5, levelRequirement = 0, storedUses = 1, },
@@ -7900,6 +8276,8 @@ skills["GSRaptorDefenderRailShot"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 5.5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -7942,6 +8320,8 @@ skills["MPSGoblinShamanBasicProj"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -7992,6 +8372,8 @@ skills["MAASExpedition2ShakariBasicMelee"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.85, levelRequirement = 0, },
 	},
@@ -8027,6 +8409,8 @@ skills["MAASExpedition2ShakariTailSwipe"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -5, baseMultiplier = 1.45, cooldown = 6, levelRequirement = 0, storedUses = 1, },
@@ -8064,6 +8448,8 @@ skills["GAExpeditionShakariMonsterSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { attackSpeedMultiplier = -15, baseMultiplier = 1.35, cooldown = 10, levelRequirement = 0, storedUses = 1, },
 	},
@@ -8098,6 +8484,8 @@ skills["GARathbreakerEnrageSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 2.5, cooldown = 5, levelRequirement = 0, storedUses = 1, },
@@ -8144,6 +8532,8 @@ skills["TCRathbreakerDrivebyCharge"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 8, levelRequirement = 0, storedUses = 1, },
 	},
@@ -8180,6 +8570,8 @@ skills["MeleeAtAnimationSpeedBoss"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8213,6 +8605,8 @@ skills["GAQuadrillaBossRectSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 3, levelRequirement = 0, },
@@ -8249,6 +8643,8 @@ skills["GAIcyQuadrillaBossRectSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 3, levelRequirement = 0, },
@@ -8288,6 +8684,8 @@ skills["MeleeMudBurrowerLeftCleave"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
 	},
@@ -8320,6 +8718,8 @@ skills["MeleeMudBurrowerRightCleave"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
@@ -8354,6 +8754,8 @@ skills["MeleeMudBurrowerBite"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.4, levelRequirement = 0, },
 	},
@@ -8386,6 +8788,8 @@ skills["MPAMudBurrowerBloodProj"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.25, levelRequirement = 0, },
@@ -8431,6 +8835,8 @@ skills["GAMudBurrowerBloodProj"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8465,6 +8871,8 @@ skills["MPAMudBurrowerSprayProj"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 16, levelRequirement = 0, storedUses = 1, },
@@ -8506,6 +8914,8 @@ skills["GAMudBurrowerSpraySmallImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8541,6 +8951,8 @@ skills["MPAMudBurrowerGoopSmallBall"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8583,6 +8995,8 @@ skills["GAMudBurrowerGoopSmallImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.35, levelRequirement = 0, },
 	},
@@ -8615,6 +9029,8 @@ skills["MPAMudBurrowerGoopBigBall"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8656,6 +9072,8 @@ skills["MudBurrowerGoopExplode"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.6, levelRequirement = 0, },
 	},
@@ -8689,6 +9107,8 @@ skills["GAMudBurrowerHeadSlam"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 4, cooldown = 12, levelRequirement = 0, storedUses = 1, },
@@ -8725,6 +9145,8 @@ skills["GAMudBurrowerDivePush"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8767,6 +9189,8 @@ skills["CGEMudBurrowerVomit"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8804,6 +9228,8 @@ skills["MPAMudBurrowerVomitProj"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.8, critChance = 5, levelRequirement = 0, },
@@ -8843,6 +9269,8 @@ skills["MudBurrowerMaggotSummon"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8877,6 +9305,8 @@ skills["GPAPorcupineAntSpikeNova"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8913,6 +9343,8 @@ skills["MMAPorcupineAntSpikeball"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -8951,6 +9383,8 @@ skills["GPAPorcupineAntSpikeNovaSanctum"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -8987,6 +9421,8 @@ skills["MMAPorcupineAntSpikeballSanctum"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1.2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9026,6 +9462,8 @@ skills["MPWBlackStriderWebProjectile"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9067,6 +9505,8 @@ skills["GABlackStriderWebMortarImpact"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, levelRequirement = 0, },
 	},
@@ -9103,6 +9543,8 @@ skills["BlackStriderMassMortar"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.92, levelRequirement = 0, },
@@ -9141,6 +9583,8 @@ skills["MPWBlackStriderWebProjectileSanctum"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 6.5, levelRequirement = 0, storedUses = 1, },
@@ -9184,6 +9628,8 @@ skills["CGESanctumBlackStriderWeb"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -9219,6 +9665,8 @@ skills["QuillCrabSpikeShrapnel"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, levelRequirement = 0, },
@@ -9262,6 +9710,8 @@ skills["QuillCrabSpikeShrapnelPoison"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.2, levelRequirement = 0, },
 	},
@@ -9304,6 +9754,8 @@ skills["CGEQuillCrabFireGround"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, },
 	},
@@ -9345,6 +9797,8 @@ skills["CGEQuillCrabCausticGround"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -9385,6 +9839,8 @@ skills["GSBeetleLightningNova"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 6, levelRequirement = 0, },
 	},
@@ -9423,6 +9879,8 @@ skills["GSCaveDwellerSonicPulse"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2.266,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 12, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -9464,6 +9922,8 @@ skills["GSCaveDwellerSuperProjectile"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -9503,6 +9963,8 @@ skills["GPSCaveDwellerSuperProjectileSanctum"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 2,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9549,6 +10011,8 @@ skills["GSPlagueNymphLaser"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -9587,6 +10051,8 @@ skills["MPSPlagueNymphRailGun"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
@@ -9637,6 +10103,8 @@ skills["GSTwilightOrderPlagueNymphLaser"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, },
 	},
@@ -9675,6 +10143,8 @@ skills["MPSTwilightOrderPlagueNymphRailGun"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 8, critChance = 5, levelRequirement = 0, storedUses = 1, },
@@ -9726,6 +10196,8 @@ skills["GSSerpentClanAcidSpit"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 1.5, critChance = 5, levelRequirement = 0, storedUses = 1, },
 	},
@@ -9764,6 +10236,8 @@ skills["HyenaCentaurSpearThrowCliff"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
@@ -9806,6 +10280,8 @@ skills["MeleeAtAnimationSpeed2"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -9839,6 +10315,8 @@ skills["MAASBaronEndgameBasic"] = {
 	skillTypes = { [SkillType.Attack] = true, [SkillType.RangedAttack] = true, [SkillType.MirageArcherCanUse] = true, [SkillType.Projectile] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.Melee] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -9879,6 +10357,8 @@ skills["GAArenaBeastSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.35, cooldown = 6, levelRequirement = 0, storedUses = 1, },
 	},
@@ -9914,6 +10394,8 @@ skills["GAArenaBeastSlamEmpowered"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -9942,6 +10424,8 @@ skills["GAGoblinArenaBeastHeadbutt"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.2, levelRequirement = 0, },
@@ -9975,6 +10459,8 @@ skills["GAGoblinArenaBeastHeadbuttEmpowered"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -10002,6 +10488,8 @@ skills["GAGoblinArenaBeastGroundSlash"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.6, levelRequirement = 0, },
@@ -10038,6 +10526,8 @@ skills["GAGoblinArenaBeastGroundSlashLightning"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.5, levelRequirement = 0, },
 	},
@@ -10073,6 +10563,8 @@ skills["GAArenaBeastBossBigSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.75, levelRequirement = 0, },
 	},
@@ -10107,6 +10599,8 @@ skills["GAArenaBeastBossShockwave"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -10136,6 +10630,8 @@ skills["GAArenaBeastBossPunchLeft"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
@@ -10172,6 +10668,8 @@ skills["GAArenaBeastBossPunchLeftEmpowered"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -10199,6 +10697,8 @@ skills["GAArenaBeastBossPunchRight"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
@@ -10235,6 +10735,8 @@ skills["GAArenaBeastBossPunchRightEmpowered"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -10262,6 +10764,8 @@ skills["GAArenaBeastBossFissureDamage"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.65, levelRequirement = 0, },
@@ -10296,6 +10800,8 @@ skills["GAArenaBeastBossFissureExplosion"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.65, levelRequirement = 0, },
 	},
@@ -10328,6 +10834,8 @@ skills["CGEArenaBeastBossSulpurGas"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },
@@ -10368,6 +10876,8 @@ skills["GAArenaBeastLeapSlam"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
 	},
@@ -10398,6 +10908,8 @@ skills["GAArenaBeastLeapSlamEnraged"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
@@ -10432,6 +10944,8 @@ skills["GAArenaBeastLeapSlamEnragedKick"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 1.1, levelRequirement = 0, },
@@ -10468,6 +10982,8 @@ skills["DTTParasiteSwarmLeap"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -10499,6 +11015,8 @@ skills["DTTParasiteSwarmLeapAttach"] = {
 	castTime = 0.5,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -10526,6 +11044,8 @@ skills["BlackStriderWebProjectile"] = {
 	skillTypes = { [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Attack] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -667,6 +667,8 @@ skills["PlagueBurstPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.1, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
 	},
@@ -763,6 +765,8 @@ skills["TriggeredCaltropsPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Projectile] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Hazard] = true, [SkillType.Duration] = true, [SkillType.CannotChain] = true, [SkillType.Attack] = true, [SkillType.GroundTargetedProjectile] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { attackTime = 1, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1005,6 +1009,8 @@ skills["TriggeredChargedMarkPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, [SkillType.SkillGrantedBySupport] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -2037,6 +2043,8 @@ skills["TriggeredLightningDetonateDeadPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.3, levelRequirement = 0, storedUses = 5, },
 		[2] = { cooldown = 0.295, levelRequirement = 0, storedUses = 5, },
@@ -2339,6 +2347,8 @@ skills["TriggeredSupportFrozenSpiteIceFragmentPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Projectile] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.FrozenSpite] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.75, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3966,6 +3976,8 @@ skills["TriggeredPoisonSporesPustule"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.Chaos] = true, [SkillType.DetonatesAfterTime] = true, [SkillType.Buff] = true, [SkillType.Cooldown] = true, [SkillType.Attack] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.Physical] = true, [SkillType.Plant] = true, [SkillType.SkillGrantedBySupport] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.1, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -5774,6 +5786,8 @@ skills["KnockbackWavePlayer"] = {
 	skillTypes = { [SkillType.Area] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.InbuiltTrigger] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -74,6 +74,8 @@ skills["TriggeredExplosiveGrowthPlayerTwo"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { critChance = 10, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -222,6 +224,8 @@ skills["TriggeredExplosiveGrowthPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, [SkillType.Spell] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 10, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1010,6 +1014,8 @@ skills["TriggeredBoneShrapnelPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 13, levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -1242,6 +1248,8 @@ skills["TriggeredBurningRunesPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1392,6 +1400,8 @@ skills["TriggeredCatalysingDischargePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Triggerable] = true, [SkillType.Cooldown] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Area] = true, [SkillType.AttackInPlace] = true, [SkillType.Cold] = true, [SkillType.Fire] = true, [SkillType.Lightning] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -2269,6 +2279,8 @@ skills["TriggeredDeadlyCurrentPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.2, critChance = 10, levelRequirement = 0, storedUses = 6, cost = { Mana = 0, }, },
 		[2] = { cooldown = 0.2, critChance = 10, levelRequirement = 0, storedUses = 6, cost = { Mana = 0, }, },
@@ -2486,6 +2498,8 @@ skills["TriggeredCreepingChillPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Cold] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, [SkillType.CreatesGroundEffect] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -2863,6 +2877,8 @@ skills["TriggeredDecayingHexPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3120,6 +3136,8 @@ skills["ChaosFrogExplosionPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3248,6 +3266,8 @@ skills["TriggeredCurseZoneHazardExplosionPlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Chaos] = true, [SkillType.Spell] = true, [SkillType.AreaSpell] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 7, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3433,6 +3453,8 @@ skills["TriggeredShockingRiftPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Area] = true, [SkillType.Sustained] = true, [SkillType.Lightning] = true, [SkillType.AttackInPlace] = true, [SkillType.Damage] = true, [SkillType.Spell] = true, },
 	castTime = 0,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3687,6 +3709,8 @@ skills["TriggeredElementalDischargePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 1, critChance = 10, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
 	},
@@ -3848,6 +3872,8 @@ skills["TriggeredSparkEmpowerPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 		[2] = { levelRequirement = 0, },
@@ -3955,6 +3981,8 @@ skills["TriggeredEmpoweredSparkPlayer"] = {
 	skillTypes = { [SkillType.SkillGrantedBySupport] = true, [SkillType.Lightning] = true, [SkillType.Projectile] = true, [SkillType.Triggered] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.InbuiltTrigger] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -4264,7 +4292,9 @@ skills["EnervatingNovaPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Trappable] = true, [SkillType.Totemable] = true, [SkillType.Mineable] = true, [SkillType.Multicastable] = true, [SkillType.Triggerable] = true, [SkillType.Lightning] = true, [SkillType.Unleashable] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, [SkillType.Cascadable] = true, [SkillType.UsableWhileMoving] = true, [SkillType.Duration] = true, },
 	castTime = 1,
 	qualityStats = {
-		{ "active_skill_electrocutes_as_though_dealt_damage_+%_final", 2 },
+		{ "active_skill_electrocutes_as_though_dealt_damage_+%_final", 2, {  } },
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 11, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -4778,6 +4808,8 @@ skills["TriggeredFieryDeathPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Fire] = true, [SkillType.TargetsDestructibleCorpses] = true, [SkillType.Area] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 8, levelRequirement = 0, manaMultiplier = 20, cost = { Mana = 0, }, },
@@ -5390,6 +5422,8 @@ skills["SupportTriggeredAnnihilationPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { critChance = 9, levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { critChance = 9, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5781,6 +5815,8 @@ skills["DoomBlastPlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.AreaSpell] = true, [SkillType.Chaos] = true, [SkillType.Cooldown] = true, [SkillType.InbuiltTrigger] = true, [SkillType.SkillGrantedBySupport] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.15, critChance = 7, levelRequirement = 0, storedUses = 3, },
@@ -6291,6 +6327,8 @@ skills["TriggeredLivingLightningPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
 		[2] = { cooldown = 0.2, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
@@ -6447,6 +6485,8 @@ skills["TriggeredLivingLightningPlayerTwo"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Lightning] = true, [SkillType.Chains] = true, [SkillType.Melee] = true, [SkillType.Duration] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.2, levelRequirement = 0, storedUses = 8, cost = { Mana = 0, }, },
@@ -6745,6 +6785,8 @@ skills["TriggeredManaFlarePlayer"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Triggerable] = true, [SkillType.Cooldown] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Area] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 1, critChance = 7, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -8044,6 +8086,8 @@ skills["TriggeredStaticShocksPlayer"] = {
 	castTime = 0,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { cooldown = 0.4, critChance = 9, levelRequirement = 0, storedUses = 3, cost = { Mana = 0, }, },
 		[2] = { cooldown = 0.4, critChance = 9, levelRequirement = 0, storedUses = 3, cost = { Mana = 0, }, },
@@ -8752,6 +8796,8 @@ skills["TriggeredXibaquasRendingPlayer"] = {
 	skillTypes = { [SkillType.SkillGrantedBySupport] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.AttackInPlace] = true, [SkillType.TargetsDestructibleCorpses] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -393,6 +393,8 @@ skills["ArmourExplosionPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -761,6 +763,8 @@ skills["TriggeredBattershoutExplosionPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -1052,6 +1056,8 @@ skills["TriggeredBrambleslamPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.Attack] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Hazard] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, [SkillType.Plant] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.15, levelRequirement = 0, storedUses = 6, cost = { Mana = 0, }, },
@@ -1745,6 +1751,8 @@ skills["TriggeredCorruptingCryPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -1904,6 +1912,8 @@ skills["TriggeredCorruptingCryTwoPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -2060,6 +2070,8 @@ skills["TriggeredCraterPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -2208,6 +2220,8 @@ skills["TriggeredDeadlyResolvePlayer"] = {
 	skillTypes = { [SkillType.Triggered] = true, [SkillType.Area] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Triggerable] = true, [SkillType.Damage] = true, [SkillType.Physical] = true, [SkillType.Attack] = true, [SkillType.AttackInPlace] = true, [SkillType.UseGlobalStats] = true, [SkillType.NonWeaponAttack] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.9, critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -3334,6 +3348,8 @@ skills["TriggeredFanTheFlamesPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, cooldown = 0.5, critChance = 7, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
 		[2] = { baseMultiplier = 0.49, cooldown = 0.5, critChance = 7, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
@@ -3480,6 +3496,8 @@ skills["TriggeredFanTheFlamesPlayerTwo"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, [SkillType.Attack] = true, [SkillType.UseGlobalStats] = true, [SkillType.Cooldown] = true, [SkillType.NonWeaponAttack] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { baseMultiplier = 0.45, cooldown = 0.5, critChance = 7, levelRequirement = 0, storedUses = 5, cost = { Mana = 0, }, },
@@ -3858,6 +3876,8 @@ skills["TriggeredFlamePillarPlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -4065,6 +4085,8 @@ skills["TriggeredHaemocrystalsPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5369,6 +5391,8 @@ skills["TriggeredCorruptingCryThreePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 		[2] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -5692,6 +5716,8 @@ skills["TriggeredQuillburstPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.15, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },
@@ -6713,6 +6739,8 @@ skills["TriggeredSkitteringStonePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
 	},
@@ -6786,6 +6814,8 @@ skills["TriggeredSkitteringStonePlayerTwo"] = {
 	minionSkillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.Physical] = true, [SkillType.MeleeSingleTarget] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { levelRequirement = 0, cost = { Mana = 0, }, },
@@ -7085,6 +7115,8 @@ skills["StompingGroundShockwavePlayer"] = {
 	castTime = 1,
 	qualityStats = {
 	},
+	altQualityStats = {
+	},
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
@@ -7309,6 +7341,8 @@ skills["TriggeredSplinterExplosionHardyTotems"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Physical] = true, [SkillType.AttackInPlace] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { critChance = 5, levelRequirement = 0, cost = { Mana = 0, }, },
@@ -8059,6 +8093,8 @@ skills["TriggeredVolcanicEruptionPlayer"] = {
 	skillTypes = { [SkillType.Triggerable] = true, [SkillType.Triggered] = true, [SkillType.InbuiltTrigger] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Fire] = true, [SkillType.SkillGrantedBySupport] = true, [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.ProjectileNoCollision] = true, [SkillType.NoAttackOrCastTime] = true, [SkillType.AttackInPlace] = true, [SkillType.Cooldown] = true, },
 	castTime = 1,
 	qualityStats = {
+	},
+	altQualityStats = {
 	},
 	levels = {
 		[1] = { cooldown = 0.4, levelRequirement = 0, storedUses = 1, cost = { Mana = 0, }, },

--- a/src/Export/Scripts/skills.lua
+++ b/src/Export/Scripts/skills.lua
@@ -303,10 +303,15 @@ directiveTable.skill = function(state, args, out)
 	end
 	if not (skillGem and granted.IsSupport) then
 		skill.qualityStats = { }
+		skill.altQualityStats = { }
 		local qualityStats = dat("GrantedEffectQualityStats"):GetRow("GrantedEffect", granted)
 		if qualityStats and qualityStats.GrantedStats then
 			for i, stat in ipairs(qualityStats.GrantedStats) do
-				table.insert(skill.qualityStats, { stat.Id, qualityStats.StatValues[i] / 1000 })
+				table.insert(skill.qualityStats, { stat.Id, qualityStats.StatValues[i] / 1000, qualityStats.StatSetIndex })
+				--ConPrintf("[%d] %s %s", i, granted.ActiveSkill.DisplayName, stat.Id)
+			end
+			for i, stat in ipairs(qualityStats.AltStats) do
+				table.insert(skill.altQualityStats, { stat.Id, qualityStats.AltStatValues[i] / 1000, qualityStats.AltStatSetIndex })
 				--ConPrintf("[%d] %s %s", i, granted.ActiveSkill.DisplayName, stat.Id)
 			end
 		end
@@ -427,7 +432,14 @@ directiveTable.skill = function(state, args, out)
 	if skill.qualityStats then
 		out:write('\tqualityStats = {\n')
 		for _, stat in ipairs(skill.qualityStats) do
-			out:write('\t\t{ "', stat[1], '", ', stat[2], ' },\n')
+			out:write('\t\t{ "', stat[1], '", ', stat[2], ', { ', table.concat(stat[3], ", "), ' } },\n')
+		end
+		out:write('\t},\n')
+	end
+	if skill.altQualityStats then
+		out:write('\taltQualityStats = {\n')
+		for _, stat in ipairs(skill.altQualityStats) do
+			out:write('\t\t{ "', stat[1], '", ', stat[2], ', { ', table.concat(stat[3], ", "), ' } },\n')
 		end
 		out:write('\t},\n')
 	end

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -14,6 +14,12 @@ statMap = {
 		mod("FlaskChargesGenerated", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }),
 		div = 60,
 	},
+	["alchemists_boon_attack_speed_granted_+%_during_life_flask"] = {
+		mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }, { type = "Condition", var = "UsingLifeFlask" }),
+	},
+	["alchemists_boon_cast_speed_granted_+%_during_mana_flask"] = {
+		mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "GlobalEffect", effectType = "Aura", effectName = "Alchemists Boon" }, { type = "Condition", var = "UsingManaFlask" }),
+	},
 	--["recovery_from_flasks_applies_to_allies_in_presence_%"] = {
 	-- how to apply this in calc perform?
 		--mod("FlasksApplyToMinionPercent", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
@@ -144,6 +150,12 @@ statMap = {
 #set ElectrocutingArrowPlayer
 #flags attack projectile duration
 statMap = {
+	["electrocuting_arrow_%_damage_gained_as_extra_lightning_on_debuffed_target"] = {
+		mod("DamageGainAsLightning", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+	},
+	["electrocuting_arrow_damage_taken_+%"] = {
+		mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }),
+	},
 	["quality_display_base_skill_effect_duration_is_gem"] = {
 		-- Display only
 	},
@@ -248,6 +260,9 @@ statMap = {
 statMap = {
 	["herald_of_thunder_storm_max_hits"] = {
 		mod("HeraldOfThunderHits", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Thunder" }),
+	},
+	["herald_of_thunder_lightning_damage_+%"] = {
+		mod("LightningDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Thunder" }),
 	},
 },
 #mods
@@ -357,6 +372,9 @@ statMap = {
 	["plague_bearer_maximum_stored_poison_damage"] = {
 		mod("PlagueBearerMaxDamage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Plague Bearer" }),
 	},
+	["poison_effect_+%_vs_non_poisoned_enemies"] = {
+		mod("AilmentMagnitude", "INC", nil, 0, KeywordFlag.Poison, { type = "GlobalEffect", effectType = "Buff", effectName = "Plague Bearer" }, { type = "MultiplierThreshold", actor = "enemy", var = "PoisonStacks", threshold = 1, upper = true }),
+	},
 },
 #mods
 #skillEnd
@@ -370,6 +388,11 @@ statMap = {
 #skill PoisonBurstArrowPlayer
 #set PoisonBurstArrowPlayer
 #flags attack projectile
+statMap = {
+	["armour_break_for_%_of_poison_damage_over_poison_duration"] = {
+		flag("Condition:CanArmourBreak", { type = "GlobalEffect", effectType = "Buff", effectName = "ArmourBreak" }),
+	},
+},
 #mods
 #set PoisonBurstArrowCloudPlayer
 #flags attack projectile area duration
@@ -483,6 +506,9 @@ statMap = {
 statMap = {
 	["enemy_additional_critical_strike_multiplier_against_self"] = {
 		mod("SelfCritMultiplier", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
+	},
+	["gem_quality_marked_enemy_damage_dealt_+%_final"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Curse" }),
 	},
 },
 #baseMod skill("debuff", true)

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -9,8 +9,8 @@ local skills, mod, flag, skill = ...
 #set ArcPlayer
 #flags spell chaining projectile
 statMap = {
-	["arc_damage_+%_final_for_each_remaining_chain"] = {
-		mod("Damage", "MORE", nil, 0, 0, { type = "PerStat", stat = "ChainRemaining" }),
+	["active_skill_projectile_damage_+%_final_for_each_remaining_chain"] = {
+		mod("Damage", "MORE", nil, bit.bor(ModFlag.Projectile, ModFlag.Hit), 0, { type = "PerStat", stat = "ChainRemaining" }),
 	},
 	["quality_display_arc_is_gem"] = {
 		-- Display only

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -165,6 +165,11 @@ statMap = {
 #skill MetaCastOnCritPlayer
 #set MetaCastOnCritPlayer
 #flags
+statMap = {
+	["cast_on_crit_global_critical_hit_chance_granted_+%"] = {
+		mod("CritChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+	},
+},
 #mods
 #skillEnd
 
@@ -232,6 +237,9 @@ statMap = {
 		mod("Armour", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 		mod("Evasion", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 		mod("EnergyShield", "MORE", nil, 0, 0, { type = "StatThreshold", stat = "EnduranceCharges", threshold = 1 }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
+	},
+	["charge_regulation_damage_per_charge_granted_+%"] = {
+		mod("Damage", "INC", nil, 0, 0, { type = "Multiplier", var = "TotalCharges" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Charge Infusion" }),
 	},
 },
 #flags
@@ -620,6 +628,9 @@ statMap = {
 	["flameblast_maximum_stages"] = {
 		mod("Multiplier:FlameblastMaxStages", "BASE", nil),
 	},
+	["gem_quality_flameblast_damaging_ailment_effect_per_stage_+%_final"] = {
+		mod("AilmentMagnitude", "MORE", nil, 0, bit.bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite), { type = "Multiplier", var = "FlameblastStage" }),
+	},
 },
 #mods
 #skillEnd
@@ -827,6 +838,9 @@ statMap = {
 statMap = {
 	["display_herald_of_ice_behaviour"] = {
 		flag("Condition:EnemiesExplode", { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ice" }),
+	},
+	["herald_of_ice_cold_damage_+%"] = {
+		mod("ColdDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ice" }),
 	},
 },
 #mods
@@ -1043,6 +1057,11 @@ statMap = {
 #skill ManaRemnantsPlayer
 #set ManaRemnantsPlayer
 #flags
+statMap = {
+	["mana_remnants_global_mana_regeneration_rate_granted_+%"] = {
+		mod("ManaRegen", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+	},
+},
 #mods
 #skillEnd
 
@@ -1184,6 +1203,9 @@ statMap = {
 statMap = {
 	["harvester_minion_resummon_speed_+%_final"] = {
 		mod("MinionRevivalSpeed", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+	},
+	["sacrifice_minion_life_granted_+%"] = {
+		mod("MinionModifier", "LIST", { mod = mod("Life", "INC", nil) }, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 	},
 },
 #mods
@@ -1465,6 +1487,9 @@ statMap = {
 	["trinity_loss_per_hit"] = {
 		-- Display only
 	},
+	["trinity_%_physical_damage_to_convert_to_random_element_granted"] = {
+		mod("PhysicalDamageConvertToRandom", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Trinity" } )
+	},
 },
 #mods
 #skillEnd
@@ -1520,6 +1545,11 @@ statMap = {
 #skill WaveOfFrostPlayer
 #set WaveOfFrostPlayer
 #flags attack area melee
+statMap = {
+	["frozen_monsters_take_increased_damage"] = {
+		mod("DamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff" }, { type = "Condition", var = "Frozen" }),
+	},
+},
 #mods
 #skillEnd
 
@@ -1537,6 +1567,11 @@ statMap = {
 #skill GaleStrikePlayer
 #set GaleStrikePlayer
 #flags attack area melee
+statMap = {
+	["wind_blast_damage_+%_final_from_distance"] = {
+		mod("Damage", "MORE", nil, 0, 0, { type = "DistanceRamp", ramp = {{15,1},{40,0}} }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -105,8 +105,11 @@ statMap = {
 		div = 100,
 	},
 	["skill_base_rage_effect_+%_to_apply"] = {
-		mod( "RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
-	}
+		mod("RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+	},
+	["berserk_maximum_rage_granted_+"] = {
+		mod("MaxRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+	},
 },
 #mods
 #skillEnd

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -82,6 +82,9 @@ statMap = {
 	["skill_attrition_hit_damage_+%_final_vs_rare_or_unique_enemy_per_second_ever_in_presence_up_to_max"] = {
 		mod("Damage", "MORE", nil, 0, KeywordFlag.Hit, { type = "GlobalEffect", effectType = "Buff"}, { type = "Multiplier", var = "EnemyPresenceSeconds", actor = "enemy", limitVar = "AttritionMaxDamage", div = 2, limitTotal = true }, { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),
 	},
+	["presence_area_+%"] = {
+		mod("PresenceArea", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+	},
 },
 #mods
 #skillEnd
@@ -108,7 +111,7 @@ statMap = {
 		mod("RageEffect", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 	},
 	["berserk_maximum_rage_granted_+"] = {
-		mod("MaxRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
+		mod("MaximumRage", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" } ),
 	},
 },
 #mods
@@ -296,6 +299,9 @@ statMap = {
 		skill("duration", nil),
 		div = 1000,
 	},
+	["gem_quality_earthquake_damaging_ailment_effect_+%_final"] = {
+		mod("AilmentMagnitude", "MORE", nil, 0, bit.bor(KeywordFlag.Poison, KeywordFlag.Bleed, KeywordFlag.Ignite)),
+	},
 },
 #mods
 #set EarthquakeAftershockPlayer
@@ -464,6 +470,9 @@ statMap = {
 	["herald_of_ash_overkill_threshold_%"] = {
 		mod("HeraldOfAshBuff", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ash" }),
 	},
+	["herald_of_ash_fire_damage_+%"] = {
+		mod("FireDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Ash" }),
+	},
 },
 #mods
 #set HeraldOfAshOnKillPlayer
@@ -477,6 +486,9 @@ statMap = {
 statMap = {
 	["display_herald_of_blood_behaviour"] = {
 		flag("Condition:EnemiesExplode", { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Blood" } ),
+	},
+	["herald_of_blood_global_physical_damage_granted_+%"] = {
+		mod("PhysicalDamage", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Herald of Blood" }),
 	},
 },
 #mods
@@ -779,6 +791,9 @@ statMap = {
 	["skill_igneous_shield_grants_block_chance_+%"] = {
 		mod("BlockChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Magma Barrier" }),
 	},
+	["magma_barrier_maximum_block_chance_granted_%"] = {
+		mod("BlockChance", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Magma Barrier" }),
+	},
 },
 #mods
 #skillEnd
@@ -1068,6 +1083,14 @@ addFlags = {
 	totem = true,
 },
 #set SupportMetaTotemSpellTotemPlayer
+statMap = {
+	["support_spell_totem_cast_speed_+%_final"] = {
+		mod("Speed", "MORE", nil, ModFlag.Cast),
+	},
+	["totems_spells_cast_speed_+%_per_active_totem"] = {
+		mod("Speed", "INC", nil, ModFlag.Cast, 0, { type = "PerStat", stat = "TotemsSummoned" }),
+	},
+},
 #baseMod mod("ActiveTotemLimit", "OVERRIDE", 2) -- Should fix to take from active part of gem
 #mods
 #skillEnd
@@ -1176,6 +1199,11 @@ statMap = {
 #skill TimeOfNeedPlayer
 #set TimeOfNeedPlayer
 #flags duration
+statMap = {
+	["time_of_need_global_life_regeneration_rate_granted_+%"] = {
+		mod("LifeRegen", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Export/spec.lua
+++ b/src/Export/spec.lua
@@ -24696,14 +24696,14 @@ return {
 		},
 		[8]={
 			list=true,
-			name="AltStatValuesPermille",
+			name="AltStatValues",
 			refTo="",
 			type="Int",
 			width=300
 		},
 		[9]={
 			list=true,
-			name="AltApplyToStatSets",
+			name="AltStatSetIndex",
 			refTo="",
 			type="Int",
 			width=300

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -668,7 +668,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	end
 
 	-- Calculate distance from enemy
-	effectiveRange = env.configInput.enemyDistance
+	effectiveRange = env.configInput.enemyDistance or env.configPlaceholder.enemyDistance
 
 	-- Build config structure for modifier searches
 	activeSkill.skillCfg = {

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -88,7 +88,7 @@ function calcs.mergeSkillInstanceMods(env, modList, skillEffect, statSet, extraS
 	local grantedEffect = skillEffect.grantedEffect
 	local selectedGlobalStats = { }
 	local function mergeStatSet(set, onlyGlobals)
-		local stats = calcLib.buildSkillInstanceStats(skillEffect, grantedEffect, set)
+		local stats = calcLib.buildSkillInstanceStats(skillEffect, grantedEffect, set, env.useAltGemQualityStats)
 		if extraStats and extraStats[1] then
 			for _, stat in pairs(extraStats) do
 				stats[stat.key] = (stats[stat.key] or 0) + stat.value
@@ -554,7 +554,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 	end
 
 	-- Apply stat-map flagged skill flags.
-	for stat, statValue in pairs(calcLib.buildSkillInstanceStats(activeEffect, activeGrantedEffect, activeStatSet)) do
+	for stat, statValue in pairs(calcLib.buildSkillInstanceStats(activeEffect, activeGrantedEffect, activeStatSet, env.useAltGemQualityStats)) do
 		local map = activeGrantedEffect.statMap[stat]
 		if statValue ~= 0 and map and map.skillFlag then
 			skillFlags[map.skillFlag] = true

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -832,6 +832,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	end
 
 	local nodesModsList = calcs.buildModListForNodeList(env, env.allocNodes, true, true)
+	env.useAltGemQualityStats = nodesModsList:Flag(nil, "GemlingQuality")
 
 	if allocatedNotableCount and allocatedNotableCount > 0 then
 		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount)

--- a/src/Modules/CalcTools.lua
+++ b/src/Modules/CalcTools.lua
@@ -135,12 +135,20 @@ function calcLib.getGemStatRequirement(level, multi, isSupport)
 end
 
 -- Build table of stats for the given skill instance statset
-function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet)
+function calcLib.buildSkillInstanceStats(skillInstance, grantedEffect, statSet, includeAltQualityStats)
 	local stats = { }
-	if skillInstance.quality > 0 and grantedEffect.qualityStats then
+	if skillInstance.quality > 0 then
 		local qualityStats = grantedEffect.qualityStats
-		for _, stat in ipairs(qualityStats) do
-			stats[stat[1]] = (stats[stat[1]] or 0) + math.modf(stat[2] * skillInstance.quality)
+		if qualityStats then
+			for _, stat in ipairs(qualityStats) do
+				stats[stat[1]] = (stats[stat[1]] or 0) + math.modf(stat[2] * skillInstance.quality)
+			end
+		end
+		qualityStats = grantedEffect.altQualityStats
+		if includeAltQualityStats and qualityStats then
+			for _, stat in ipairs(qualityStats) do
+				stats[stat[1]] = (stats[stat[1]] or 0) + math.modf(stat[2] * skillInstance.quality)
+			end
 		end
 	end
 	local grantedEffectLevel = grantedEffect.levels[skillInstance.level] or { }

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3349,6 +3349,7 @@ local specialModList = {
 	["gain maximum life instead of maximum energy shield from equipped armour items"] = { flag("ConvertArmourESToLife") },
 	-- Mercenary - Gemling
 	["attribute requirements of gems can be satisi?fied by your highest attribute"] = { flag("GemAttributeRequirementsSatisfiedByHighestAttribute") },
+	["gem quality grants socketed skills an additional effect"] = { flag("GemlingQuality") },
 	["you can use two copies of the same support gem in different skills"] = { mod("MaxSupportGemCopies", "OVERRIDE", 2) },
 	["you can use each type of support gem an additional time in different skills"] = { mod("MaxSupportGemCopies", "OVERRIDE", 2) },
 	["skills have (%d+)%% increased critical hit chance per connected blue support gem"] = function(num) return {


### PR DESCRIPTION
### Description of the problem being solved:
Adds support for the new gemling quality stats
There are still a bunch that need supporting but that should be easy
Only shows the quality stats and adds their effect when you have the node allocated
Also fixes an issue where some stat descriptions for quality mods weren't working as they were using the wrong stat set stat description scope

### Link to a build that showcases this PR:
https://maxroll.gg/poe2/pob/96jfcu0w
### Before screenshot:
<img width="940" height="409" alt="image" src="https://github.com/user-attachments/assets/eb191830-1e77-4378-89b1-a663b5e01094" />
<img width="656" height="141" alt="image" src="https://github.com/user-attachments/assets/f570ce76-a0b5-4dff-8cb5-8a622d036a58" />
<img width="581" height="60" alt="image" src="https://github.com/user-attachments/assets/4285da8b-5ecc-41f5-87b8-477e5f249dc3" />

### After screenshot:
<img width="942" height="427" alt="image" src="https://github.com/user-attachments/assets/d98b382d-a8fe-421d-8406-1c2860d9c5f2" />
<img width="449" height="161" alt="image" src="https://github.com/user-attachments/assets/09171ad0-7485-4ac5-ab87-718e13479d77" />
<img width="918" height="82" alt="image" src="https://github.com/user-attachments/assets/2f2b3aae-9839-43f1-8c05-a33d0fc9c3a1" />
