### PR TITLE
Fix parsing Vaal Unique modifiers on items

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -475,7 +475,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			elseif fullModName:match("(.*)Enhancement.*") then
 				linePostfix = " (enchant)"
 			end
-			local possibleLineFlags = fullModName:match("(.*)Modifier.*")
+			local possibleLineFlags = fullModName:gsub("Vaal Unique", "Mutated"):match("(.*)Modifier.*")
 			if possibleLineFlags then
 				for flag in possibleLineFlags:gmatch("%a+") do
 					if lineFlags[flag:lower()] then


### PR DESCRIPTION
### Description of the problem being solved:

It seems that PoB supports mutated (aka vaal cultivation orb) modifiers properly, but they don't get parsed from items due to the modifier {} text saying "vaal unique" instead of mutated, as was on the non-advanced item strings. This seems to happen simply because the wording doesn't match up with what is defined in the lineFlags variable. I'm not sure if this is hacky, but this seems to work.

This shouldn't change any functionality since as far as I know, the mutated tag doesn't actually do anything (yet?).

### Steps taken to verify a working solution:
- Tests pass
- Items seem to work as they did

### Link to a build that showcases this PR:

### Before screenshot:
<img width="688" height="661" alt="image" src="https://github.com/user-attachments/assets/dd80f3a3-3364-4af9-a88a-7ed4a096faef" />

### After screenshot:
<img width="708" height="801" alt="image" src="https://github.com/user-attachments/assets/e7300fe0-614e-4f6c-a7c4-8bf96ec30d1c" />
