### PR TITLE
Fix Normal and Magic Ward bases not importing

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1146,7 +1146,7 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 	return charData -- For the wrapper
 end
 
-local rarityMap = { [0] = "NORMAL", "MAGIC", "RARE", "UNIQUE", [9] = "RELIC", [10] = "RELIC", [13] = "RARE", [14] = "UNIQUE" }
+local rarityMap = { [0] = "NORMAL", "MAGIC", "RARE", "UNIQUE", [9] = "RELIC", [10] = "RELIC", [11] = "NORMAL", [12] = "MAGIC", [13] = "RARE", [14] = "UNIQUE" }
 local slotMap = { ["Weapon"] = "Weapon 1", ["Offhand"] = "Weapon 2", ["Weapon2"] = "Weapon 1 Swap", ["Offhand2"] = "Weapon 2 Swap", ["Helm"] = "Helmet", ["BodyArmour"] = "Body Armour", ["Gloves"] = "Gloves", ["Boots"] = "Boots", ["Amulet"] = "Amulet", ["Ring"] = "Ring 1", ["Ring2"] = "Ring 2", ["Ring3"] = "Ring 3", ["Belt"] = "Belt", ["IncursionArmLeft"] = "Arm 2", ["IncursionArmRight"] = "Arm 1", ["IncursionLegLeft"] = "Leg 2", ["IncursionLegRight"] = "Leg 1" }
 
 function ImportTabClass:ImportItem(itemData, slotName)


### PR DESCRIPTION
### Description of the problem being solved:
The bases were not being imported as they were using a frame type value of 11 and 12 which were not in the rarity map so PoB just wouldn't import them

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldurhcssf/character/lipeehopp-7185/Throyin_HCSSF?i=1&search=class%3DSmith%2Bof%2BKitava%26skills%3DSupercharged%2BSlam

### Before screenshot:
<img width="414" height="126" alt="image" src="https://github.com/user-attachments/assets/b189b24f-ffd5-4fc6-8812-cabee5e806e4" />
<img width="281" height="450" alt="image" src="https://github.com/user-attachments/assets/ad8a30c8-72dc-4c82-bfd0-161b68cfcb59" />


### After screenshot:
<img width="833" height="384" alt="image" src="https://github.com/user-attachments/assets/c2c97330-5e73-43d9-96fb-bd40aaa4f5c3" />
<img width="283" height="452" alt="image" src="https://github.com/user-attachments/assets/8c622ab6-e269-4899-bd8a-4e608af28834" />
