### PR TITLE
Fix crash when adding +1 Suffix Rune

### DIFF
--- a/spec/System/TestItemsTab_spec.lua
+++ b/spec/System/TestItemsTab_spec.lua
@@ -655,22 +655,26 @@ describe("TestItemsTab", function()
 					Rarity: RARE
 					New
 					Stocky Mitts
+					Crafted: true
 					Sockets: S
 				]], true)
 
 				local runeControl = build.itemsTab.controls.displayItemRune1
+				local serlesIndex
 				for index, rune in ipairs(runeControl.list) do
 					if rune.name == "Serle's Triumph" then
-						runeControl:SetSel(index)
+						serlesIndex = index
 						break
 					end
 				end
+				assert.is_not_nil(serlesIndex)
+				runeControl:SetSel(serlesIndex)
 
 				local affixControl = build.itemsTab.controls.displayItemAffix7
 				assert.are.equals(7, build.itemsTab.displayItem.affixLimit)
 				assert.are.equals("suffixes", affixControl.outputTable)
 				assert.are.equals("None", affixControl.list[1])
-				affixControl.tooltipFunc({ Clear = function() end }, "BODY", affixControl.selIndex, nil)
+				affixControl.tooltipFunc({ Clear = function() end }, "BODY", affixControl.selIndex, affixControl.list[affixControl.selIndex])
 			end)
 
 			it("keeps Darkness Enthroned's socket editor available at zero sockets", function ()

--- a/spec/System/TestItemsTab_spec.lua
+++ b/spec/System/TestItemsTab_spec.lua
@@ -650,6 +650,29 @@ describe("TestItemsTab", function()
 				assert.is_true(foundMaximumRage)
 			end)
 
+			it("refreshes affix controls when an augment changes affix limits", function ()
+				build.itemsTab:CreateDisplayItemFromRaw([[
+					Rarity: RARE
+					New
+					Stocky Mitts
+					Sockets: S
+				]], true)
+
+				local runeControl = build.itemsTab.controls.displayItemRune1
+				for index, rune in ipairs(runeControl.list) do
+					if rune.name == "Serle's Triumph" then
+						runeControl:SetSel(index)
+						break
+					end
+				end
+
+				local affixControl = build.itemsTab.controls.displayItemAffix7
+				assert.are.equals(7, build.itemsTab.displayItem.affixLimit)
+				assert.are.equals("suffixes", affixControl.outputTable)
+				assert.are.equals("None", affixControl.list[1])
+				affixControl.tooltipFunc({ Clear = function() end }, "BODY", affixControl.selIndex, nil)
+			end)
+
 			it("keeps Darkness Enthroned's socket editor available at zero sockets", function ()
 				build.itemsTab:CreateDisplayItemFromRaw([[
 					Item Class: Belts

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -700,6 +700,7 @@ holding Shift will put it in the second.]])
 			self.displayItem.runes[i] = value.name
 			self.displayItem:UpdateRunes()
 			self.displayItem:BuildAndParseRaw()
+			self:UpdateRuneControls()
 			self:UpdateDisplayItemTooltip()
 		end)
 		drop.y = function()
@@ -808,7 +809,7 @@ holding Shift will put it in the second.]])
 			return i == 1 and 0 or 24 + (prev.slider:IsShown() and 18 or 0)
 		end
 		drop.tooltipFunc = function(tooltip, mode, index, value)
-			local modList = value.modList
+			local modList = value and value.modList
 			if not modList or main.popups[1] or mode == "OUT" or (self.selControl and self.selControl ~= drop) then
 				tooltip:Clear()
 			elseif tooltip:CheckForUpdate(modList) then
@@ -2034,6 +2035,10 @@ function ItemsTabClass:UpdateRuneControls()
 	end
 	if runesUpdated then
 		item:UpdateRunes()
+	end
+	-- Socketed augments can change the available prefix and suffix slots, e.g. Serle's Triumph.
+	if item.crafted then
+		self:UpdateAffixControls()
 	end
 end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -700,7 +700,9 @@ holding Shift will put it in the second.]])
 			self.displayItem.runes[i] = value.name
 			self.displayItem:UpdateRunes()
 			self.displayItem:BuildAndParseRaw()
-			self:UpdateRuneControls()
+			if self.displayItem.crafted then
+				self:UpdateAffixControls()
+			end
 			self:UpdateDisplayItemTooltip()
 		end)
 		drop.y = function()
@@ -2035,10 +2037,6 @@ function ItemsTabClass:UpdateRuneControls()
 	end
 	if runesUpdated then
 		item:UpdateRunes()
-	end
-	-- Socketed augments can change the available prefix and suffix slots, e.g. Serle's Triumph.
-	if item.crafted then
-		self:UpdateAffixControls()
 	end
 end
 


### PR DESCRIPTION
Fixes #2371.

### Description of the problem being solved:
UI crash when socketing an augment that changes the number of affix slots without updating list of available modifiers for newly added slot.
### Steps taken to verify a working solution:
- Validated that every craftable base that has the option of adding Serle's Triumph rune no longer causes the crash.
- Added a test validating the desired behaviour.
-

### Link to a build that showcases this PR:

### Before screenshot:
<img width="493" height="371" alt="{65727E2F-E804-4DAF-AD6E-3FC2391D7C50}" src="https://github.com/user-attachments/assets/0fa9c85b-f978-4432-ac49-f6d82ad3f62a" />

### After screenshot:
<img width="284" height="301" alt="{E5E30E23-E0D1-4477-98CA-D68A013B80E8}" src="https://github.com/user-attachments/assets/09feb841-9254-4ba4-b2e0-756a3cd9cb05" />
