### PR TITLE
Add legacy flag to Commandment support

### DIFF
--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -2042,6 +2042,7 @@ skills["SupportCommandment"] = {
 	levels = {
 		[1] = { levelRequirement = 0, },
 	},
+	legacy = true,
 	statSets = {
 		[1] = {
 			label = "Commandment",

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -351,6 +351,7 @@ statMap = {
 #skillEnd
 
 #skill SupportCommandment
+legacy = true
 #set SupportCommandment
 statMap = {
 	["support_minion_damage_with_non_command_skills_+%_final"] = {


### PR DESCRIPTION
### Description of the problem being solved:

Commandment was missing the legacy flag, this PR fixes that.

### Steps taken to verify a working solution:
- Verify that commandment is only available if you enable `Show legacy gems`