### PR TITLE
Fix Conductive Runes scaling with weapon damage

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3826,7 +3826,7 @@ skills["ConductiveRunesPlayer"] = {
 			incrementalEffectiveness = 0.27349999547005,
 			statDescriptionScope = "conductive_runes_statset_1",
 			baseFlags = {
-				attack = true,
+				nonWeaponAttack = true,
 			},
 			constantStats = {
 				{ "rune_hazard_cone_angle", 80 },

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -256,7 +256,7 @@ statMap = {
 #flags attack duration
 #mods
 #set ConductiveRunesExplosionPlayer
-#flags attack
+#flags nonWeaponAttack
 #mods
 #skillEnd
 


### PR DESCRIPTION
### Description of the problem being solved:

`Conductive Runes` should not scale with weapon damage, currently it does.

### Steps taken to verify a working solution:

- Add Conductive Runes
- Equip a random white weapon
- Verify that the average hit does not change