### PR TITLE
Fix Life Conversion with CI

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1380,8 +1380,8 @@ function calcs.defence(env, actor)
 						local gainRate = modDB:Sum("BASE", nil, source.name .. "GainAs" .. target.name)
 						local rate = source.conversionRate[target.name] + gainRate
 						if rate > 0 then
-							local targetBase = math.ceil(globalBase * rate / 100)
-							local targetTotalBase = math.ceil(totalBase * rate / 100)
+							local targetBase = round(globalBase * rate / 100)
+							local targetTotalBase = round(totalBase * rate / 100)
 							target.globalBase = target.globalBase + targetBase
 							target.totalBase = target.totalBase + targetTotalBase
 							if breakdown then


### PR DESCRIPTION
Fixes #2349 

### Description of the problem being solved:
Conversion should be rounded it seems. With CI which makes life 1, 5% should not give any conversion ES. Even with Ghostwrithe, 40% of 1 life should not provide any ES.

Build provided from the issue, added a Ghostwrithe to swap out and compare the numbers. All match the provided numbers from the OP.

https://poe.ninja/poe2/pob/243ab