### PR TITLE
Fix Rathpith magnitude of Ailments per 100 Life not scaling Ailments properly

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -894,6 +894,19 @@ describe("TestSkills", function()
 		assert.True(avgDPS < lightningDPS)
 	end)
 
+	it("scales spell bleed magnitude from maximum Life", function()
+		build.configTab.input.customMods = [[
+			+5000 to maximum Life
+			100% chance to inflict Bleeding on Hit
+			Non-Channelling Spells have 3% increased Magnitude of Ailments per 100 maximum Life
+		]]
+		build.configTab:BuildModList()
+		build.skillsTab:PasteSocketGroup("Unearth 20/0  1")
+		runCallback("OnFrame")
+
+		assert.are.equals(1 + math.floor(build.calcsTab.mainOutput.Life / 100) * 0.03, build.calcsTab.mainOutput.BleedMagnitudeEffect)
+	end)
+
 	it("Test flicker strike scales with power charges", function()
 		build.skillsTab:PasteSocketGroup("Flicker Strike 20/0  1")
 		build.itemsTab:CreateDisplayItemFromRaw([[

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3241,6 +3241,9 @@ function calcs.perform(env, skipEHP)
 		},
 	}
 
+	-- precalculate life for rathpith Spells have 3% increased Magnitude of Ailments per 100 maximum
+	-- Life cultivated mod
+	calcs.doActorLifeManaSpirit(env.player, true)
 	local hitFlag
 	if env.mode == "CALCS" then
 		hitFlag = env.player.mainSkill.activeEffect.statSetCalcs.skillFlags.hit
@@ -3265,9 +3268,9 @@ function calcs.perform(env, skipEHP)
 					-- if not, use the generic modifiers
 					-- Scorch/Sap/Brittle do not have guaranteed sources from hits, and therefore will only end up in this bit of code if it's not supposed to apply the skillModList, which is bad
 					if ailment ~= "Scorch" and ailment ~= "Sap" and ailment ~= "Brittle" and not env.player.mainSkill.skillModList:Flag(nil, "Cannot"..ailment) and hitFlag and modDB:Flag(nil, "ChecksHighestDamage") then
-						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self"..ailment.."Magnitude", "AilmentMagnitude")
+						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillCfg, "Enemy" .. ailment .. "Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self" .. ailment .. "Magnitude", "AilmentMagnitude")
 					else
-						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillModList.skillCfg, "Enemy"..ailment.."Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self"..ailment.."Magnitude", "AilmentMagnitude")
+						effect = effect * calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillCfg, "Enemy" .. ailment .. "Magnitude", "AilmentMagnitude") * calcLib.mod(enemyDB, nil, "Self" .. ailment .. "Magnitude", "AilmentMagnitude")
 					end
 					modDB:NewMod(ailment.."Override", "BASE", effect, mod.source, mod.flags, mod.keywordFlags, unpack(mod))
 					if mod.name == ailment.."Minimum" then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3821,6 +3821,8 @@ local specialModList = {
 		mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Poisoned" }),
 		mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Electrocuted" }),
 	} end,
+	["non%-channelling spells have (%d+)%% increased magnitude of ailments per (%d+) maximum life"] = function(num, _, div) return { mod("AilmentMagnitude", "INC", num, nil, 0, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel, neg = true }, { type = "PerStat", stat = "Life", div = tonumber(div) }) } end,
+	["non%-channelling spells have (%d+)%% reduced magnitude of ailments per (%d+) maximum life"] = function(num, _, div) return { mod("AilmentMagnitude", "INC", -num, nil, 0, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel, neg = true }, { type = "PerStat", stat = "Life", div = tonumber(div) }) } end,
 	-- Elemental Ailments
 	["enemies take (%d+)%% increased damage for each elemental ailment type among your ailments on them"] = function(num) return {
 		mod("EnemyModifier", "LIST", { mod = mod("DamageTaken", "INC", num) }, { type = "ActorCondition", actor = "enemy", var = "Frozen" }),


### PR DESCRIPTION
Fixes #2362.

### Description of the problem being solved:

The rathpith per 100 life shock mod wasn't working because the output had no life, and possibly because the code was incorrectly accessing skillCfg, which was always nil.

### Steps taken to verify a working solution:
- Tests pass
- Mod works
- 
### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/24c22
### Before screenshot:
<img width="1440" height="728" alt="image" src="https://github.com/user-attachments/assets/ee174859-e490-4ec7-b050-5d3837aa0d3d" />

### After screenshot:
<img width="701" height="782" alt="image" src="https://github.com/user-attachments/assets/e52ccdf4-da77-4b0f-9c81-fc7c97bf8cba" />
