### PR TITLE
Add support for poe.ninja profile import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -223,15 +223,20 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 		end
 
 		for j=1,#buildSites.websiteList do
-			if urlText:match(buildSites.websiteList[j].matchURL) then
-				self.controls.importCodeIn.text = urlText
-				self.importCodeValid = true
-				self.importCodeDetail = colorCodes.POSITIVE.."URL is valid ("..buildSites.websiteList[j].label..")"
-				self.importCodeSite = j
-				if buf ~= urlText then
-					self.controls.importCodeIn:SetText(urlText, false)
+			local matchURL = buildSites.websiteList[j].matchURL
+			local matchURLs = type() == "table" and matchURL or { matchURL }
+			for _, v in ipairs(matchURLs) do
+				if urlText:match(v) then
+					self.controls.importCodeIn.text = urlText
+					self.importCodeValid = true
+					self.importCodeDetail = colorCodes.POSITIVE ..
+						"URL is valid (" .. buildSites.websiteList[j].label .. ")"
+					self.importCodeSite = j
+					if buf ~= urlText then
+						self.controls.importCodeIn:SetText(urlText, false)
+					end
+					return
 				end
-				return
 			end
 		end
 

--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -26,7 +26,11 @@ buildSites.websiteList = {
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = "", linkURL = "pobb.in/%1"
 	},
 	{
-		label = "poe.ninja", id = "PoeNinja", matchURL = "^https://poe2?%.ninja/?p?o?e?2?/pob/.+", regexURL = "poe2?%.ninja/?p?o?e?2?/pob/(.+)%s*$", downloadURL = "poe.ninja/poe2/pob/raw/%1",
+		label = "poe.ninja",
+		id = "PoeNinja",
+		matchURL = { "^https://poe2?%.ninja/?p?o?e?2?/pob/.+", "^https://poe2?%.ninja/?p?o?e?2?/profile/.+/.+/character/.+" },
+		regexURL = { "poe2?%.ninja/?p?o?e?2?/pob/(.+)%s*$", "poe2?%.ninja/?p?o?e?2?/profile/(.+)/(.+)/character/(.+)%s*$" },
+		downloadURL = { "poe.ninja/poe2/pob/raw/%1", "poe.ninja/poe2/pob/raw/profile/code/%1/%2/%3" },
 		codeOut = "", postUrl = "https://poe.ninja/poe2/pob/api/upload", postFields = "code=", linkURL="poe.ninja/poe2/pob/%1"
 	},
 	{ 
@@ -96,7 +100,18 @@ function buildSites.DownloadBuild(link, websiteInfo, callback)
 			end
 		end
 	else -- called via the ImportTab
-		siteCodeURL = link:gsub(websiteInfo.regexURL, websiteInfo.downloadURL)
+		-- if the site supports multiple endpoints, use the first one that matches
+		if type(websiteInfo.regexURL) == "table" then
+			for i = 1, #websiteInfo.regexURL do
+				if link:match(websiteInfo.matchURL[i]) then
+					siteCodeURL = link:gsub(websiteInfo.regexURL[i], websiteInfo.downloadURL[i])
+					break
+				end
+			end
+		else
+			siteCodeURL = link:gsub(websiteInfo.regexURL, websiteInfo.downloadURL)
+		end
+		ConPrintf("%s", siteCodeURL)
 	end
 	if websiteInfo then
 		launch:DownloadPage(siteCodeURL, function(response, errMsg)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Allows links like `https://poe.ninja/poe2/profile/Turtvaiz-6152/runesofaldur/character/lolxdlmaokekw` to be imported from the import tab as a link. Previously only the pob exports were parsed

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
