### PR TITLE
Extract parent proxy handlers and simplify parent-member lookup

### DIFF
--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -112,6 +112,31 @@ function newClass(className, ...)
 	end
 	return class
 end
+
+local parentCall = function(proxy, ...)
+	local parent = proxy._parent
+	local object = proxy._object
+
+	if not parent._constructor then
+		error("Parent class '"..parent._className.."' has no constructor")
+	end
+	if object._parentInit[parent] then
+		error("Parent class '"..parent._className.."' has already been initialised")
+	end
+
+	parent._constructor(object, ...)
+	object._parentInit[parent] = true
+end
+
+local parentIndex = function(self, key)
+	local v = rawget(self._object, key)
+	if v ~= nil then
+		return v
+	else
+		return self._parent[key]
+	end
+end
+
 function new(className, ...)
 	local class = getClass(className)
 	local object = setmetatable({ }, class)
@@ -121,25 +146,11 @@ function new(className, ...)
 		object._parentInit = { }
 		for parent in pairs(class._superParents) do
 			local proxyMeta = {
-				__index = function(self, key)
-					local v = rawget(object, key)
-					if v ~= nil then
-						return v
-					else
-						return parent[key]
-					end
-				end,
+				_parent = parent,
+				_object = object,
+				__index = parentIndex,
 				__newindex = object,
-				__call = function(...)
-					if not parent._constructor then
-						error("Parent class '"..parent._className.."' of class '"..class._className.."' has no constructor")
-					end
-					if object._parentInit[parent] then
-						error("Parent class '"..parent._className.."' of class '"..class._className.."' has already been initialised")
-					end
-					parent._constructor(...)
-					object._parentInit[parent] = true
-				end,
+				__call = parentCall,
 			}
 			object[parent._className] = setmetatable(proxyMeta, proxyMeta)
 		end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -98,17 +98,13 @@ function newClass(className, ...)
 		class._superParents = { }
 		addSuperParents(class, class)
 		-- Set up inheritance
-		setmetatable(class, {
-			__index = function(self, key)
-				for _, parent in ipairs(class._parents) do
-					local val = parent[key]
-					if val ~= nil then
-						self[key] = val
-						return val
-					end
+		for _, parent in ipairs(class._parents) do
+			for k, v in pairs(parent) do
+				if class[k] == nil then
+					class[k] = v
 				end
 			end
-		})
+		end
 	end
 	return class
 end


### PR DESCRIPTION
### Description of the problem being solved:
JIT traces were aborting due to per-instance dynamic metamethods and anonymous closures created for parent lookups and constructor calls.
#### Example trace aborts:
```[TRACE --- (969/3) ModStore.lua:99 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- (969/3) ModStore.lua:99 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- CalcPerform.lua:41 -- inner loop in root trace at Common.lua:123]
[TRACE --- (165/2) ModList.lua:87 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- PassiveSpec.lua:1199 -- inner loop in root trace at Common.lua:104]
[TRACE --- PassiveSpec.lua:1121 -- inner loop in root trace at Common.lua:104]
[TRACE --- Common.lua:102 -- inner loop in root trace at Common.lua:104]
[TRACE --- CalcSetup.lua:890 -- inner loop in root trace at Common.lua:104]
[TRACE --- (997/2) ModList.lua:87 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- Common.lua:122 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- (997/2) ModList.lua:87 -- NYI: bytecode FNEW   at Common.lua:131]
[TRACE --- (997/2) ModList.lua:87 -- NYI: bytecode FNEW   at Common.lua:131]
```
### Changes made:
- Extracted reusable local helper functions `parentIndex` and `parentCall`.
- Updated proxy metatables to store `_parent` and `_object` and reuse the extracted handlers instead of creating new anonymous closures per parent.
- Simplified parent-to-child member resolution to avoid dynamic per-object `__index` logic.

### Impact:
- Behaviour is unchanged for normal usage but members added to a parent _after_ child classes are created will no longer automatically become visible to existing children.
- No more `FNEW` trace aborts (verified using `jit.v`). While the exact counts vary between runs due to non-deterministic nature of the JIT, I observed fewer abort and more successful traces in `Common.lua`.
- Possible slight performance increase. Because of run-to-run variance I’m not presenting hard numbers, but I believe this change is a net positive for interaction with the rest of the codebase.
