### PR TITLE
Fix 2H weapons not removing off-hand items in comparisons

### DIFF
--- a/spec/System/TestMiscCalculator_spec.lua
+++ b/spec/System/TestMiscCalculator_spec.lua
@@ -1,0 +1,126 @@
+describe("MiscCalculator", function()
+	before_each(function()
+		newBuild()
+	end)
+	describe("repItem behaviour", function()
+		local calcFunc
+		before_each(function ()
+			calcFunc = build.calcsTab:GetMiscCalculator()
+		end)
+
+		local function pasteAndEquipItem(itemText)
+			build.itemsTab:CreateDisplayItemFromRaw(itemText)
+			build.itemsTab:AddDisplayItem()
+			runCallback("OnFrame")
+		end
+
+		local function allocateKeystone(keystoneText)
+			build.configTab.input.customMods = keystoneText
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
+			calcFunc = build.calcsTab:GetMiscCalculator()
+		end
+
+		local function equipInSlot(item, slotName)
+			build.itemsTab:AddItem(item, true)
+			build.itemsTab.slots[slotName]:SetSelItemId(item.id)
+			runCallback("OnFrame")
+		end
+		local focus = [[Rarity: RARE
++2 Energy Shield
+Hallowed Focus
+Energy Shield: 57
+Crafted: true
+Prefix: {range:0.8}LocalIncreasedEnergyShield8
+Prefix: {range:0.8}LocalIncreasedEnergyShieldPercent6
+Prefix: None
+Suffix: {range:0.8}GlobalSpellGemsLevel2
+Suffix: None
+Suffix: None
+Quality: 0
+LevelReq: 61
+Implicits: 0
++71 to maximum Energy Shield
+89% increased Energy Shield
++2 to Level of all Spell Skills]]
+
+		local quiver = [[Test Subject
+Rarity: Rare
+Toxic Quiver
+Crafted: true
+Implicits: 1
++100 to maximum energy shield]]
+
+		local bow = new("Item", [[Rarity: Rare
+Test Subject
+Gemini Bow]])
+
+		local talisman = new("Item", [[Rarity: Rare
+Test Subject
+Spiny Talisman]])
+
+		local staff = new("Item", [[Rarity: Rare
+Test Subject
+Chiming Staff]])
+
+		local mace = new("Item", [[Rarity: Rare
+Test Subject
+Ironwood Greathammer]])
+
+		local sceptre = new("Item", [[Rarity: Rare
+Test Subject
+Rattling Sceptre
++100 to maximum Energy Shield]])
+		local wand = new("Item", [[Rarity: Rare
+Test Subject
+Dueling Wand]])
+		it("calculates off-hand without a weapon", function ()
+			pasteAndEquipItem(focus)
+			local output = calcFunc()
+			assert.True(output.EnergyShield > 0)
+		end)
+		it("unequips the off-hand focus when replacing weapon 1 with two-handed weapons", function()
+			pasteAndEquipItem(focus)
+			for _, item in ipairs({ bow, talisman, staff, mace }) do
+				local output = calcFunc({ repSlotName = "Weapon 1", repItem = item })
+				assert.True(output.EnergyShield == 0)
+			end
+		end)
+		it("keeps the off-hand quiver when using bow", function()
+			-- quivers need a bow to be equipped first
+			pasteAndEquipItem(bow:BuildRaw())
+			pasteAndEquipItem(quiver)
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = bow })
+			assert.True(output.EnergyShield > 0)
+		end)
+		it("keeps the off-hand focus when using a two-handed weapon with Giant's Blood", function()
+			pasteAndEquipItem(focus)
+			allocateKeystone("You can wield Two-Handed Axes, Maces and Swords in one hand")
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = mace })
+			assert.True(output.EnergyShield > 0)
+		end)
+		it("keeps the off-hand focus when using a staff with Instruments of Power", function()
+			pasteAndEquipItem(focus)
+			allocateKeystone("You can equip a Focus while wielding a Staff")
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = staff })
+			assert.True(output.EnergyShield > 0)
+		end)
+		it("keeps rare off-hand sceptre when using a talisman with Lord of the Wilds", function()
+			equipInSlot(sceptre, "Weapon 2")
+			allocateKeystone("You can equip a non-Unique Sceptre while wielding a Talisman")
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = talisman })
+			assert.True(output.EnergyShield > 0)
+		end)
+		it("unequips unique off-hand sceptre when using a talisman with Lord of the Wilds", function()
+			equipInSlot(new("Item", "Rarity: Unique\n" .. sceptre:BuildRaw()), "Weapon 2")
+			allocateKeystone("You can equip a non-Unique Sceptre while wielding a Talisman")
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = talisman })
+			assert.True(output.EnergyShield == 0)
+		end)
+		it("keeps off-hand when using one-handed weapon", function()
+			pasteAndEquipItem(focus)
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = wand })
+			assert.True(output.EnergyShield > 0)
+		end)
+	end)
+end)

--- a/spec/System/TestMiscCalculator_spec.lua
+++ b/spec/System/TestMiscCalculator_spec.lua
@@ -51,27 +51,27 @@ Crafted: true
 Implicits: 1
 +100 to maximum energy shield]]
 
-		local bow = new("Item", [[Rarity: Rare
+		local bow = new("Item"):Item([[Rarity: Rare
 Test Subject
 Gemini Bow]])
 
-		local talisman = new("Item", [[Rarity: Rare
+		local talisman = new("Item"):Item([[Rarity: Rare
 Test Subject
 Spiny Talisman]])
 
-		local staff = new("Item", [[Rarity: Rare
+		local staff = new("Item"):Item([[Rarity: Rare
 Test Subject
 Chiming Staff]])
 
-		local mace = new("Item", [[Rarity: Rare
+		local mace = new("Item"):Item([[Rarity: Rare
 Test Subject
 Ironwood Greathammer]])
 
-		local sceptre = new("Item", [[Rarity: Rare
+		local sceptre = new("Item"):Item([[Rarity: Rare
 Test Subject
 Rattling Sceptre
 +100 to maximum Energy Shield]])
-		local wand = new("Item", [[Rarity: Rare
+		local wand = new("Item"):Item([[Rarity: Rare
 Test Subject
 Dueling Wand]])
 		it("calculates off-hand without a weapon", function ()
@@ -99,6 +99,13 @@ Dueling Wand]])
 			local output = calcFunc({ repSlotName = "Weapon 1", repItem = mace })
 			assert.True(output.EnergyShield > 0)
 		end)
+		it("removes the off-hand quiver when using a two-handed weapon with Giant's Blood", function()
+			pasteAndEquipItem(bow:BuildRaw())
+			pasteAndEquipItem(quiver)
+			allocateKeystone("You can wield Two-Handed Axes, Maces and Swords in one hand")
+			local output = calcFunc({ repSlotName = "Weapon 1", repItem = mace })
+			assert.True(output.EnergyShield == 0)
+		end)
 		it("keeps the off-hand focus when using a staff with Instruments of Power", function()
 			pasteAndEquipItem(focus)
 			allocateKeystone("You can equip a Focus while wielding a Staff")
@@ -112,7 +119,7 @@ Dueling Wand]])
 			assert.True(output.EnergyShield > 0)
 		end)
 		it("unequips unique off-hand sceptre when using a talisman with Lord of the Wilds", function()
-			equipInSlot(new("Item", "Rarity: Unique\n" .. sceptre:BuildRaw()), "Weapon 2")
+			equipInSlot(new("Item"):Item("Rarity: Unique\n" .. sceptre:BuildRaw()), "Weapon 2")
 			allocateKeystone("You can equip a non-Unique Sceptre while wielding a Talisman")
 			local output = calcFunc({ repSlotName = "Weapon 1", repItem = talisman })
 			assert.True(output.EnergyShield == 0)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -906,7 +906,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			if overrideTwoHand and override.repSlotName and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") then
 				local allowLordOfTheWilds = lordOfTheWilds and override.repItem.base.type == "Talisman" and item and item.base.type == "Sceptre" and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
 				local allowInstrumentsOfPower = instrumentsOfPower and override.repItem.base.type == "Staff" and item and item.base.type == "Focus"
-				local allowGiantsBlood = giantsBlood and (override.repItem.base.type == "Two Hand Sword" or override.repItem.base.type == "Two Hand Axe" or override.repItem.base.type == "Two Hand Mace")
+				local allowGiantsBlood = giantsBlood and item and item.type ~= "Quiver" and (override.repItem.base.type == "Two Hand Sword" or override.repItem.base.type == "Two Hand Axe" or override.repItem.base.type == "Two Hand Mace")
 				local allowQuiver = (override.repItem.base.type == "Bow" and item and item.base.type == "Quiver")
 				local allowOffHand = allowLordOfTheWilds or allowInstrumentsOfPower or allowGiantsBlood or allowQuiver
 				if not allowOffHand then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -854,9 +854,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 	modDB:NewMod("Condition:WeaponSet" .. (build.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1) , "FLAG", true, "Weapon Set")
 
 	local weaponFlagState = {
-		giantsBlood = nodesModsList:Flag(nil, "GiantsBlood") or false,
-		instrumentsOfPower = nodesModsList:Flag(nil, "InstrumentsOfPower") or false,
-		lordOfTheWilds = nodesModsList:Flag(nil, "LordOfTheWilds") or false,
+		giantsBlood = nodesModsList:Flag(nil, "GiantsBlood") or modDB:Flag(nil, "GiantsBlood") or false,
+		instrumentsOfPower = nodesModsList:Flag(nil, "InstrumentsOfPower") or modDB:Flag(nil, "InstrumentsOfPower") or false,
+		lordOfTheWilds = nodesModsList:Flag(nil, "LordOfTheWilds") or modDB:Flag(nil, "LordOfTheWilds") or false,
 	}
 	-- Only mutate equipped items in the real build pass; calculator overrides (e.g. node power) are transient.
 	if mode == "MAIN" then
@@ -896,18 +896,22 @@ function calcs.initEnv(build, mode, override, specEnv)
 			local item
 			if slotName == override.repSlotName then
 				item = override.repItem
-			elseif override.repItem and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") and
-			(
-				(not lordOfTheWilds and override.repItem.base.type == "Talisman" and item and item.base.type ~= "Sceptre" and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC")
-				or (not instrumentsOfPower and override.repItem.base.type == "Staff" and item and item.base.type ~= "Focus")
-				or (not giantsBlood and (override.repItem.base.type == "Two Hand Sword" or override.repItem.base.type == "Two Hand Axe" or override.repItem.base.type == "Two Hand Mace"))
-				or (override.repItem.base.type == "Bow" and item and item.base.type ~= "Quiver")
-			) then
-				goto continue
 			elseif slot.nodeId and override.spec then
 				item = build.itemsTab.items[env.spec.jewels[slot.nodeId]]
 			else
 				item = build.itemsTab.items[slot.selItemId]
+			end
+			-- if we are replacing the main hand weapon, we should unequip the off hand weapon if it's not allowed
+			local overrideTwoHand = override.repItem and override.repItem.base.type and not (env.data.weaponTypeInfo[override.repItem.base.type] or {}).oneHand
+			if overrideTwoHand and override.repSlotName and override.repSlotName:match("^Weapon 1") and slotName:match("^Weapon 2") then
+				local allowLordOfTheWilds = lordOfTheWilds and override.repItem.base.type == "Talisman" and item and item.base.type == "Sceptre" and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+				local allowInstrumentsOfPower = instrumentsOfPower and override.repItem.base.type == "Staff" and item and item.base.type == "Focus"
+				local allowGiantsBlood = giantsBlood and (override.repItem.base.type == "Two Hand Sword" or override.repItem.base.type == "Two Hand Axe" or override.repItem.base.type == "Two Hand Mace")
+				local allowQuiver = (override.repItem.base.type == "Bow" and item and item.base.type == "Quiver")
+				local allowOffHand = allowLordOfTheWilds or allowInstrumentsOfPower or allowGiantsBlood or allowQuiver
+				if not allowOffHand then
+					goto continue
+				end
 			end
 			if item and item.grantedSkills then
 				-- Find skills granted by this item


### PR DESCRIPTION
Fixes #2252.

### Description of the problem being solved:

The calculator repItem functionality was allowing many off-hand items to be used with 2H weapons. This fixes that, adds test for it, and allows for custom mods to affect the related code.

### Steps taken to verify a working solution:
- Tests added

### Link to a build that showcases this PR:
N/A
### Before screenshot:
<img width="951" height="488" alt="image" src="https://github.com/user-attachments/assets/e7cef017-85eb-4bcb-b42f-a2ff1d3a8fe9" />

### After screenshot:
<img width="922" height="484" alt="image" src="https://github.com/user-attachments/assets/27ad5683-b657-4ee2-92fa-490d7ebfecd4" />
