### PR TITLE
Parse "+#% to Maximum Quality"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3437,6 +3437,9 @@ local specialModList = {
 	["maximum quality is (%d+)%%"] = {
 		-- Display only. For Breach Rings and Serle's Grit.
 	},
+	["%+(%d+)%% to maximum quality"] = {
+		-- Display only. For Breach Rings and the Breachlord's prefix.
+	},
 	["can have (%d+) additional instilled modifiers?"] = function(num) return {
 		-- For Strugglescream. Handled in Item.lua
 	} end,


### PR DESCRIPTION
### Description of the problem being solved:

`Breach Ring` and `Refined Breach Ring` carry `+20% to Maximum Quality` and `+25% to Maximum Quality` as their implicit (`Data/Bases/ring.lua:196,203`), and the `Breachlord's` essence prefix grants the same line (`Data/ModItem.lua:1437`). `ModParser` only handled the `Maximum Quality is #%` wording, so those items showed their implicit as an unsupported modifier.

The new entry sits next to that one and is display only, for the same reason: PoB does not track quality on rings at all, so there is no value to apply yet. This only stops the line from being reported as unsupported.

### Steps taken to verify a working solution:
- Put `+20% to Maximum Quality` on an equipped ring and listed the mod lines the parser left with an `extra` field: the line is reported before this change and gone after it, same build file both times.
- `ModCache.lua` regenerated with `REGENERATE_MOD_CACHE=1 luajit HeadlessWrapper.lua`: no diff, this wording is not cached.
- Full busted suite: 566 successes / 0 failures / 0 errors.