### PR TITLE
Fix crash on Lich Jewel breakdown hover

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -31,7 +31,7 @@ function CalcBreakdownClass:IsMouseOver()
 	if not self:IsShown() then
 		return
 	end
-	return self:IsMouseInBounds() or self:GetMouseOverControl() 
+	return self:IsMouseInBounds() or self:GetMouseOverControl()
 end
 
 function CalcBreakdownClass:SetBreakdownData(displayData, pinned)
@@ -87,7 +87,7 @@ function CalcBreakdownClass:SetBreakdownData(displayData, pinned)
 						local _, num = string.gsub(row[col.key], "%d%d%d%d", "") -- count how many commas will be added
 						if main.showThousandsSeparators and num > 0 then
 							col.width = m_max(col.width or 0, DrawStringWidth(16, "VAR", col.label) + 6, DrawStringWidth(12, "VAR", row[col.key]) + 6 + (4 * num))
-						else 
+						else
 							col.width = m_max(col.width or 0, DrawStringWidth(16, "VAR", col.label) + 6, DrawStringWidth(12, "VAR", row[col.key]) + 6)
 						end
 					end
@@ -176,7 +176,7 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 		local section = {
 			type = "TABLE",
 			rowList = breakdown.reservations,
-			colList = { 
+			colList = {
 				{ label = "Skill", key = "skillName" },
 				{ label = "Base", key = "base" },
 				{ label = "MCM", key = "mult" },
@@ -195,7 +195,7 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 		local section = {
 			type = "TABLE",
 			rowList = breakdown.damageTypes,
-			colList = { 
+			colList = {
 				{ label = "From", key = "source", right = true },
 				{ label = "Base", key = "base" },
 				{ label = "Inc/red", key = "inc" },
@@ -242,8 +242,8 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 		table.sort(rowList, function(a, b)
 			return a['base'] > b['base']
 		end)
-		
-		local section = { 
+
+		local section = {
 			type = "TABLE",
 			rowList = rowList,
 			colList = colList,
@@ -297,7 +297,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		type = "TABLE",
 		label = sectionData.label,
 		rowList = rowList,
-		colList = { 
+		colList = {
 			{ label = "Value", key = "displayValue" },
 			{ label = "Stat", key = "name" },
 			{ label = "Skill types", key = "flags" },
@@ -340,7 +340,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 			local sourceType = row.mod.source:match("[^:]+")
 			if not sourceTotals[sourceType] then
 				sourceTotals[sourceType] = { }
-			end	
+			end
 		end
 		for sourceType, lines in pairs(sourceTotals) do
 			cfg.source = sourceType
@@ -402,7 +402,7 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 				row.sourceNameTooltip = function(tooltip)
 					local args = row.mod.sourceSlot
 					if row.mod.sourceSlot == "Jewel" and row.mod.sourceSlotNum ~= nil and build.spec.nodes[row.mod.sourceSlotNum] and build.spec.nodes[row.mod.sourceSlotNum].containJewelSocket then
-						args = { nodeId = row.mod.sourceSlotNum }
+						args = build.itemsTab.sockets[row.mod.sourceSlotNum]
 					end
 					build.itemsTab:AddItemTooltip(tooltip, item, args)
 				end
@@ -546,7 +546,7 @@ function CalcBreakdownClass:FormatModValue(value, modType)
 			return "?"
 		end
 	else
-		return value		
+		return value
 	end
 end
 


### PR DESCRIPTION
Fixes #2356

### Description of the problem being solved:
Lich ascendancy node would show an error when hovering the the jewel in breakdowns.
Had AI track this down, as the compare stuff is hella confusing to me. I think this is the right way to do it though.

<img width="833" height="377" alt="image" src="https://github.com/user-attachments/assets/59c3078a-ebce-46ad-b4bd-023bd86fa1c6" />
