### PR TITLE
Fix Infused Spark Cast time

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -2272,7 +2272,7 @@ return {
 	div = 1000,
 },
 ["base_spell_cast_time_ms"] = {
-	mod("TotalCastTime", "BASE", nil),
+	mod("Speed", "BASE", nil, ModFlag.Cast),
 	div = 1000,
 },
 ["active_skill_cast_speed_+%_final"] = {

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2743,7 +2743,7 @@ function calcs.offence(env, actor, activeSkill)
 					baseTime = 1 / ( source.AttackRate or 1 ) + skillModList:Sum("BASE", cfg, "Speed")
 				end
 			else
-				baseTime = skillData.castTimeOverride or activeSkill.activeEffect.grantedEffect.castTime or 1
+				baseTime = (skillData.castTimeOverride or activeSkill.activeEffect.grantedEffect.castTime or 1) + skillModList:Sum("BASE", cfg, "Speed")
 			end
 			local more = skillModList:More(cfg, "Speed")
 			output.Repeats = globalOutput.Repeats or 1


### PR DESCRIPTION
Fixes #2360

### Description of the problem being solved:
We were adding the 0.5s cast time as a total time mod instead of adding to the base 0.7s cast time

### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/24c10

### Before screenshot:
<img width="233" height="101" alt="image" src="https://github.com/user-attachments/assets/64f9f2b4-ba77-4155-807e-478414063cef" />


### After screenshot:
<img width="240" height="102" alt="image" src="https://github.com/user-attachments/assets/e8931878-3940-4954-bd63-c2fc1ed5003d" />
