### PR TITLE
Fix Liminal Coil counting Marks as Curses

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -618,6 +618,12 @@ describe("TetsItemMods", function()
 		-- more curse more dmg
 		assert.are_not.equals(afterEleWeaknessPhys, afterEnfeeblePhys)
 		assert.are_not.equals(afterEleWeaknessChaos, afterEnfeebleChaos)
+
+		build.skillsTab:PasteSocketGroup("Freezing Mark 20/0  1")
+		runCallback("OnFrame")
+		-- marks are not curses and should not grant more damage
+		assert.are.equals(afterEnfeeblePhys, round(build.calcsTab.mainOutput.PhysicalStoredCombinedAvg))
+		assert.are.equals(afterEnfeebleChaos, round(build.calcsTab.mainOutput.ChaosStoredCombinedAvg))
 	end)
 
 	it("twisted empyrean", function()

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3089,7 +3089,13 @@ function calcs.perform(env, skipEHP)
 	for _, modList in pairs(debuffs) do
 		enemyDB:AddList(modList)
 	end
-	modDB.multipliers["CurseOnEnemy"] = #curseSlots
+	local cursesInCurseSlots = {}
+	for _, slot in ipairs(curseSlots) do
+		if not slot.isMark then
+			table.insert(cursesInCurseSlots, slot)
+		end
+	end
+	modDB.multipliers["CurseOnEnemy"] = #cursesInCurseSlots
 	for _, slot in ipairs(curseSlots) do
 		enemyDB.conditions["Cursed"] = true
 		if slot.isMark then


### PR DESCRIPTION
Fixes #2351.

### Description of the problem being solved:

It seems that curse and mark slots were concatenated, which resulted in later code counting marks as curses. This PR filters those slots based on the isMark variable.

This feels like more of a workaround, and the real solution would be to completely separate marks and curses, as unlike PoE1 they are completely separate from one another.

### Steps taken to verify a working solution:
- Tests pass
- Marks are limited to 1 (tested with sniper and freezing) and apply to enemy
- Curse calcs are as expected in linked issue

### Link to a build that showcases this PR:
https://poe.ninja/poe2/pob/2515b
### Before screenshot:

<img width="1453" height="639" alt="image" src="https://github.com/user-attachments/assets/47372c42-28ca-416f-b917-ef7981250712" />


### After screenshot:
<img width="1453" height="646" alt="image" src="https://github.com/user-attachments/assets/445f3315-e759-41b1-a376-326a5421eea6" />

