### PR TITLE
Name the weapon set that has points available

### DIFF
--- a/spec/System/TestWeaponSetPoints_spec.lua
+++ b/spec/System/TestWeaponSetPoints_spec.lua
@@ -1,0 +1,38 @@
+describe("WeaponSetPoints", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	-- The warning only reads the per-set counts from CountAllocNodes, so the
+	-- nodes are placed straight into allocNodes: allocating through the tree
+	-- would drag pathing into a test about which set gets named.
+	local function warningFor(set1Used, set2Used)
+		local id = 0
+		for _ = 1, set1Used + set2Used do
+			id = id + 1
+			build.spec.allocNodes["fake" .. id] = {
+				type = "Normal",
+				allocMode = id <= set1Used and 1 or 2,
+			}
+		end
+		build.controls.warnings.lines = { }
+		build:EstimatePlayerProgress()
+		for _, line in ipairs(build.controls.warnings.lines) do
+			if line:match("passives available") then
+				return line
+			end
+		end
+	end
+
+	it("names weapon set 1 when set 1 has fewer points allocated", function()
+		assert.are.equals("You have 2 Weapon set 1 passives available", warningFor(1, 3))
+	end)
+
+	it("names weapon set 2 when set 2 has fewer points allocated", function()
+		assert.are.equals("You have 2 Weapon set 2 passives available", warningFor(3, 1))
+	end)
+
+	it("says nothing when both sets have the same number allocated", function()
+		assert.is_nil(warningFor(2, 2))
+	end)
+end)

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1049,9 +1049,12 @@ function buildMode:EstimatePlayerProgress()
 		end
 
 		if not warningsWeaponSet and weaponSet1Used ~= weaponSet2Used then
+			-- The set with fewer allocated points is the one with points to
+			-- spare, since a node allocated in both sets is only paid for once.
 			InsertIfNew(self.controls.warnings.lines, string.format(
-				"You have %d Weapon set 2 passives available",
-				math.abs(weaponSet2Used - weaponSet1Used)
+				"You have %d Weapon set %d passives available",
+				math.abs(weaponSet2Used - weaponSet1Used),
+				weaponSet1Used < weaponSet2Used and 1 or 2
 			))
 		end
 


### PR DESCRIPTION
Fixes #2119.

### Description of the problem being solved:

`EstimatePlayerProgress` builds the unspent weapon set points warning with the set number written into the format string (`Modules/Build.lua:1051`):

```lua
if not warningsWeaponSet and weaponSet1Used ~= weaponSet2Used then
    InsertIfNew(self.controls.warnings.lines, string.format(
        "You have %d Weapon set 2 passives available",
        math.abs(weaponSet2Used - weaponSet1Used)
    ))
end
```

The count is fine, since it is the difference between the two sets, but the set is always reported as 2. A character with fewer points allocated in set 1 is told the spare points belong to set 2.

The set with fewer allocated points is the one with room, because a node allocated in both sets is only paid for once — the same reasoning behind `normalPassives = PointsUsed - m_min(weaponSet1Used, weaponSet2Used)` a few lines above.

### Steps taken to verify a working solution:
- Added `spec/System/TestWeaponSetPoints_spec.lua` covering set 1 behind, set 2 behind, and both equal (no warning). Against `dev` it reports 2 successes / 1 failure; with the fix, 3 successes / 0 failures.
- Full busted suite: 569 successes / 0 failures / 0 errors.
