### PR TITLE
Add new variant for Controlled Metamorphosis

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -977,7 +977,6 @@ c["-10% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",typ
 c["-10% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=-10}},nil}
 c["-10% to all Elemental Resistances per Power Charge"]={{[1]={[1]={type="Multiplier",var="PowerCharge"},flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=-10}},nil}
 c["-10% to maximum Block chance"]={{[1]={flags=0,keywordFlags=0,name="BlockChanceMax",type="BASE",value=-10}},nil}
-c["-13% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=-13}},nil}
 c["-13% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=-13}},nil}
 c["-13% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=-13}},nil}
 c["-13% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=-13}},nil}

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1,8 +1,8 @@
 -- Item data (c) Grinding Gear Games
 
 return {
--- Jewel: Drop
-[[
+	-- Jewel: Drop
+	[[
 The Adorned
 Diamond
 Source: Drops from unique{Trialmaster} in normal{The Trial of Chaos}
@@ -13,10 +13,16 @@ Limited to: 1
 {variant:1}containing Corrupted Magic Jewels
 {variant:2}(0-150)% increased Effect of Jewel Socket Passive Skills
 {variant:2}containing Corrupted Magic Jewels
-]],[[
+]],
+	[[
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
+Has Alt Variant: true
+Selected Variant: 2
+Selected Alt Variant: 6
+Variant: Pre 0.4.0
+Variant: Current
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -27,29 +33,31 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:1}Only affects Passives in Very Small Ring
-{variant:2}Only affects Passives in Small Ring
-{variant:3}Only affects Passives in Medium-Small Ring
-{variant:4}Only affects Passives in Medium Ring
-{variant:5}Only affects Passives in Medium-Large Ring
-{variant:6}Only affects Passives in Large Ring
-{variant:7}Only affects Passives in Very Large Ring
-{variant:8}Only affects Passives in Massive Ring
+{variant:3}Only affects Passives in Very Small Ring
+{variant:4}Only affects Passives in Small Ring
+{variant:5}Only affects Passives in Medium-Small Ring
+{variant:6}Only affects Passives in Medium Ring
+{variant:7}Only affects Passives in Medium-Large Ring
+{variant:8}Only affects Passives in Large Ring
+{variant:9}Only affects Passives in Very Large Ring
+{variant:10}Only affects Passives in Massive Ring
 Passives in Radius can be Allocated without being connected to your tree
 -(20-5)% to all Elemental Resistances
--(23-3)% to Chaos Resistance
-]],[[
+{variant:1}-(23-3)% to Chaos Resistance
+]],
+	[[
 Grand Spectrum
 Ruby
 Limited to: 3
 2% increased Maximum Life per socketed Grand Spectrum
 ]],
-[[
+	[[
 Grand Spectrum
 Emerald
 Limited to: 3
 2% increased Spirit per socketed Grand Spectrum
-]],[[
+]],
+	[[
 Grand Spectrum
 Sapphire
 Variant: Pre 0.4.0
@@ -57,7 +65,8 @@ Variant: Current
 Limited to: 3
 {variant:1}+4% to all Elemental Resistances per socketed Grand Spectrum
 {variant:2}+6% to all Elemental Resistances per socketed Grand Spectrum
-]],[[
+]],
+	[[
 Split Personality
 Ruby
 Variant: Mercenary
@@ -75,7 +84,8 @@ Limited to: 1
 {variant:1}Can Allocate Passive Skills from the Mercenary's starting point
 {variant:5}Can Allocate Passive Skills from the Templar's starting point
 Corrupted
-]],[[
+]],
+	[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets
@@ -88,8 +98,8 @@ Limited to: 1
 {variant:3}Allocates 4 Sinister Jewel sockets
 Corrupted
 ]],
--- Jewel: Timeless
-[[
+	-- Jewel: Timeless
+	[[
 Heroic Tragedy
 Timeless Jewel
 Source: Drops from unique{Olroth, Origin of the Fall}
@@ -104,7 +114,7 @@ Radius: Very Large
 Passives in radius are Conquered by the Kalguur
 Historic
 ]],
-[[
+	[[
 Undying Hate
 Timeless Jewel
 Source: Drops from unique{Vessel of Kulemak}

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1,8 +1,8 @@
 -- Item data (c) Grinding Gear Games
 
 return {
-	-- Jewel: Drop
-	[[
+-- Jewel: Drop
+[[
 The Adorned
 Diamond
 Source: Drops from unique{Trialmaster} in normal{The Trial of Chaos}
@@ -13,8 +13,7 @@ Limited to: 1
 {variant:1}containing Corrupted Magic Jewels
 {variant:2}(0-150)% increased Effect of Jewel Socket Passive Skills
 {variant:2}containing Corrupted Magic Jewels
-]],
-	[[
+]],[[
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
@@ -44,20 +43,18 @@ Radius: Variable
 Passives in Radius can be Allocated without being connected to your tree
 -(20-5)% to all Elemental Resistances
 {variant:1}-(23-3)% to Chaos Resistance
-]],
-	[[
+]], [[
 Grand Spectrum
 Ruby
 Limited to: 3
 2% increased Maximum Life per socketed Grand Spectrum
 ]],
-	[[
+[[
 Grand Spectrum
 Emerald
 Limited to: 3
 2% increased Spirit per socketed Grand Spectrum
-]],
-	[[
+]],[[
 Grand Spectrum
 Sapphire
 Variant: Pre 0.4.0
@@ -65,8 +62,7 @@ Variant: Current
 Limited to: 3
 {variant:1}+4% to all Elemental Resistances per socketed Grand Spectrum
 {variant:2}+6% to all Elemental Resistances per socketed Grand Spectrum
-]],
-	[[
+]],[[
 Split Personality
 Ruby
 Variant: Mercenary
@@ -84,8 +80,7 @@ Limited to: 1
 {variant:1}Can Allocate Passive Skills from the Mercenary's starting point
 {variant:5}Can Allocate Passive Skills from the Templar's starting point
 Corrupted
-]],
-	[[
+]],[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets
@@ -98,8 +93,8 @@ Limited to: 1
 {variant:3}Allocates 4 Sinister Jewel sockets
 Corrupted
 ]],
-	-- Jewel: Timeless
-	[[
+-- Jewel: Timeless
+[[
 Heroic Tragedy
 Timeless Jewel
 Source: Drops from unique{Olroth, Origin of the Fall}
@@ -114,7 +109,7 @@ Radius: Very Large
 Passives in radius are Conquered by the Kalguur
 Historic
 ]],
-	[[
+[[
 Undying Hate
 Timeless Jewel
 Source: Drops from unique{Vessel of Kulemak}

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -43,7 +43,7 @@ Radius: Variable
 Passives in Radius can be Allocated without being connected to your tree
 -(20-5)% to all Elemental Resistances
 {variant:1}-(23-3)% to Chaos Resistance
-]], [[
+]],[[
 Grand Spectrum
 Ruby
 Limited to: 3

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -1,8 +1,8 @@
 -- Item data (c) Grinding Gear Games
 
 return {
-	-- Jewel: Drop
-	[[
+-- Jewel: Drop
+[[
 The Adorned
 Diamond
 Source: Drops from unique{Trialmaster} in normal{The Trial of Chaos}
@@ -11,8 +11,7 @@ Variant: Current
 Limited to: 1
 {variant:1}CorruptedMagicJewelModEffectUnique__1[0,100]
 {variant:2}CorruptedMagicJewelModEffectUnique__1
-]],
-	[[
+]],[[
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
@@ -42,20 +41,18 @@ Radius: Variable
 JewelUniqueAllocateDisconnectedPassives
 UniqueAllResistances12
 {variant:1}UniqueChaosResist18
-]],
-	[[
+]], [[
 Grand Spectrum
 Ruby
 Limited to: 3
 UniqueMaximumLifePerStackableJewel1
 ]],
-	[[
+[[
 Grand Spectrum
 Emerald
 Limited to: 3
 UniqueMaximumSpiritPerStackableJewel1
-]],
-	[[
+]],[[
 Grand Spectrum
 Sapphire
 Variant: Pre 0.4.0
@@ -63,8 +60,7 @@ Variant: Current
 Limited to: 3
 {variant:1}UniqueAllResistancePerStackableJewel1[4,4]
 {variant:2}UniqueAllResistancePerStackableJewel1
-]],
-	[[
+]],[[
 Split Personality
 Ruby
 Variant: Mercenary
@@ -82,8 +78,7 @@ Limited to: 1
 {variant:5}UniqueJewelSplitPersonalityClassStart5
 {variant:6}UniqueJewelSplitPersonalityClassStart1
 Corrupted
-]],
-	[[
+]],[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets
@@ -96,8 +91,8 @@ Limited to: 1
 {variant:3}UniqueJewelGrantsVoicesJewelSockets3
 Corrupted
 ]],
-	-- Jewel: Timeless
-	[[
+-- Jewel: Timeless
+[[
 Heroic Tragedy
 Timeless Jewel
 Source: Drops from unique{Olroth, Origin of the Fall}
@@ -112,7 +107,7 @@ Radius: Very Large
 Passives in radius are Conquered by the Kalguur
 Historic
 ]],
-	[[
+[[
 Undying Hate
 Timeless Jewel
 Source: Drops from unique{Vessel of Kulemak}

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -1,8 +1,8 @@
 -- Item data (c) Grinding Gear Games
 
 return {
--- Jewel: Drop
-[[
+	-- Jewel: Drop
+	[[
 The Adorned
 Diamond
 Source: Drops from unique{Trialmaster} in normal{The Trial of Chaos}
@@ -11,10 +11,16 @@ Variant: Current
 Limited to: 1
 {variant:1}CorruptedMagicJewelModEffectUnique__1[0,100]
 {variant:2}CorruptedMagicJewelModEffectUnique__1
-]],[[
+]],
+	[[
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
+Has Alt Variant: true
+Selected Variant: 2
+Selected Alt Variant: 6
+Variant: Pre 0.4.0
+Variant: Current
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -25,29 +31,31 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:1}Only affects Passives in Very Small Ring
-{variant:2}Only affects Passives in Small Ring
-{variant:3}Only affects Passives in Medium-Small Ring
-{variant:4}Only affects Passives in Medium Ring
-{variant:5}Only affects Passives in Medium-Large Ring
-{variant:6}Only affects Passives in Large Ring
-{variant:7}Only affects Passives in Very Large Ring
-{variant:8}Only affects Passives in Massive Ring
+{variant:3}Only affects Passives in Very Small Ring
+{variant:4}Only affects Passives in Small Ring
+{variant:5}Only affects Passives in Medium-Small Ring
+{variant:6}Only affects Passives in Medium Ring
+{variant:7}Only affects Passives in Medium-Large Ring
+{variant:8}Only affects Passives in Large Ring
+{variant:9}Only affects Passives in Very Large Ring
+{variant:10}Only affects Passives in Massive Ring
 JewelUniqueAllocateDisconnectedPassives
 UniqueAllResistances12
-UniqueChaosResist18
-]],[[
+{variant:1}UniqueChaosResist18
+]],
+	[[
 Grand Spectrum
 Ruby
 Limited to: 3
 UniqueMaximumLifePerStackableJewel1
 ]],
-[[
+	[[
 Grand Spectrum
 Emerald
 Limited to: 3
 UniqueMaximumSpiritPerStackableJewel1
-]],[[
+]],
+	[[
 Grand Spectrum
 Sapphire
 Variant: Pre 0.4.0
@@ -55,7 +63,8 @@ Variant: Current
 Limited to: 3
 {variant:1}UniqueAllResistancePerStackableJewel1[4,4]
 {variant:2}UniqueAllResistancePerStackableJewel1
-]],[[
+]],
+	[[
 Split Personality
 Ruby
 Variant: Mercenary
@@ -73,7 +82,8 @@ Limited to: 1
 {variant:5}UniqueJewelSplitPersonalityClassStart5
 {variant:6}UniqueJewelSplitPersonalityClassStart1
 Corrupted
-]],[[
+]],
+	[[
 Voices
 Sapphire
 Variant: 2 Sinister Sockets
@@ -86,8 +96,8 @@ Limited to: 1
 {variant:3}UniqueJewelGrantsVoicesJewelSockets3
 Corrupted
 ]],
--- Jewel: Timeless
-[[
+	-- Jewel: Timeless
+	[[
 Heroic Tragedy
 Timeless Jewel
 Source: Drops from unique{Olroth, Origin of the Fall}
@@ -102,7 +112,7 @@ Radius: Very Large
 Passives in radius are Conquered by the Kalguur
 Historic
 ]],
-[[
+	[[
 Undying Hate
 Timeless Jewel
 Source: Drops from unique{Vessel of Kulemak}

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -41,7 +41,7 @@ Radius: Variable
 JewelUniqueAllocateDisconnectedPassives
 UniqueAllResistances12
 {variant:1}UniqueChaosResist18
-]], [[
+]],[[
 Grand Spectrum
 Ruby
 Limited to: 3


### PR DESCRIPTION
Fixes #2284 .

### Description of the problem being solved:

`Controlled Metamorphosis` no longer has -chaos resist as of 0.4.0.

### Steps taken to verify a working solution:
- Verify that `Controlled Metamorphosis` has another variant dropdown where you can select the version

### Before screenshot:

<img width="751" height="611" alt="image" src="https://github.com/user-attachments/assets/2d667bd8-285a-4134-9d66-2a756a8a991d" />

### After screenshot:

<img width="753" height="522" alt="image" src="https://github.com/user-attachments/assets/94430ff2-106d-4ebc-a83f-34bc0784f811" />
