### PR TITLE
Fix Verglas destroyed Ice Crystal damage gain

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -536,6 +536,7 @@ describe("TestSkills", function()
 		build.itemsTab:AddDisplayItem()
 		build.skillsTab:PasteSocketGroup("Quarterstaff Strike 20/0  1\nVerglas 1/0  1")
 		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
+		build.skillsTab:PasteSocketGroup("Frost Wall 20/20  1")
 		build.skillsTab.socketGroupList[1].includeInFullDPS = true
 		runCallback("OnFrame")
 
@@ -544,7 +545,6 @@ describe("TestSkills", function()
 		assert.True(baseFullDPS > 0)
 
 		build.configTab.input.conditionDestroyedIceCrystalPast6Seconds = true
-		build.configTab.input.multiplierDestroyedIceCrystalLife = 2000
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
 
@@ -557,10 +557,25 @@ describe("TestSkills", function()
 		end
 		local linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
 		local unlinkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[2])
+		local frostWallSkill = findSkillForGroup(build.skillsTab.socketGroupList[3])
 		assert.is_not_nil(linkedSkill)
 		assert.is_not_nil(unlinkedSkill)
-		assert.are.equals(1, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		assert.is_not_nil(frostWallSkill)
+		local frostWallLife = frostWallSkill.skillModList:Sum("BASE", frostWallSkill.skillCfg, "IceCrystalLifeBase") * calcLib.mod(frostWallSkill.skillModList, frostWallSkill.skillCfg, "IceCrystalLife")
+		assert.are.equals(frostWallLife, build.calcsTab.mainEnv.player.automaticDestroyedIceCrystalLife)
+		assert.are.equals(frostWallLife, build.calcsTab.mainEnv.player.destroyedIceCrystalLife)
+		assert.are.equals(tostring(math.floor(frostWallLife + 0.5)), build.configTab.varControls.multiplierDestroyedIceCrystalLife.placeholder)
+		assert.are.equals(math.floor(frostWallLife / 2000), linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
 		assert.are.equals(0, unlinkedSkill.skillModList:Sum("BASE", unlinkedSkill.skillCfg, "DamageGainAsCold"))
+		local automaticFullDPS = build.calcsTab.mainOutput.FullDPS
+		assert.True(automaticFullDPS > baseFullDPS)
+
+		build.configTab.input.multiplierDestroyedIceCrystalLife = 2000
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(1, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
 
 		build.configTab.input.multiplierDestroyedIceCrystalLife = 3999
 		build.configTab:BuildModList()
@@ -585,6 +600,19 @@ describe("TestSkills", function()
 
 		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
 		assert.are.equals(135, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+
+		build.configTab.input.multiplierDestroyedIceCrystalLife = nil
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(math.floor(frostWallLife / 2000), linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		assert.are.near(automaticFullDPS, build.calcsTab.mainOutput.FullDPS, automaticFullDPS * 0.001)
+
+		local calcFunc, baseOutput = LoadModule("Modules/Calcs").getMiscCalculator(build)
+		local advancedThaumaturgy = build.spec.nodes[14429]
+		local qualityOutput = calcFunc({ addNodes = { [advancedThaumaturgy] = true } }, true, { fullDPSOnly = true })
+		assert.True(qualityOutput.FullDPS > baseOutput.FullDPS)
 
 		build.configTab.input.conditionDestroyedIceCrystalPast6Seconds = false
 		build.configTab:BuildModList()

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -531,6 +531,70 @@ describe("TestSkills", function()
 		assert.True(math.abs(build.calcsTab.mainOutput.FullDPS - fullDPS * 0.5) < fullDPS * 0.001)
 	end)
 
+	it("applies Verglas from destroyed Ice Crystal Life only to supported skills", function()
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nRazor Quarterstaff\nQuality: 0")
+		build.itemsTab:AddDisplayItem()
+		build.skillsTab:PasteSocketGroup("Quarterstaff Strike 20/0  1\nVerglas 1/0  1")
+		build.skillsTab:PasteSocketGroup("Leap Slam 20/0  1")
+		build.skillsTab.socketGroupList[1].includeInFullDPS = true
+		runCallback("OnFrame")
+
+		local baseFullDPS = build.calcsTab.mainOutput.FullDPS
+		assert.truthy(baseFullDPS)
+		assert.True(baseFullDPS > 0)
+
+		build.configTab.input.conditionDestroyedIceCrystalPast6Seconds = true
+		build.configTab.input.multiplierDestroyedIceCrystalLife = 2000
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		local function findSkillForGroup(socketGroup)
+			for _, activeSkill in ipairs(build.calcsTab.mainEnv.player.activeSkillList) do
+				if activeSkill.socketGroup == socketGroup then
+					return activeSkill
+				end
+			end
+		end
+		local linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		local unlinkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[2])
+		assert.is_not_nil(linkedSkill)
+		assert.is_not_nil(unlinkedSkill)
+		assert.are.equals(1, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		assert.are.equals(0, unlinkedSkill.skillModList:Sum("BASE", unlinkedSkill.skillCfg, "DamageGainAsCold"))
+
+		build.configTab.input.multiplierDestroyedIceCrystalLife = 3999
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(1, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		local fullDPSAt3999Life = build.calcsTab.mainOutput.FullDPS
+		assert.True(fullDPSAt3999Life > baseFullDPS)
+
+		build.configTab.input.multiplierDestroyedIceCrystalLife = 4000
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(2, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		assert.True(build.calcsTab.mainOutput.FullDPS > fullDPSAt3999Life)
+
+		build.configTab.input.multiplierDestroyedIceCrystalLife = 271990
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(135, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+
+		build.configTab.input.conditionDestroyedIceCrystalPast6Seconds = false
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		linkedSkill = findSkillForGroup(build.skillsTab.socketGroupList[1])
+		assert.are.equals(0, linkedSkill.skillModList:Sum("BASE", linkedSkill.skillCfg, "DamageGainAsCold"))
+		assert.are.near(baseFullDPS, build.calcsTab.mainOutput.FullDPS, baseFullDPS * 0.001)
+	end)
+
 	it("Test mana cost efficiency with support gems", function()
 		-- Test interaction between cost efficiency and cost multipliers
 		build.skillsTab:PasteSocketGroup("Contagion 6/0  1\nMagnified Area I 1/0  1")

--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -610,9 +610,9 @@ describe("TestSkills", function()
 		assert.are.near(automaticFullDPS, build.calcsTab.mainOutput.FullDPS, automaticFullDPS * 0.001)
 
 		local calcFunc, baseOutput = LoadModule("Modules/Calcs").getMiscCalculator(build)
-		local advancedThaumaturgy = build.spec.nodes[14429]
-		local qualityOutput = calcFunc({ addNodes = { [advancedThaumaturgy] = true } }, true, { fullDPSOnly = true })
-		assert.True(qualityOutput.FullDPS > baseOutput.FullDPS)
+		build.skillsTab:PasteSocketGroup("Frost Wall 20/20  1\nGlacier 1/0  1")
+		local glacierOutput = calcFunc(nil, true, { fullDPSOnly = true })
+		assert.True(glacierOutput.FullDPS > baseOutput.FullDPS)
 
 		build.configTab.input.conditionDestroyedIceCrystalPast6Seconds = false
 		build.configTab:BuildModList()

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -8553,6 +8553,14 @@ skills["SupportVerglasPlayer"] = {
 			label = "Verglas",
 			incrementalEffectiveness = 0.054999999701977,
 			statDescriptionScope = "gem_stat_descriptions",
+			statMap = {
+				["support_crystalshatter_buff_damage_%_gained_as_extra_cold_per_2000_crystal_life"] = {
+					mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "DestroyedIceCrystalPast6Seconds" }, { type = "Multiplier", var = "DestroyedIceCrystalLife", div = 2000 }),
+				},
+				["support_crystalshatter_buff_duration"] = {
+					-- Display only
+				},
+			},
 			baseFlags = {
 			},
 			constantStats = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -1521,6 +1521,14 @@ statMap = {
 
 #skill SupportVerglasPlayer
 #set SupportVerglasPlayer
+statMap = {
+	["support_crystalshatter_buff_damage_%_gained_as_extra_cold_per_2000_crystal_life"] = {
+		mod("DamageGainAsCold", "BASE", nil, 0, 0, { type = "Condition", var = "DestroyedIceCrystalPast6Seconds" }, { type = "Multiplier", var = "DestroyedIceCrystalLife", div = 2000 }),
+	},
+	["support_crystalshatter_buff_duration"] = {
+		-- Display only
+	},
+},
 #mods
 #skillEnd
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -11,6 +11,7 @@ local t_insert = table.insert
 local t_remove = table.remove
 local m_min = math.min
 local m_max = math.max
+local m_floor = math.floor
 local band = AND64
 
 local tempTable1 = { }
@@ -2090,6 +2091,35 @@ function calcs.initEnv(build, mode, override, specEnv)
 			activeSkill.skillData.totemLevel = skillData.totemLevel
 			activeSkill.skillData.damageEffectiveness = skillData.damageEffectiveness
 			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent
+		end
+	end
+
+	-- Verglas uses the maximum Life of the Ice Crystal that granted its buff.
+	-- Prefer the highest value from enabled Ice Crystal skills in the build, while
+	-- retaining the Config value as an explicit override for other crystal sources.
+	local automaticDestroyedIceCrystalLife = 0
+	for _, activeSkill in pairs(env.player.activeSkillList) do
+		local socketGroup = activeSkill.socketGroup
+		if (not socketGroup or (socketGroup.enabled and socketGroup.slotEnabled)) and activeSkill.skillModList then
+			local baseLife = activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "IceCrystalLifeBase")
+			if baseLife > 0 then
+				automaticDestroyedIceCrystalLife = m_max(automaticDestroyedIceCrystalLife, baseLife * calcLib.mod(activeSkill.skillModList, activeSkill.skillCfg, "IceCrystalLife"))
+			end
+		end
+	end
+	local configuredDestroyedIceCrystalLife = tonumber(env.configInput.multiplierDestroyedIceCrystalLife) or 0
+	local resolvedDestroyedIceCrystalLife = configuredDestroyedIceCrystalLife > 0 and configuredDestroyedIceCrystalLife or automaticDestroyedIceCrystalLife
+	env.player.automaticDestroyedIceCrystalLife = automaticDestroyedIceCrystalLife
+	env.player.destroyedIceCrystalLife = resolvedDestroyedIceCrystalLife
+	if configuredDestroyedIceCrystalLife <= 0 and automaticDestroyedIceCrystalLife > 0 then
+		env.modDB.multipliers.DestroyedIceCrystalLife = automaticDestroyedIceCrystalLife
+	else
+		env.modDB.multipliers.DestroyedIceCrystalLife = nil
+	end
+	if mode == "MAIN" then
+		local control = build.configTab.varControls.multiplierDestroyedIceCrystalLife
+		if control then
+			control:SetPlaceholder(automaticDestroyedIceCrystalLife > 0 and m_floor(automaticDestroyedIceCrystalLife + 0.5) or "", false)
 		end
 	end
 

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -225,6 +225,9 @@ end
 local exposureElements = { "Fire", "Cold", "Lightning", "Chaos" }
 local function captureCouplingSurface(env)
 	local surface = { mods = { }, meta = { } }
+	-- Automatic Verglas scaling is derived from another active skill (usually
+	-- Frost Wall), so it must participate in Full-DPS cache invalidation.
+	surface.meta[#surface.meta + 1] = "destroyedIceCrystalLife/" .. tostring(env.player.destroyedIceCrystalLife or 0)
 	for _, skill in ipairs(env.player.activeSkillList) do
 		for _, buff in ipairs(skill.buffList or { }) do
 			surface.meta[#surface.meta + 1] = tostring(buff.type) .. "/" .. tostring(buff.name)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1172,6 +1172,12 @@ Huge sets the radius to 11.
 	{ var = "conditionKilledLast3Seconds", type = "check", label = "Have you Killed in the last 3 Seconds?", ifCond = "KilledLast3Seconds", implyCond = "KilledRecently", tooltip = "This also implies that you have Killed Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:KilledLast3Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "conditionDestroyedIceCrystalPast6Seconds", type = "check", label = "Have you Destroyed an Ice Crystal in the past 6 Seconds?", ifCond = "DestroyedIceCrystalPast6Seconds", apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:DestroyedIceCrystalPast6Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
+	end },
+	{ var = "multiplierDestroyedIceCrystalLife", type = "count", label = "Maximum Life of the Destroyed Ice Crystal:", ifOption = "conditionDestroyedIceCrystalPast6Seconds", ifMult = "DestroyedIceCrystalLife", tooltip = "Enter the maximum Life of the Ice Crystal that granted the current Verglas buff.", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:DestroyedIceCrystalLife", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionKilledPoisonedLast2Seconds", type = "check", label = "Killed a poisoned enemy in the last 2 Seconds?", ifCond = "KilledPoisonedLast2Seconds", implyCond = "KilledRecently", tooltip = "This also implies that you have Killed Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:KilledPoisonedLast2Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1172,10 +1172,10 @@ Huge sets the radius to 11.
 	{ var = "conditionKilledLast3Seconds", type = "check", label = "Have you Killed in the last 3 Seconds?", ifCond = "KilledLast3Seconds", implyCond = "KilledRecently", tooltip = "This also implies that you have Killed Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:KilledLast3Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "conditionDestroyedIceCrystalPast6Seconds", type = "check", label = "Have you Destroyed an Ice Crystal in the past 6 Seconds?", ifCond = "DestroyedIceCrystalPast6Seconds", apply = function(val, modList, enemyModList)
+	{ var = "conditionDestroyedIceCrystalPast6Seconds", type = "check", label = "Destroyed an Ice Crystal in past 6s?", ifCond = "DestroyedIceCrystalPast6Seconds", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:DestroyedIceCrystalPast6Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "multiplierDestroyedIceCrystalLife", type = "count", label = "Maximum Life of the Destroyed Ice Crystal:", ifOption = "conditionDestroyedIceCrystalPast6Seconds", ifMult = "DestroyedIceCrystalLife", tooltip = "Enter the maximum Life of the Ice Crystal that granted the current Verglas buff.", apply = function(val, modList, enemyModList)
+	{ var = "multiplierDestroyedIceCrystalLife", type = "count", label = "Ice Crystal Life override:", ifOption = "conditionDestroyedIceCrystalPast6Seconds", ifMult = "DestroyedIceCrystalLife", tooltip = "Automatically uses the highest maximum Life from enabled Ice Crystal skills.\nEnter a value to override it for another Ice Crystal source.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:DestroyedIceCrystalLife", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "conditionKilledPoisonedLast2Seconds", type = "check", label = "Killed a poisoned enemy in the last 2 Seconds?", ifCond = "KilledPoisonedLast2Seconds", implyCond = "KilledRecently", tooltip = "This also implies that you have Killed Recently.", apply = function(val, modList, enemyModList)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1172,7 +1172,7 @@ Huge sets the radius to 11.
 	{ var = "conditionKilledLast3Seconds", type = "check", label = "Have you Killed in the last 3 Seconds?", ifCond = "KilledLast3Seconds", implyCond = "KilledRecently", tooltip = "This also implies that you have Killed Recently.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:KilledLast3Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "conditionDestroyedIceCrystalPast6Seconds", type = "check", label = "Destroyed an Ice Crystal in past 6s?", ifCond = "DestroyedIceCrystalPast6Seconds", apply = function(val, modList, enemyModList)
+	{ var = "conditionDestroyedIceCrystalPast6Seconds", type = "check", label = "Ice Crystal destroyed (past 6s)?", ifCond = "DestroyedIceCrystalPast6Seconds", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:DestroyedIceCrystalPast6Seconds", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "multiplierDestroyedIceCrystalLife", type = "count", label = "Ice Crystal Life override:", ifOption = "conditionDestroyedIceCrystalPast6Seconds", ifMult = "DestroyedIceCrystalLife", tooltip = "Automatically uses the highest maximum Life from enabled Ice Crystal skills.\nEnter a value to override it for another Ice Crystal source.", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Fixes #2389.

### Description of the problem being solved:

Verglas exports its 1% Damage gained as extra Cold per 2,000 maximum Life of the destroyed Ice Crystal and its 6-second duration, but `SupportVerglasPlayer` had no stat mapping. As a result, linking or disabling Verglas produced identical per-skill and Full DPS values.

This adds:

- A local `DamageGainAsCold` modifier for skills actually supported by Verglas.
- A default-off configuration for destroying an Ice Crystal in the past 6 seconds.
- Automatic maximum-Life detection from enabled Ice Crystal skills in the build, using the highest calculated value.
- An optional Life override for a different crystal source or a specific lower-Life crystal.
- Full-DPS cache invalidation when the resolved cross-skill Ice Crystal Life changes.
- Display-only handling for the exported buff duration.

The modifier uses the existing `Multiplier` tag with `div = 2000`, which floors to complete 2,000-Life increments. It is intentionally not a `GlobalEffect`, since Verglas only applies to supported skills.

The automatic value is shown as the input placeholder. Leaving the field empty uses that value; entering a positive value takes explicit precedence. The checkbox remains default-off because having an Ice Crystal skill does not imply that the player destroyed a crystal within the past 6 seconds.

### Steps taken to verify a working solution:

- Focused Verglas regression: 1/1 passed.
- Complete `TestSkills_spec.lua`: 61/61 passed with 0 failures and 0 errors.
- Complete `TestFullDPSCache_spec.lua`: 8/8 passed with 0 failures and 0 errors.
- Regression covers the disabled condition, automatic Life and placeholder, manual override precedence, 2,000 / 3,999 / 4,000 Life breakpoints, 271,990 Life producing 135%, linked-versus-unlinked skill scope, selecting a higher-Life Ice Crystal source, cross-skill Full-DPS cache invalidation, and Full DPS returning to baseline when the condition is disabled.
- Affected build on this PR alone: automatic Frost Wall Life 30,908 and 26,087,034.64 Full DPS. The separate Frost Wall quality mapping fix in #2386 is required for Advanced Thaumaturgy's additional quality to affect that Life.
- Affected build with #2386 and this PR combined: automatic Frost Wall Life 271,990.4 and 47,163,971.67 Full DPS, matching the prior 135% gained-as-Cold proxy.
- Lua syntax checks and `git diff --check` passed.

### Link to a build that showcases this PR:

https://pobb.in/CI4hChFipObn

### Before screenshot:

Verglas enabled or disabled: 23,452,423.18 Full DPS.

### After screenshot:

With "Ice Crystal destroyed (past 6s)?" enabled and the Life override left empty, Verglas uses the highest calculated Life from enabled Ice Crystal skills. With #2386 also applied, this build resolves 271,990.4 Life and 47,163,971.67 Full DPS.
