### PR TITLE
Fix "Shapeshifted" condition being toggled on every build.

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -4458,6 +4458,9 @@ skills["DemonFormPlayer"] = {
 			},
 			baseFlags = {
 			},
+			baseMods = {
+				flag("Condition:Shapeshifted", { type = "GlobalEffect", effectType = "Buff" }, { type = "Condition", var = "DemonForm" }),
+			},
 			constantStats = {
 				{ "demon_form_spell_damage_+%_final_per_stack", 3 },
 			},

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -304,6 +304,7 @@ statMap = {
 		mod("LifeDegen", "BASE", nil, 0, 0, { type = "Condition", var = "DemonForm" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Demon Form" }, { type = "Multiplier", var = "DemonFlameStacks", limitVar = "DemonFlameMaximum" } ),
 		div = 60,
 	},
+#baseMod flag("Condition:Shapeshifted", { type = "GlobalEffect", effectType = "Buff" }, { type = "Condition", var = "DemonForm" })
 },
 #mods
 #skillEnd

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -365,20 +365,6 @@ local function doActorAttribsConditions(env, actor)
 			modDB:NewMod("StunThreshold", "INC", 50, "Wyvern Form")
 			modDB:NewMod("AilmentThreshold", "INC", 50, "Wyvern Form")
 		end
-		-- Demon Form is a toggled shapeshift buff applied via the inDemonForm config option; flag its
-		-- presence so those config-applied Shapeshifted/DemonForm conditions only take effect on builds
-		-- that actually have the Demon Form skill.
-		for _, activeSkill in ipairs(actor.activeSkillList or { }) do
-			local activeEffect = activeSkill.activeEffect
-			local grantedEffect = activeEffect and activeEffect.grantedEffect
-			if grantedEffect and grantedEffect.name == "Demon Form" then
-				local statSet = env.mode == "CALCS" and activeEffect.statSetCalcs or activeEffect.statSet
-				if not (statSet and statSet.skillFlags.disable) then
-					condList["HaveDemonForm"] = true
-					break
-				end
-			end
-		end
 		if skillFlags.hit and not skillFlags.trap and not skillFlags.mine and not skillFlags.totem then
 			condList["HitRecently"] = true
 			if skillFlags.spell then

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -365,6 +365,20 @@ local function doActorAttribsConditions(env, actor)
 			modDB:NewMod("StunThreshold", "INC", 50, "Wyvern Form")
 			modDB:NewMod("AilmentThreshold", "INC", 50, "Wyvern Form")
 		end
+		-- Demon Form is a toggled shapeshift buff applied via the inDemonForm config option; flag its
+		-- presence so those config-applied Shapeshifted/DemonForm conditions only take effect on builds
+		-- that actually have the Demon Form skill.
+		for _, activeSkill in ipairs(actor.activeSkillList or { }) do
+			local activeEffect = activeSkill.activeEffect
+			local grantedEffect = activeEffect and activeEffect.grantedEffect
+			if grantedEffect and grantedEffect.name == "Demon Form" then
+				local statSet = env.mode == "CALCS" and activeEffect.statSetCalcs or activeEffect.statSet
+				if not (statSet and statSet.skillFlags.disable) then
+					condList["HaveDemonForm"] = true
+					break
+				end
+			end
+		end
 		if skillFlags.hit and not skillFlags.trap and not skillFlags.mine and not skillFlags.totem then
 			condList["HitRecently"] = true
 			if skillFlags.spell then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -342,12 +342,8 @@ local configSettings = {
 	end },
 	{ label = "Demon Form:", ifSkill = "Demon Form" },
 	{ var = "inDemonForm", type = "check", label = "Are you in Demon Form?", ifSkill = "Demon Form", defaultState = true, tooltip = "Players need a minimum of 2 ^xE05030Life ^7to enter Demon Form, so you cannot use it with Chaos Inoculation", apply = function(val, modList, enemyModList)
-		-- Gate on HaveDemonForm (set in CalcPerform when the Demon Form skill is present). ifSkill only
-		-- hides the UI control, not this apply(), and defaultState is true, so without a gate these would
-		-- grant Condition:Shapeshifted (an untagged global flag) on every build, making all
-		-- "while Shapeshifted" modifiers apply.
-		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config", { type = "Condition", var = "HaveDemonForm" }, { type = "StatThreshold", stat = "Life", threshold = 2 })
-		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "Condition", var = "HaveDemonForm" }, { type = "StatThreshold", stat = "Life", threshold = 2 })
+		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config")
+		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "StatThreshold", stat = "Life", threshold = 2 })
 	end },
 	{ var = "demonFormStacks", type = "count", label = "Demonflame Stacks", ifSkill = "Demon Form", defaultPlaceholderState = 10, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:DemonFlameStacks", "BASE", val, "Config", { type = "Condition", var = "DemonForm" } )

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -342,8 +342,12 @@ local configSettings = {
 	end },
 	{ label = "Demon Form:", ifSkill = "Demon Form" },
 	{ var = "inDemonForm", type = "check", label = "Are you in Demon Form?", ifSkill = "Demon Form", defaultState = true, tooltip = "Players need a minimum of 2 ^xE05030Life ^7to enter Demon Form, so you cannot use it with Chaos Inoculation", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config")
-		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "StatThreshold", stat = "Life", threshold = 2 })
+		-- Gate on HaveDemonForm (set in CalcPerform when the Demon Form skill is present). ifSkill only
+		-- hides the UI control, not this apply(), and defaultState is true, so without a gate these would
+		-- grant Condition:Shapeshifted (an untagged global flag) on every build, making all
+		-- "while Shapeshifted" modifiers apply.
+		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config", { type = "Condition", var = "HaveDemonForm" }, { type = "StatThreshold", stat = "Life", threshold = 2 })
+		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "Condition", var = "HaveDemonForm" }, { type = "StatThreshold", stat = "Life", threshold = 2 })
 	end },
 	{ var = "demonFormStacks", type = "count", label = "Demonflame Stacks", ifSkill = "Demon Form", defaultPlaceholderState = 10, apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:DemonFlameStacks", "BASE", val, "Config", { type = "Condition", var = "DemonForm" } )

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -342,7 +342,6 @@ local configSettings = {
 	end },
 	{ label = "Demon Form:", ifSkill = "Demon Form" },
 	{ var = "inDemonForm", type = "check", label = "Are you in Demon Form?", ifSkill = "Demon Form", defaultState = true, tooltip = "Players need a minimum of 2 ^xE05030Life ^7to enter Demon Form, so you cannot use it with Chaos Inoculation", apply = function(val, modList, enemyModList)
-		modList:NewMod("Condition:Shapeshifted", "FLAG", true, "Config")
 		modList:NewMod("Condition:DemonForm", "FLAG", true, "Config", { type = "StatThreshold", stat = "Life", threshold = 2 })
 	end },
 	{ var = "demonFormStacks", type = "count", label = "Demonflame Stacks", ifSkill = "Demon Form", defaultPlaceholderState = 10, apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Fixes "Shapeshifted" condition being toggled on every build.

### Description of the problem being solved:

The shapeshifted condition is always true on every build.

### Steps taken to verify a working solution:
- Checked that the shapeshifter nodes don't show bonuses unless:
1. the "Currently Shapeshifted" config is toggled
2. Demon Form is an enabled skill gem (new behavior)
3. Any of the shapeshift gems are the main skill gem (old behavior)

### Link to a build that showcases this PR:

Any build.

### Before screenshot:

<img width="2559" height="1439" alt="Screenshot 2026-07-03 000932" src="https://github.com/user-attachments/assets/73903f35-6c26-41f8-9ba2-91546ea55005" />

### After screenshot:

<img width="2559" height="1439" alt="Screenshot 2026-07-03 081905" src="https://github.com/user-attachments/assets/2e1c9179-e5a5-4eec-9ff5-0ce447382468" />


