### PR TITLE
Add support for Baryanic Leylines notable

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1391,6 +1391,18 @@ function PassiveSpecClass:NodesInIntuitiveLeapLikeRadius(node)
 	return result
 end
 
+-- Returns the radius index a jewel actually uses in this spec, accounting for
+-- "Non-Unique Time-Lost Jewels have 40% increased radius" (Baryanic Leylines)
+function PassiveSpecClass:GetJewelRadiusIndex(item)
+	local radiusIndex = item.jewelRadiusIndex
+	if radiusIndex and self.hasTimeLostJewelRadiusIncrease
+		and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+		and item.baseName and item.baseName:find("Time%-Lost") then
+		return data.timeLostJewelIncreasedRadiusIndex[radiusIndex] or radiusIndex
+	end
+	return radiusIndex
+end
+
 -- Rebuilds dependencies and paths for all nodes
 function PassiveSpecClass:BuildAllDependsAndPaths()
 	-- This table will keep track of which nodes have been visited during each path-finding attempt
@@ -1413,6 +1425,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 		end
 	end
 	wipeTable(intuitiveLeapLikeNodes)
+	self.hasTimeLostJewelRadiusIncrease = false
 	for id, node in pairs(self.allocNodes) do
 		if node.ascendancyName then -- avoid processing potentially replaceable nodes
 			self.tree:ProcessStats(node)
@@ -1420,6 +1433,9 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 				for _, radius in ipairs(node.modList:List(nil, "AllocateFromNodeRadius")) do
 					t_insert(intuitiveLeapLikeNodes, radius)
 				end
+			end
+			if node.modList:Sum("INC", nil, "NonUniqueTimeLostJewelRadius") > 0 then
+				self.hasTimeLostJewelRadiusIncrease = true
 			end
 			processed[id] = true
 		end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1394,13 +1394,7 @@ end
 -- Returns the radius index a jewel actually uses in this spec, accounting for
 -- "Non-Unique Time-Lost Jewels have 40% increased radius" (Baryanic Leylines)
 function PassiveSpecClass:GetJewelRadiusIndex(item)
-	local radiusIndex = item.jewelRadiusIndex
-	if radiusIndex and self.hasTimeLostJewelRadiusIncrease
-		and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
-		and item.baseName and item.baseName:find("Time%-Lost") then
-		return data.timeLostJewelIncreasedRadiusIndex[radiusIndex] or radiusIndex
-	end
-	return radiusIndex
+	return data.getTimeLostJewelRadiusIndex(item, self.hasTimeLostJewelRadiusIncrease)
 end
 
 -- Rebuilds dependencies and paths for all nodes

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1098,8 +1098,10 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 							end
 						else
 							-- Jewel in socket is not Thread of Hope or similar
+							-- Use the increased radii instead of the base ones if the socketed jewel benefits from them
+							local isIncreased = jewel and build.spec:GetJewelRadiusIndex(jewel) ~= jewel.jewelRadiusIndex
 							for index, data in ipairs(build.data.jewelRadius) do
-								if hoverNode.nodesInRadius[index][node.id] then
+								if (not data.increased) == (not isIncreased) and hoverNode.nodesInRadius[index][node.id] then
 									-- Draw normal jewel radii
 									if data.inner == 0 then
 										SetDrawColor(data.col)
@@ -1221,8 +1223,8 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 	end
 
 	-- Draw ring overlays for jewel sockets
-	local function drawJewelRadius(jewel, scrX, scrY, tint)
-		local radData = build.data.jewelRadius[jewel.jewelRadiusIndex]
+	local function drawJewelRadius(jewel, scrX, scrY, tint, jewelSpec)
+		local radData = build.data.jewelRadius[jewelSpec:GetJewelRadiusIndex(jewel)]
 		local outerSize = radData.outer * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale
 		local innerSize = radData.inner * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale * 1.06
 		SetDrawColor(tint[1], tint[2], tint[3], tint[4])
@@ -1270,6 +1272,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 			if node == hoverNode then
 				local effectiveJewel = jewel or cJewel
 				local isThreadOfHope = effectiveJewel and effectiveJewel.jewelRadiusLabel == "Variable"
+				-- Preview the increased radii instead of the base ones if the socketed jewel benefits from them
+				local jewelSpec = jewel and spec or self.compareSpec
+				local isIncreased = effectiveJewel and jewelSpec and jewelSpec:GetJewelRadiusIndex(effectiveJewel) ~= effectiveJewel.jewelRadiusIndex
 				for _, radData in ipairs(build.data.jewelRadius) do
 					local outerSize = radData.outer * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale
 					local innerSize = radData.inner * data.gameConstants["PassiveTreeJewelDistanceMultiplier"] * scale
@@ -1282,7 +1287,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 						end
 					else
 						-- Standard jewel: draw the full-disc radii (inner == 0)
-						if innerSize == 0 then
+						if innerSize == 0 and (not radData.increased) == (not isIncreased) then
 							SetDrawColor(radData.col)
 							DrawImage(self.ring, scrX - outerSize, scrY - outerSize, outerSize * 2, outerSize * 2)
 						end
@@ -1295,10 +1300,10 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 				local sameJewel = compareJewelsEqual(jewel, cJewel)
 				if pHasRadius then
 					local tint = (not self.compareSpec or sameJewel) and JEWEL_RADIUS_TINT_NEUTRAL or JEWEL_RADIUS_TINT_PRIMARY_ONLY
-					drawJewelRadius(jewel, scrX, scrY, tint)
+					drawJewelRadius(jewel, scrX, scrY, tint, spec)
 				end
 				if cHasRadius and not sameJewel then
-					drawJewelRadius(cJewel, scrX, scrY, JEWEL_RADIUS_TINT_COMPARE_ONLY)
+					drawJewelRadius(cJewel, scrX, scrY, JEWEL_RADIUS_TINT_COMPARE_ONLY, self.compareSpec)
 				end
 			end
 		end
@@ -1800,7 +1805,9 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		local isInRadius = false
 		for id, socket in pairs(build.itemsTab.sockets) do
 			if build.itemsTab.activeSocketList and socket.inactive == false or socket.inactive == nil then
-				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[4][node.id] ~= nil)
+				-- index 4 is Very Large; its increased version covers the largest possible Time-Lost radius
+				local maxRadiusIndex = build.spec.hasTimeLostJewelRadiusIncrease and data.timeLostJewelIncreasedRadiusIndex[4] or 4
+				isInRadius = isInRadius or (build.spec.nodes[id] and build.spec.nodes[id].nodesInRadius and build.spec.nodes[id].nodesInRadius[maxRadiusIndex][node.id] ~= nil)
 				if isInRadius then break end
 			end
 		end

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6337,7 +6337,7 @@ c["Non-Keystone Passive Skills in Medium Radius of allocated Keystone Passive Sk
 c["Non-Minion Skills have 50% less Reservation Efficiency"]={{[1]={[1]={neg=true,skillType=6,type="SkillType"},flags=0,keywordFlags=0,name="ReservationEfficiency",type="MORE",value=-50}},nil}
 c["Non-Unique Life Flasks apply their Effects constantly"]={nil,"Non-Unique Life Flasks apply their Effects constantly "}
 c["Non-Unique Life Flasks apply their Effects constantly Recovery from Life Flasks cannot be Instant"]={nil,"Non-Unique Life Flasks apply their Effects constantly Recovery from Life Flasks cannot be Instant "}
-c["Non-Unique Time-Lost Jewels have 40% increased radius"]={nil,"Non-Unique Time-Lost Jewels have 40% increased radius "}
+c["Non-Unique Time-Lost Jewels have 40% increased radius"]={{[1]={flags=0,keywordFlags=0,name="NonUniqueTimeLostJewelRadius",type="INC",value=40}},nil}
 c["Oasis"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Oasis"}},nil}
 c["Off-hand Hits inflict Runefather's Challenge"]={nil,"Off-hand Hits inflict Runefather's Challenge "}
 c["Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds"]={nil,"Off-hand Hits inflict Runefather's Challenge Inflicts Runefather's Challenge on enemies 6 metres in front of you when raised, no more than once every 2 seconds "}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -964,6 +964,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 					if item and not (node and node.sinister) and ( item.jewelRadiusIndex or (override and override.extraJewelFuncs and #override.extraJewelFuncs > 0) ) then
 						-- Jewel has a radius, add it to the list
+						local radiusIndex = env.spec:GetJewelRadiusIndex(item)
 						local funcList = (item.jewelData and item.jewelData.funcList) or { { type = "Self", func = function(node, out, data)
 							-- Default function just tallies all stats in radius
 							if node then
@@ -974,19 +975,19 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end } }
 						for _, func in ipairs(funcList) do
 							t_insert(env.radiusJewelList, {
-								nodes = node.nodesInRadius and node.nodesInRadius[item.jewelRadiusIndex] or { },
+								nodes = node.nodesInRadius and node.nodesInRadius[radiusIndex] or { },
 								func = func.func,
 								type = func.type,
 								item = item,
 								nodeId = slot.nodeId,
-								attributes = node.attributesInRadius and node.attributesInRadius[item.jewelRadiusIndex] or { },
+								attributes = node.attributesInRadius and node.attributesInRadius[radiusIndex] or { },
 								data = { },
 								-- store this to compare with cache later
 								jewelHash = getHashFromString(item.modSource..item.raw)
 							})
 							if func.type ~= "Self" and node.nodesInRadius then
 								-- Add nearby unallocated nodes to the extra node list
-								for nodeId, node in pairs(node.nodesInRadius[item.jewelRadiusIndex]) do
+								for nodeId, node in pairs(node.nodesInRadius[radiusIndex]) do
 									if not env.allocNodes[nodeId] then
 										env.extraRadiusNodeList[nodeId] = env.spec.nodes[nodeId]
 									end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -833,6 +833,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 
 	local nodesModsList = calcs.buildModListForNodeList(env, env.allocNodes, true, true)
 	env.useAltGemQualityStats = nodesModsList:Flag(nil, "GemlingQuality")
+	-- Check the environment's own node list rather than the spec's allocation, so that
+	-- simulated allocations (e.g. node hover tooltips) see the radius change too
+	local timeLostJewelRadiusIncrease = nodesModsList:Sum("INC", nil, "NonUniqueTimeLostJewelRadius") > 0
 
 	if allocatedNotableCount and allocatedNotableCount > 0 then
 		modDB:NewMod("Multiplier:AllocatedNotable", "BASE", allocatedNotableCount)
@@ -964,7 +967,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					end
 					if item and not (node and node.sinister) and ( item.jewelRadiusIndex or (override and override.extraJewelFuncs and #override.extraJewelFuncs > 0) ) then
 						-- Jewel has a radius, add it to the list
-						local radiusIndex = env.spec:GetJewelRadiusIndex(item)
+						local radiusIndex = data.getTimeLostJewelRadiusIndex(item, timeLostJewelRadiusIncrease)
 						local funcList = (item.jewelData and item.jewelData.funcList) or { { type = "Self", func = function(node, out, data)
 							-- Default function just tallies all stats in radius
 							if node then

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -683,6 +683,18 @@ data.jewelRadii = {
 -- Maps a Time-Lost jewel's base radius index to its 40% increased counterpart above
 data.timeLostJewelIncreasedRadiusIndex = { [1] = 13, [2] = 14, [3] = 15, [4] = 16 }
 
+-- Returns the radius index a jewel uses given whether the Time-Lost radius increase
+-- (Baryanic Leylines) applies; only non-unique Time-Lost jewels are remapped
+data.getTimeLostJewelRadiusIndex = function(item, timeLostJewelRadiusIncrease)
+	local radiusIndex = item.jewelRadiusIndex
+	if radiusIndex and timeLostJewelRadiusIncrease
+		and item.rarity ~= "UNIQUE" and item.rarity ~= "RELIC"
+		and item.baseName and item.baseName:find("Time%-Lost") then
+		return data.timeLostJewelIncreasedRadiusIndex[radiusIndex] or radiusIndex
+	end
+	return radiusIndex
+end
+
 data.jewelRadius = data.setJewelRadiiGlobally(latestTreeVersion)
 
 -- Stat descriptions

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -669,8 +669,19 @@ data.jewelRadii = {
 		{ inner = 1400, outer = 1700, col = "^xFFCC00", label = "Variable" },
 		{ inner = 1650, outer = 1950, col = "^xFF6600", label = "Variable" },
 		{ inner = 1800, outer = 2100, col = "^x0099FF", label = "Variable" },
+
+		-- 40% increased versions of the four base radii, used for non-Unique Time-Lost
+		-- jewels when "Non-Unique Time-Lost Jewels have 40% increased radius" is allocated
+		-- (Baryanic Leylines). `increased` keeps them out of the generic radius previews.
+		{ inner = 0, outer = 1400, col = "^xBB6600", label = "Increased Small", increased = true },
+		{ inner = 0, outer = 1610, col = "^x66FFCC", label = "Increased Medium", increased = true },
+		{ inner = 0, outer = 1820, col = "^x2222CC", label = "Increased Large", increased = true },
+		{ inner = 0, outer = 2100, col = "^xC100FF", label = "Increased Very Large", increased = true },
 	}
 }
+
+-- Maps a Time-Lost jewel's base radius index to its 40% increased counterpart above
+data.timeLostJewelIncreasedRadiusIndex = { [1] = 13, [2] = 14, [3] = 15, [4] = 16 }
 
 data.jewelRadius = data.setJewelRadiiGlobally(latestTreeVersion)
 

--- a/src/Modules/ItemSlotHelper.lua
+++ b/src/Modules/ItemSlotHelper.lua
@@ -18,6 +18,15 @@ function M.DrawViewer(itemsTab, nodeId, x, y, w, h)
 
 	local viewer = itemsTab.socketViewer
 	viewer.zoom = 17
+	-- Zoom out if needed so the socketed jewel's radius ring (including the Time-Lost
+	-- radius increase from Baryanic Leylines) fits inside the preview: the ring's
+	-- diameter must fit min(w,h), with ~5% margin so the ring stroke isn't clipped
+	local _, jewel = itemsTab:GetSocketAndJewelForNodeID(nodeId)
+	if jewel and jewel.jewelRadiusIndex then
+		local radData = data.jewelRadius[itemsTab.build.spec:GetJewelRadiusIndex(jewel)]
+		local ringSize = radData.outer * data.gameConstants["PassiveTreeJewelDistanceMultiplier"]
+		viewer.zoom = math.min(viewer.zoom, itemsTab.build.spec.tree.size / (2 * ringSize) / 1.05)
+	end
 
 	local viewPortSize = math.min(w, h)
 	local scale = itemsTab.build.spec.tree.size / (viewPortSize * viewer.zoom)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5525,6 +5525,7 @@ local specialModList = {
 	["upgrades radius to medium"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 2 })},
 	["upgrades radius to large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 3 })},
 	["upgrades radius to very large"] = { mod("JewelData", "LIST", { key = "timeLostJewelRadiusOverride", value = 4 })},
+	["non%-unique time%-lost jewels have (%d+)%% increased radius"] = function(num) return { mod("NonUniqueTimeLostJewelRadius", "INC", num) } end,
 	["primordial"] = { mod("Multiplier:PrimordialItem", "BASE", 1) },
 	["spectres have a base duration of (%d+) seconds"] = { mod("SkillData", "LIST", { key = "duration", value = 6 }, { type = "SkillName", skillName = "Raise Spectre", includeTransfigured = true }) },
 	["flasks applied to you have (%d+)%% increased effect"] = function(num) return { mod("FlaskEffect", "INC", num, { type = "ActorCondition", actor = "player"}) } end,


### PR DESCRIPTION
Parses "Non-Unique Time-Lost Jewels have 40% increased radius" and applies it to socketed non-unique Time-Lost jewels.

Adds 40% increased versions of the four base radii to data.jewelRadius. PassiveSpec:GetJewelRadiusIndex() now remaps Time-Lost jewel's index to the new versions when the notable is allocated. The lookup goes through the spec instead of the item, so loadouts and tree compare can disagree for the same jewel.

Tree view rings, hover previews, and tooltips are updated to use the effective index.

ModCache is also regenerated for the new parser entry.

Fixes #2380 .

### Description of the problem being solved:

### Steps taken to verify a working solution:
- Ran the dev build locally
-
-

### Link to a build that showcases this PR:

https://poe.ninja/poe2/pob/2606e

### Before screenshot:

<img width="2249" height="1209" alt="unsupported" src="https://github.com/user-attachments/assets/2d242878-df5f-4e54-babd-6d5bd79683ce" />

### After screenshot:

unallocated:

<img width="2248" height="1208" alt="unallocated" src="https://github.com/user-attachments/assets/9ff19074-4291-40b0-b4c9-c5c523279f43" />

allocated:

<img width="2248" height="1208" alt="allocated" src="https://github.com/user-attachments/assets/28d9723c-e222-4a2e-aee0-a03fde222e4e" />

item preview:

<img width="404" height="315" alt="Screenshot 2026-07-19 at 11 52 29 PM" src="https://github.com/user-attachments/assets/079aa4f9-2d7d-47f0-ae19-461ebef3eece" />

