### PR TITLE
Only show scalable mods in Corruption roll range UI

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2854,7 +2854,9 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 					selectedVariant = true
 				end
 			end
-			if #variantIds > 0 and selectedVariant or #variantIds == 0 then
+			-- test if a mod is scalable at all. this will let through mods that scale, but don't actually change within the corrupt range
+			local testScaledLine = itemLib.applyRange(mod.line, mod.range or main.defaultItemAffixQuality, mod.valueScalar or 1, 2)
+			if not (testScaledLine == mod.line) and (#variantIds > 0 and selectedVariant or #variantIds == 0) then
 				local label = ""
 				controls["rollRangeValue"..i] = new("LabelControl", {"TOPLEFT",nil,"TOPLEFT"}, {10, 10 + offset, 200, 16}, "^71.00")
 				controls["rollRangeSlider"..i] = new("SliderControl", { "LEFT", controls["rollRangeValue"..i], "RIGHT" }, {5, 0, 80, 18}, function(val)
@@ -2993,7 +2995,7 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 	end)
 	controls.save.tooltipFunc = function(tooltip)
 		tooltip:Clear()
-		self:AddItemTooltip(tooltip, corruptItem(controls.enchant1.shown), nil, true)
+		self:AddItemTooltip(tooltip, corruptItem(controls.enchant1.shown))
 	end
 	controls.close = new("ButtonControl", nil, {45, 69 + enchantNum * 20, 80, 20}, "Cancel", function()
 		main:ClosePopup()


### PR DESCRIPTION
### Description of the problem being solved:
Contains some tiny improvements from https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/9935
### Steps taken to verify a working solution:
- Tested on some DB items

### Link to a build that showcases this PR:

### Before screenshot:
<img width="985" height="480" alt="image" src="https://github.com/user-attachments/assets/8af04f70-ce91-4ba1-85a6-47a54c888bb3" />
<img width="1052" height="953" alt="image" src="https://github.com/user-attachments/assets/0cdf3ac1-69ea-43b5-b8a8-1ce2688f3fde" />

### After screenshot:
<img width="1136" height="473" alt="image" src="https://github.com/user-attachments/assets/b96fde8c-ad66-4395-ba2c-2332c1f774a1" />
<img width="1064" height="907" alt="image" src="https://github.com/user-attachments/assets/469a0504-cf37-4364-b986-2f15b219a4bc" />
