### PR TITLE
Fix duplicated socket parsing on item rebuild

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -845,6 +845,34 @@ describe("TestItemParse", function()
 		assert.are.equals(65, item.requirements.level)
 	end)
 
+	it("does not duplicate socket lines when rebuilding pasted game items", function()
+		local item = new("Item", [[
+			Rarity: Rare
+			Rage Mast
+			Razor Quarterstaff
+			--------
+			Item Level: 81
+			--------
+			Sockets: S S
+		]])
+
+		assert.are.equals(2, item.itemSocketCount)
+		assert.are.equals(2, #item.sockets)
+
+		local rawItem = item:BuildRaw()
+		local socketLineCount = 0
+		for line in rawItem:gmatch("[^\n]+") do
+			if line:match("^Sockets:") then
+				socketLineCount = socketLineCount + 1
+			end
+		end
+		assert.are.equals(1, socketLineCount)
+
+		item = new("Item", rawItem)
+		assert.are.equals(2, item.itemSocketCount)
+		assert.are.equals(2, #item.sockets)
+	end)
+
 	it("multi-line rune mod", function()
 		-- Thruldana is Bow-only as well
 		local item = new("Item", [[

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -565,18 +565,28 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				elseif specName == "Quality" then
 					self.quality = specToNumber(specVal)
 				elseif specName == "Sockets" then
+					local itemSockets = { }
+					local jewelSocketCount = 0
 					local group = 0
 					for c in specVal:gmatch(".") do
 						if c:match("[S]") then
-							t_insert(self.sockets, { group = group })
+							t_insert(itemSockets, { group = group })
 							group = group + 1
 						elseif c:match("[J]") then -- e.g. specVal = "Sockets: J J J J J J"
-							self.jewelSocketCount = self.jewelSocketCount + 1
+							jewelSocketCount = jewelSocketCount + 1
 						end
 					end
-					self.itemSocketCount = #self.sockets
+					if #itemSockets > 0 and #self.sockets == 0 then
+						self.sockets = itemSockets
+						self.itemSocketCount = #self.sockets
+					end
+					if jewelSocketCount > 0 and self.jewelSocketCount == 0 then
+						self.jewelSocketCount = jewelSocketCount
+					end
+					goto continue
 				elseif specName == "Rune" then
 					t_insert(self.runes, specVal)
+					goto continue
 				elseif specName == "Radius" and self.type == "Jewel" then
 					self.jewelRadiusLabel = specVal:match("^[%a ]+")
 					if specVal:match("^%a+") == "Variable" then


### PR DESCRIPTION
### Description of the problem being solved:

Pasted game items with structured `Sockets:` lines could rebuild with duplicate socket lines after an edit/save/reimport cycle. `Item:ParseRaw` parsed `Sockets:` and `Rune:` spec lines into structured item fields, but those lines could also remain as modifier text and be emitted again by `BuildRaw`.

This PR consumes those structured spec lines after parsing them, so socket and rune data is kept in the item fields without duplicating the original text line.

### Steps taken to verify a working solution:
- Added regression coverage in `spec/System/TestItemParse_spec.lua` for `ParseRaw -> BuildRaw -> ParseRaw` on a pasted item with `Sockets: S S`; the rebuilt raw item keeps one `Sockets:` line and reparses to two sockets.
- `busted ../spec/System/TestItemParse_spec.lua` (65 passed)
- `busted ../spec/System/TestItemsTab_spec.lua` (53 passed)
- Manually checked the before/after item tooltips below: the duplicate unsupported red `Sockets:` modifier is gone, while the structured socket header remains.

### Before screenshot:

<img width="337" height="382" alt="before-duplicate-sockets" src="https://github.com/user-attachments/assets/61bbb3a2-48d3-4841-af3d-756454c9d8cd" />

### After screenshot:

<img width="418" height="601" alt="after-duplicate-sockets" src="https://github.com/user-attachments/assets/c548e9e4-79ad-4b19-b20b-6fe821ed3f2b" />
