### PR TITLE
Support Cadiro's Gambit's Perandus Arrows

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -5226,7 +5226,7 @@ c["Double Stun Threshold while Shield is Raised"]={{[1]={[1]={globalLimit=100,gl
 c["Double the number of your Poisons that targets can be affected by at the same time"]={{[1]={flags=0,keywordFlags=0,name="PoisonCanStack",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="PoisonStacks",type="MORE",value=100}},nil}
 c["Drop Ignited Ground while moving, which lasts 8 seconds and Ignites as though dealing Fire Damage equal to 10% of your maximum Life"]={nil,"Drop Ignited Ground while moving, which lasts 8 seconds and Ignites as though dealing Fire Damage equal to 10% of your maximum Life "}
 c["Drop Shocked Ground while moving, lasting 8 seconds"]={nil,"Drop Shocked Ground while moving, lasting 8 seconds "}
-c["Each Arrow fired is a Crescendo, Splinter, Reversing, Diamond, Covetous, or Blunt Arrow"]={nil,"Each Arrow fired is a Crescendo, Splinter, Reversing, Diamond, Covetous, or Blunt Arrow "}
+c["Each Arrow fired is a Crescendo, Splinter, Reversing, Diamond, Covetous, or Blunt Arrow"]={{[1]={flags=0,keywordFlags=0,name="Condition:PerandusArrows",type="FLAG",value=true}},nil}
 c["Each Totem applies 2% increased Damage taken to Enemies in their Presence"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={type="Multiplier",var="TotemsSummoned"},flags=0,keywordFlags=0,name="DamageTaken",type="INC",value=2}}}},nil}
 c["Echoed Spells have 25% increased Area of Effect"]={nil,"Echoed Spells have 25% increased Area of Effect "}
 c["Effect is not removed when Unreserved Life is Filled"]={nil,"Effect is not removed when Unreserved Life is Filled "}

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -170,6 +170,31 @@ local configSettings = {
 	{ var = "ailmentMode", type = "list", label = "Ailment calculation mode:", tooltip = "Controls how the base damage for applying Ailments is calculated:\n\tAverage: damage is based on the average application, including both crits and non-crits\n\tCrits Only: damage is based solely on Ailments inflicted with crits", list = {{val="AVERAGE",label="Average"},{val="CRIT",label="Crits Only"}} },
 	{ var = "cooldownMode", type = "list", label = "Cooldown calculation mode:", tooltip = "Controls how the cooldown for skills is calculated:\n\tBase: The cooldown is calculated with normal behavior.\n\tAverage: The cooldown is adjusted to reflect the average time between uses, factoring in effects such as a chance to not consume a cooldown.", list = {{val="BASE",label="Base"},{val="AVERAGE",label="Average"}} },
 	{ var = "physMode", type = "list", label = "Random element mode:", ifFlag = "randomPhys", tooltip = "Controls how modifiers which choose a random element will function.\n\tAverage: Modifiers will grant one third of their value to ^xB97123Fire^7, ^x3F6DB3Cold^7, and ^xADAA47Lightning ^7simultaneously\n\t^xB97123Fire ^7/ ^x3F6DB3Cold ^7/ ^xADAA47Lightning^7: Modifiers will grant their full value as the specified element\nIf a modifier chooses between just two elements, the full value can only be given as those two elements.", list = {{val="AVERAGE",label="Average"},{val="FIRE",label="^xB97123Fire"},{val="COLD",label="^x3F6DB3Cold"},{val="LIGHTNING",label="^xADAA47Lightning"}} },
+	{ var = "perandusArrow", type = "list", label = "Perandus Arrow type:", ifFlag = "Condition:PerandusArrows", tooltip = "Cadiro's Gambit turns every Arrow into a random one of six Perandus Arrows, so each type applies to a sixth of the Arrows you fire.\nTheir behaviours are too different to average into one number (Chaining against guaranteed Critical Hits), so this picks the Arrow to calculate.\nRandom: none of the six is applied.", list = {{val="NONE",label="Random (none applied)"},{val="CRESCENDO",label="Crescendo (Chain)"},{val="SPLINTER",label="Splinter (Split)"},{val="REVERSING",label="Reversing (Pierce)"},{val="DIAMOND",label="Diamond (Critical)"},{val="COVETOUS",label="Covetous (Rarity)"},{val="BLUNT",label="Blunt (Stun)"}}, apply = function(val, modList, enemyModList)
+		-- In-game Arrow descriptions, quoted so the values below can be checked:
+		-- Crescendo: "Crescendo Arrows Chain 6 additional times and deal 60% increased Damage for each time they have Chained."
+		-- Splinter: "Splintering Arrows Split towards 6 targets."
+		-- Reversing: "Reversing Arrows Pierce all targets and Return to you."
+		-- Diamond: "All Hits with Diamond Arrows are Critical Hits with 60% increased Critical Damage Bonus."
+		-- Covetous: "Enemies killed with Covetous Arrows drop items with 600% increased Rarity."
+		-- Blunt: "Blunt Arrows cause 600% increased Stun Buildup."
+		if val == "CRESCENDO" then
+			modList:NewMod("ChainCountMax", "BASE", 6, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+			modList:NewMod("Damage", "INC", 60, "Config", 0, KeywordFlag.Arrow, { type = "PerStat", stat = "Chain" }, { type = "Condition", var = "PerandusArrows" })
+		elseif val == "SPLINTER" then
+			modList:NewMod("SplitCount", "BASE", 6, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+		elseif val == "REVERSING" then
+			-- The Arrow also returns to you, which PoB does not model.
+			modList:NewMod("PierceAllTargets", "FLAG", true, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+		elseif val == "DIAMOND" then
+			modList:NewMod("CritChance", "OVERRIDE", 100, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+			modList:NewMod("CritMultiplier", "INC", 60, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+		elseif val == "COVETOUS" then
+			modList:NewMod("LootRarity", "INC", 600, "Config", { type = "Condition", var = "PerandusArrows" })
+		elseif val == "BLUNT" then
+			modList:NewMod("EnemyHeavyStunBuildup", "INC", 600, "Config", 0, KeywordFlag.Arrow, { type = "Condition", var = "PerandusArrows" })
+		end
+	end },
 	{ var = "lifeRegenMode", type = "list", label = "^xE05030Life ^7regen calculation mode:", ifCond = { "LifeRegenBurstAvg", "LifeRegenBurstFull" }, tooltip = "Controls how ^xE05030Life ^7regeneration is calculated:\n\tMinimum: does not include burst regen\n\tAverage: includes burst regen, averaged based on uptime\n\tBurst: includes full burst regen", list = {{val="MIN",label="Minimum"},{val="AVERAGE",label="Average"},{val="FULL",label="Burst"}}, apply = function(val, modList, enemyModList)
 		if val == "AVERAGE" then
 			modList:NewMod("Condition:LifeRegenBurstAvg", "FLAG", true, "Config")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4866,6 +4866,10 @@ local specialModList = {
 	["always pierce with arrows"] = { flag("PierceAllTargets", nil, 0, KeywordFlag.Arrow) },
 	["arrows always pierce"] = { flag("PierceAllTargets", nil, 0, KeywordFlag.Arrow) },
 	["arrows pierce all targets"] = { flag("PierceAllTargets", nil, 0, KeywordFlag.Arrow) },
+	-- Cadiro's Gambit. Each Arrow is a random one of six Perandus Arrows, whose
+	-- behaviours differ too much to average; the "Perandus Arrow type" config
+	-- picks which one to calculate.
+	["each arrow fired is a crescendo, splinter, reversing, diamond, covetous, or blunt arrow"] = { flag("Condition:PerandusArrows") },
 	["arrows that pierce cause bleeding"] = { mod("BleedChance", "BASE", 100, nil, 0, KeywordFlag.Arrow, { type = "StatThreshold", stat = "PierceCount", threshold = 1 }) },
 	["arrows that pierce have (%d+)%% chance to cause bleeding"] = function(num) return { mod("BleedChance", "BASE", num, nil, 0, KeywordFlag.Arrow, { type = "StatThreshold", stat = "PierceCount", threshold = 1 }) } end,
 	["arrows that pierce deal (%d+)%% increased damage"] = function(num) return { mod("Damage", "INC", num, nil, 0, KeywordFlag.Arrow, { type = "StatThreshold", stat = "PierceCount", threshold = 1 }) } end,


### PR DESCRIPTION
Related to #2415.

### Description of the problem being solved:

Cadiro's Gambit has the line "Each Arrow fired is a Crescendo, Splinter, Reversing, Diamond, Covetous, or Blunt Arrow", which was unsupported, so the quiver calculated as if it only granted increased Attack Speed.

The Diamond Arrow is what makes that matter: all its Hits are Critical Hits, with 60% increased Critical Damage Bonus. On a bow character sitting at 28.88% Critical Hit Chance, that Arrow takes Total DPS from 120,714 to 297,952.

The six Arrows are rolled per Arrow and behave too differently to average into one number, so the item's line only sets a flag and a new config picks which Arrow to calculate. This follows the existing "Random element mode" config for modifiers that choose an element. The default, "Random (none applied)", applies none of them, so no existing build changes.

Each Arrow reuses modifiers that already exist:

| Arrow | Modifiers |
| --- | --- |
| Crescendo | ChainCountMax +6, 60% increased Damage per Chain |
| Splinter | SplitCount 6 |
| Reversing | PierceAllTargets |
| Diamond | CritChance 100 override, 60% increased CritMultiplier |
| Covetous | 600% increased LootRarity |
| Blunt | 600% increased EnemyHeavyStunBuildup |

The Reversing Arrow also returns to you, which PoB does not model.

### Steps taken to verify a working solution:
- Equipped Cadiro's Gambit on a level 96 Ice Shot Deadeye and stepped through every option of the new config.
- Diamond: Total DPS 120,714 -> 297,952, Crit Chance 28.88% -> 100.00%, Crit Multiplier 396% -> 456%. Screenshots below.
- Crescendo: Chain Max 0 -> 6, and with "# of times Skill has Chained" set to 6, Full DPS 392,738 -> 651,538.
- Splinter: Split Count 0 -> 6. Reversing: Pierce Count 0 -> "All targets". Neither changes single target DPS, as expected.
- Regenerated ModCache.lua, which now caches the line as a parsed flag instead of an unsupported mod.

### Link to a build that showcases this PR:

Any bow build with this item works. The quiver used above:

```
Rarity: UNIQUE
Cadiro's Gambit
Primed Quiver
Item Level: 82
LevelReq: 66
Implicits: 0
10% increased Attack Speed
Each Arrow fired is a Crescendo, Splinter, Reversing, Diamond, Covetous, or Blunt Arrow
```

### Before screenshot:
<img width="1720" height="1392" alt="Path_of_Building-PoE2_Mv7eOzs2zW" src="https://github.com/user-attachments/assets/e71410d6-4e1e-4668-b9a5-9ec7b0339cd8" />

### After screenshot:
<img width="1720" height="1392" alt="Path_of_Building-PoE2_pn4cFVBIM8" src="https://github.com/user-attachments/assets/ceea95b5-7fb5-4ce8-984f-a1b1457d8e8e" />
