### PR TITLE
Improve Build Export qol

### DIFF
--- a/spec/System/TestBuildExportPoE2_spec.lua
+++ b/spec/System/TestBuildExportPoE2_spec.lua
@@ -2,14 +2,39 @@ local BuildExportPoE2 = require("Modules.BuildExportPoE2")
 
 describe("PoE2 BuildPlanner export", function()
 	local originalWriteFile
+	local originalWriteAllLoadouts
+
+	local function addRing(note)
+		local item = new("Item"):Item([[Rarity: RARE
+Export Ring
+Gold Ring
+Implicits: 0
++10 to maximum Life]])
+		build.itemsTab:AddItem(item, true)
+		local slot = build.itemsTab.activeItemSet["Ring 1"]
+		slot.selItemId = item.id
+		slot.note = note
+		return item, slot
+	end
+
+	local function inventoryEntry(exported, slotName)
+		local slotId = data.buildFileInventorySlotMap[slotName].id
+		for _, entry in ipairs(exported.inventory_slots) do
+			if entry.inventory_id == slotId then
+				return entry
+			end
+		end
+	end
 
 	before_each(function()
 		newBuild()
 		originalWriteFile = BuildExportPoE2.WriteFile
+		originalWriteAllLoadouts = BuildExportPoE2.WriteAllLoadouts
 	end)
 
 	after_each(function()
 		BuildExportPoE2.WriteFile = originalWriteFile
+		BuildExportPoE2.WriteAllLoadouts = originalWriteAllLoadouts
 	end)
 
 	it("uses game ids for active and support gems", function()
@@ -69,13 +94,87 @@ describe("PoE2 BuildPlanner export", function()
 		assert.are.equal("", importTab.controls.buildPlannerAuthorName.buf)
 		assert.are.equal("Author name", importTab.controls.buildPlannerAuthorName.prompt)
 		assert.are.equal("Author", importTab.controls.buildPlannerAuthorName.placeholder)
-		assert.are.same({ name = "Unnamed Build", author = "Author", description = "" }, importTab:GetBuildPlannerMetadata())
+		assert.are.same({ name = "Unnamed Build", author = "Author", description = "", useGeneratedItemText = true }, importTab:GetBuildPlannerMetadata())
 
 		importTab.controls.buildPlannerBuildName:SetText("My Build", true)
 		importTab.controls.buildPlannerAuthorName:SetText("My Author")
-		assert.are.same({ name = "My Build", author = "My Author", description = "" }, importTab:GetBuildPlannerMetadata())
+		assert.are.same({ name = "My Build", author = "My Author", description = "", useGeneratedItemText = true }, importTab:GetBuildPlannerMetadata())
 		local treeVersion = build.treeTab.specList[importTab.exportSpecIndex].treeVersion:gsub("_", ".")
 		assert.are.equal(BuildExportPoE2.DefaultDir() .. "My Build [" .. treeVersion .. "].build", importTab.controls.poe2ExportPath.buf)
+	end)
+
+	it("passes export options through the selected export button without serialising them", function()
+		local importTab = build.importTab
+		local selectedMetadata
+		importTab.controls.poe2ExportPath:SetText("build-export-test.build")
+		importTab.controls.buildPlannerUseGeneratedItemText.state = false
+		BuildExportPoE2.WriteFile = function(_, path, metadata)
+			selectedMetadata = metadata
+			return path
+		end
+
+		importTab.controls.poe2ExportSave.onClick()
+
+		assert.is_false(importTab:GetBuildPlannerMetadata().useGeneratedItemText)
+		assert.is_false(selectedMetadata.useGeneratedItemText)
+		local json = BuildExportPoE2.Export(build, selectedMetadata, {
+			specIndex = build.treeTab.activeSpec,
+			skillSetId = build.skillsTab.activeSkillSetId,
+			itemSetId = build.itemsTab.activeItemSetId,
+		})
+		assert.is_nil(json:find("useGeneratedItemText", 1, true))
+		while main.popups[1] do
+			main:ClosePopup()
+		end
+	end)
+
+	it("passes export options through the all-loadout export button", function()
+		local importTab = build.importTab
+		local allLoadoutsMetadata
+		importTab.controls.poe2ExportPath:SetText("build-export-test.build")
+		importTab.controls.buildPlannerUseGeneratedItemText.state = false
+		BuildExportPoE2.WriteAllLoadouts = function(_, _, metadata)
+			allLoadoutsMetadata = metadata
+			return { }, { }
+		end
+
+		importTab.controls.poe2ExportSaveAll.onClick()
+
+		assert.is_false(allLoadoutsMetadata.useGeneratedItemText)
+		while main.popups[1] do
+			main:ClosePopup()
+		end
+	end)
+
+	it("forwards the export option to every loadout", function()
+		local calls = { }
+		BuildExportPoE2.WriteFile = function(_, path, metadata, selection)
+			table.insert(calls, { metadata = metadata, selection = selection })
+			return path
+		end
+		local selection = {
+			specIndex = build.treeTab.activeSpec,
+			skillSetId = build.skillsTab.activeSkillSetId,
+			itemSetId = build.itemsTab.activeItemSetId,
+		}
+		local written, errors = BuildExportPoE2.WriteAllLoadouts(build, "build-export-test.build", {
+			name = "Build",
+			author = "Author",
+			description = "",
+			useGeneratedItemText = false,
+		}, {
+			{ name = "First", fileName = "First", specIndex = selection.specIndex, skillSetId = selection.skillSetId, itemSetId = selection.itemSetId },
+			{ name = "Second", fileName = "Second", specIndex = selection.specIndex, skillSetId = selection.skillSetId, itemSetId = selection.itemSetId },
+		})
+
+		assert.are.equal(2, #written)
+		assert.are.equal(0, #errors)
+		assert.are.equal(2, #calls)
+		for _, call in ipairs(calls) do
+			assert.is_false(call.metadata.useGeneratedItemText)
+			local json = BuildExportPoE2.Export(build, call.metadata, call.selection)
+			assert.is_nil(json:find("useGeneratedItemText", 1, true))
+		end
 	end)
 
 	it("keeps the tree version at the end of loadout filenames", function()
@@ -163,6 +262,57 @@ Implicits: 0
 		local _, count = beltEntry.additional_text:gsub("Legacy of Amethyst", "")
 
 		assert.are.equal(2, count)
+	end)
+
+	it("exports generated item text for an equipped item with a nil note when enabled", function()
+		local item = addRing(nil)
+		local exported = BuildExportPoE2.BuildTable(build, { useGeneratedItemText = true }, {
+			specIndex = build.treeTab.activeSpec,
+			skillSetId = build.skillsTab.activeSkillSetId,
+			itemSetId = build.itemsTab.activeItemSetId,
+		})
+
+		assert.are.equal(BuildExportPoE2.ItemAdditionalText(item), inventoryEntry(exported, "Ring 1").additional_text)
+	end)
+
+	it("does not export an empty item note when generated text is disabled", function()
+		addRing("")
+		local exported = BuildExportPoE2.BuildTable(build, { useGeneratedItemText = false }, {
+			specIndex = build.treeTab.activeSpec,
+			skillSetId = build.skillsTab.activeSkillSetId,
+			itemSetId = build.itemsTab.activeItemSetId,
+		})
+
+		assert.is_nil(inventoryEntry(exported, "Ring 1"))
+	end)
+
+	it("uses a non-empty item note instead of generated text for either option", function()
+		local item, slot = addRing("Only this note")
+		for _, useGeneratedItemText in ipairs({ true, false }) do
+			local exported = BuildExportPoE2.BuildTable(build, { useGeneratedItemText = useGeneratedItemText }, {
+				specIndex = build.treeTab.activeSpec,
+				skillSetId = build.skillsTab.activeSkillSetId,
+				itemSetId = build.itemsTab.activeItemSetId,
+			})
+			local entry = inventoryEntry(exported, "Ring 1")
+
+			assert.are.equal(slot.note, entry.additional_text)
+			assert.is_nil(entry.additional_text:find(item.name, 1, true))
+			assert.is_nil(entry.additional_text:find("maximum Life", 1, true))
+		end
+	end)
+
+	it("exports a note even when its slot has no item", function()
+		local slot = build.itemsTab.activeItemSet["Ring 1"]
+		slot.selItemId = 0
+		slot.note = "Standalone note"
+		local exported = BuildExportPoE2.BuildTable(build, { useGeneratedItemText = false }, {
+			specIndex = build.treeTab.activeSpec,
+			skillSetId = build.skillsTab.activeSkillSetId,
+			itemSetId = build.itemsTab.activeItemSetId,
+		})
+
+		assert.are.equal("Standalone note", inventoryEntry(exported, "Ring 1").additional_text)
 	end)
 
 	it("keeps linked loadout identifiers in filenames", function()

--- a/spec/System/TestBuildExportPoE2_spec.lua
+++ b/spec/System/TestBuildExportPoE2_spec.lua
@@ -71,9 +71,37 @@ describe("PoE2 BuildPlanner export", function()
 		assert.are.equal("Author", importTab.controls.buildPlannerAuthorName.placeholder)
 		assert.are.same({ name = "Unnamed Build", author = "Author", description = "" }, importTab:GetBuildPlannerMetadata())
 
-		importTab.controls.buildPlannerBuildName:SetText("My Build")
+		importTab.controls.buildPlannerBuildName:SetText("My Build", true)
 		importTab.controls.buildPlannerAuthorName:SetText("My Author")
 		assert.are.same({ name = "My Build", author = "My Author", description = "" }, importTab:GetBuildPlannerMetadata())
+		local treeVersion = build.treeTab.specList[importTab.exportSpecIndex].treeVersion:gsub("_", ".")
+		assert.are.equal(BuildExportPoE2.DefaultDir() .. "My Build [" .. treeVersion .. "].build", importTab.controls.poe2ExportPath.buf)
+	end)
+
+	it("keeps the tree version at the end of loadout filenames", function()
+		assert.are.equal("Build [0.5].build", BuildExportPoE2.BuildPath("Build", "0_5", "Existing.build"))
+		assert.are.equal("Build - Leveling [0.5].build", BuildExportPoE2.LoadoutPath("Build [0.4].build", "Leveling", "0_5"))
+		assert.are.equal("Build [SSF] - Leveling [0.5].build", BuildExportPoE2.LoadoutPath("Build [SSF].build", "Leveling", "0_5"))
+	end)
+
+	it("hides the user profile from displayed paths", function()
+		local path = BuildExportPoE2.DefaultDir() .. "Test.build"
+		local sep = path:find("\\", 1, true) and "\\" or "/"
+		local displayedPath = BuildExportPoE2.DisplayPath(path)
+
+		assert.are.equal("..." .. sep .. "Path of Exile 2" .. sep .. "BuildPlanner" .. sep .. "Test.build", displayedPath)
+	end)
+
+	it("hides the full path by default", function()
+		local importTab = build.importTab
+
+		assert.is_false(importTab.controls.poe2ExportShowPath.state)
+		assert.is_false(importTab.controls.poe2ExportPath.shown())
+		assert.is_true(importTab.controls.poe2ExportPathDisplay.shown())
+		importTab.controls.poe2ExportShowPath.state = true
+
+		assert.is_true(importTab.controls.poe2ExportPath.shown())
+		assert.is_false(importTab.controls.poe2ExportPathDisplay.shown())
 	end)
 
 	it("exports only the selected item variant", function()
@@ -145,9 +173,9 @@ Implicits: 0
 		end
 		local exportBuild = {
 			buildName = "Build",
-			treeTab = {},
-			skillsTab = {},
-			itemsTab = {},
+			treeTab = { specList = {} },
+			skillsTab = { skillSets = {} },
+			itemsTab = { itemSets = {} },
 			controls = { buildLoadouts = { list = { "^7^7Loadouts:", "Leveling {a}", "Leveling {b}" } } },
 			SyncLoadouts = function() end,
 			GetLoadoutByName = function()

--- a/spec/System/TestImportTab_spec.lua
+++ b/spec/System/TestImportTab_spec.lua
@@ -96,6 +96,51 @@ describe("ImportTab", function()
 	end)
 end)
 
+describe("ImportTab BuildPlanner export option", function()
+	before_each(function()
+		newBuild()
+	end)
+
+	it("defaults to true and persists false and true XML values", function()
+		local importTab = build.importTab
+		local option = importTab.controls.buildPlannerUseGeneratedItemText
+
+		assert.are.equal("Tree", StripEscapes(importTab.controls.buildPlannerTreeLabel.label))
+		assert.are.equal("Skill", StripEscapes(importTab.controls.buildPlannerSkillLabel.label))
+		assert.are.equal("Item", StripEscapes(importTab.controls.buildPlannerItemLabel.label))
+		assert.are.equal("TOPLEFT", option.anchor.point)
+		assert.are.equal(importTab.controls.buildPlannerSpec, option.anchor.other)
+		assert.is_true(option.labelRight)
+		assert.is_true(option.state)
+		local xml = {}
+		importTab:Save(xml)
+		assert.are.equal("true", xml.attrib.useGeneratedItemText)
+
+		importTab:Load({ attrib = { useGeneratedItemText = "false" } })
+		assert.is_false(option.state)
+		importTab:Load({ attrib = { useGeneratedItemText = "true" } })
+		assert.is_true(option.state)
+		importTab:Load({ attrib = {} })
+		assert.is_true(option.state)
+
+		option.state = false
+		importTab:Save(xml)
+		assert.are.equal("false", xml.attrib.useGeneratedItemText)
+	end)
+
+	it("marks the build modified when toggled", function()
+		local option = build.importTab.controls.buildPlannerUseGeneratedItemText
+		build.modFlag = false
+		option.IsShown = function() return true end
+		option.IsMouseOver = function() return true end
+		option:OnKeyDown("LEFTBUTTON")
+		option:OnKeyUp("LEFTBUTTON")
+
+		assert.is_false(option.state)
+		assert.is_true(build.modFlag)
+	end)
+end)
+
 describe("ImportTab quest reward import", function()
 	before_each(function()
 		newBuild()

--- a/spec/System/TestTooltip_spec.lua
+++ b/spec/System/TestTooltip_spec.lua
@@ -1,3 +1,5 @@
+local BuildExportPoE2 = require("Modules.BuildExportPoE2")
+
 describe("Tooltip", function()
 	local tooltip
 
@@ -103,5 +105,118 @@ describe("Tooltip", function()
 		end)
 		assertLines({ line(note) })
 		assert.are.equal("<rgb(255, 0, 0)>{unfinished", note)
+	end)
+end)
+
+describe("BuildPlanner note popup", function()
+	local function openNote(initial, generatedText)
+		main:OpenNoteEditPopup("Test note", initial, function() end, generatedText)
+		return main.popups[1], main.popups[1].controls
+	end
+
+	local function addRing()
+		local item = new("Item"):Item([[Rarity: RARE
+Export Ring
+Gold Ring
+Implicits: 0
++10 to maximum Life]])
+		build.itemsTab:AddItem(item, true)
+		build.itemsTab:EquipItemInSet(item, build.itemsTab.activeItemSetId)
+		return item, build.itemsTab.slots["Ring 1"]
+	end
+
+	local function click(popup, button)
+		button.IsMouseOver = function() return true end
+		popup.GetMouseOverControl = function() end
+		popup:SelectControl(button)
+		popup:ProcessControlsInput({
+			{ type = "KeyDown", key = "LEFTBUTTON" },
+			{ type = "KeyUp", key = "LEFTBUTTON" },
+		}, { })
+	end
+
+	before_each(function()
+		newBuild()
+	end)
+
+	after_each(function()
+		while main.popups[1] do
+			main:ClosePopup()
+		end
+	end)
+
+	it("does not add an item-text control to ordinary note popups", function()
+		local _, controls = openNote("")
+
+		assert.is_nil(controls.addItemText)
+	end)
+
+	it("adds the item-text control only for a selected item", function()
+		local item, slot = addRing()
+		slot.controls.noteButton.onClick()
+
+		local controls = main.popups[1].controls
+		assert.is_not_nil(controls.addItemText)
+		assert.are.equal("TOPLEFT", controls.addItemText.anchor.point)
+		assert.is_true(controls.addItemText.forceTooltip)
+		assert.are.equal(240, controls.edit.height)
+	end)
+
+	it("inserts exact generated item text at the edit caret", function()
+		local item, slot = addRing()
+		slot.controls.noteButton.onClick()
+		local popup = main.popups[1]
+		local controls = popup.controls
+		local generatedText = BuildExportPoE2.ItemAdditionalText(item)
+		local prefix, suffix = "prefix\n", "\nsuffix"
+
+		controls.edit:SetText(prefix .. suffix)
+		controls.edit.caret = #prefix + 1
+		click(popup, controls.addItemText)
+
+		assert.are.equal(prefix .. generatedText .. suffix, controls.edit.buf)
+		assert.are.equal(controls.edit, popup.selControl)
+		assert.is_true(controls.edit.hasFocus)
+		assert.are.equal(#prefix + #generatedText + 1, controls.edit.caret)
+	end)
+
+	it("saves generated item text when the existing note is over 960 bytes", function()
+		local item, slot = addRing()
+		local prefix = string.rep("x", 961)
+		local generatedText = BuildExportPoE2.ItemAdditionalText(item)
+		slot.note = prefix
+		slot.controls.noteButton.onClick()
+		local popup = main.popups[1]
+		local controls = popup.controls
+
+		controls.edit.caret = #controls.edit.buf + 1
+		click(popup, controls.addItemText)
+
+		assert.are.equal(prefix .. generatedText, controls.edit.buf)
+		assert.are.equal(#controls.edit.buf + 1, controls.edit.caret)
+		controls.save.onClick()
+		assert.are.equal(prefix .. generatedText, slot.note)
+	end)
+
+	it("builds the save tooltip from the current formatted buffer", function()
+		local _, controls = openNote("")
+		local tooltip = new("Tooltip"):Tooltip()
+
+		assert.is_true(controls.save.forceTooltip)
+		controls.edit:SetText("<rgb(1, 2, 3)>{coloured}\n<b>{bold}")
+		controls.save.tooltipFunc(tooltip)
+		assert.are.equal(2, #tooltip.lines)
+		assert.are.equal("^x010203coloured^7", tooltip.lines[1].text)
+		assert.are.equal("bold", tooltip.lines[2].text)
+		assert.are.equal("VAR BOLD", tooltip.lines[2].font)
+
+		controls.edit:SetText("updated")
+		controls.save.tooltipFunc(tooltip)
+		assert.are.equal(1, #tooltip.lines)
+		assert.are.equal("updated", tooltip.lines[1].text)
+
+		controls.edit:SetText("")
+		controls.save.tooltipFunc(tooltip)
+		assert.are.equal("Save an empty note to remove it.", tooltip.lines[1].text)
 	end)
 end)

--- a/spec/System/TestTooltip_spec.lua
+++ b/spec/System/TestTooltip_spec.lua
@@ -1,0 +1,107 @@
+describe("Tooltip", function()
+	local tooltip
+
+	local function line(text, size, font)
+		return { text = text, size = size or 14, font = font or "VAR" }
+	end
+
+	local function assertLines(expected)
+		local actual = { }
+		for _, value in ipairs(tooltip.lines) do
+			table.insert(actual, { text = value.text, size = value.size, font = value.font })
+		end
+		assert.are.same(expected, actual)
+	end
+
+	before_each(function()
+		newBuild()
+		tooltip = new("Tooltip"):Tooltip()
+	end)
+
+	it("converts inline RGB colours and restores the default colour", function()
+		local note = "Before <rgb(12, 34, 56)>{colour} after"
+		tooltip:AddBuildPlannerNote(14, note)
+
+		assertLines({ line("Before ^x0C2238colour^7 after") })
+		assert.are.equal("Before <rgb(12, 34, 56)>{colour} after", note)
+	end)
+
+	it("restores the parent colour after nested RGB colours", function()
+		tooltip:AddBuildPlannerNote(14, "<rgb(255, 0, 0)>{outer <rgb(0, 128, 255)>{inner} outer}")
+
+		assertLines({ line("^xFF0000outer ^x0080FFinner^xFF0000 outer^7") })
+	end)
+
+	it("keeps inline styles inside inline colours on the default line style", function()
+		tooltip:AddBuildPlannerNote(14, "Before <rgb(12, 34, 56)>{colour <i>{italic}} after")
+
+		assertLines({ line("Before ^x0C2238colour italic^7 after") })
+	end)
+
+	it("reapplies RGB colours to each independently drawn line", function()
+		tooltip:AddBuildPlannerNote(14, "<rgb(10, 20, 30)>{first\nsecond}")
+
+		assertLines({
+			line("^x0A141Efirst^7"),
+			line("^x0A141Esecond^7"),
+		})
+	end)
+
+	it("reapplies RGB colours to lines wrapped by AddLine", function()
+		tooltip.maxWidth = 12
+		tooltip:AddBuildPlannerNote(14, "<rgb(10, 20, 30)>{first second}")
+
+		assertLines({
+			line("^x0A141Efirst^7"),
+			line("^x0A141Esecond^7"),
+		})
+	end)
+
+	it("converts the documented red tag", function()
+		tooltip:AddBuildPlannerNote(14, "Warning <red>{danger}")
+
+		assertLines({ line("Warning ^xFF0000danger^7") })
+	end)
+
+	it("applies whole-line font and size tags", function()
+		tooltip:AddBuildPlannerNote(20, table.concat({
+			"<i>{italic}",
+			"<b>{bold}",
+			"<s>{small}",
+			"<m>{medium}",
+			"<l>{large}",
+			"<rgb(1, 2, 3)>{<i>{coloured italic}}",
+		}, "\n"))
+
+		assertLines({
+			line("italic", 20, "FONTIN SC ITALIC"),
+			line("bold", 20, "VAR BOLD"),
+			line("small", 15),
+			line("medium", 20),
+			line("large", 25),
+			line("^x010203coloured italic^7", 20, "FONTIN SC ITALIC"),
+		})
+	end)
+
+	it("strips inline font tags without applying line style", function()
+		tooltip:AddBuildPlannerNote(14, "Inline <i>{italic} and <b>{bold}")
+
+		assertLines({ line("Inline italic and bold") })
+	end)
+
+	it("strips underline tags without applying line style", function()
+		tooltip:AddBuildPlannerNote(14, "Inline <u>{underline}")
+
+		assertLines({ line("Inline underline") })
+	end)
+
+	it("keeps malformed markup safe and plain", function()
+		local note = "<rgb(255, 0, 0)>{unfinished"
+
+		assert.has_no.errors(function()
+			tooltip:AddBuildPlannerNote(14, note)
+		end)
+		assertLines({ line(note) })
+		assert.are.equal("<rgb(255, 0, 0)>{unfinished", note)
+	end)
+end)

--- a/src/Classes/CheckBoxControl.lua
+++ b/src/Classes/CheckBoxControl.lua
@@ -29,8 +29,10 @@ function CheckBoxClass:IsMouseOver()
 	-- move x left by label width, increase width by label width
 	local label = self:GetProperty("label")
 	if label then
-		x = x - self.labelWidth
 		width = width + self.labelWidth
+		if not self.labelRight then
+			x = x - self.labelWidth
+		end
 	end
 	return cursorX >= x and cursorY >= y and cursorX < x + width and cursorY < y + height
 end
@@ -95,7 +97,11 @@ function CheckBoxClass:Draw(viewPort, noTooltip)
 	end
 	local label = self:GetProperty("label")
 	if label then
-		DrawString(x - 5, y + 2, "RIGHT_X", size - 4, "VAR", label)
+		if self.labelRight then
+			DrawString(x + size + 5, y + 2, "LEFT", size - 4, "VAR", label)
+		else
+			DrawString(x - 5, y + 2, "RIGHT_X", size - 4, "VAR", label)
+		end
 	end
 	if mOver and not noTooltip then
 		SetDrawLayer(nil, 100)

--- a/src/Classes/GemTooltip.lua
+++ b/src/Classes/GemTooltip.lua
@@ -380,7 +380,7 @@ function GemTooltip.AddGemTooltip(tooltip, build, gemInstance, options)
 		tooltip:AddSeparator(10)
 		tooltip:AddLine(14, colorCodes.TIP .. "Shift + Right-Click to add a build note (PoE2 .build export)")
 		if gemInstance.note and gemInstance.note ~= "" then
-			tooltip:AddLine(14, "^7Note: " .. gemInstance.note)
+			tooltip:AddBuildPlannerNote(14, gemInstance.note, "^7Note: ")
 		end
 	end
 end

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -353,17 +353,26 @@ function ImportTabClass:ImportTab(build)
 
 	-- Path of Exile 2 BuildPlanner export
 	local BuildExportPoE2 = require("Modules.BuildExportPoE2")
-	self.controls.sectionPoE2Export = new("SectionControl"):SectionControl({ "TOPLEFT", self.controls.sectionBuild, "BOTTOMLEFT", true }, { 0, 18, 650, 282 }, "Export to in-game build planner")
+	local function updateBuildPlannerPath()
+		if not self.controls.poe2ExportPath then return end
+		local buildName = self.controls.buildPlannerBuildName.buf ~= "" and self.controls.buildPlannerBuildName.buf or self.controls.buildPlannerBuildName.placeholder
+		local spec = self.build.treeTab and self.build.treeTab.specList[self.exportSpecIndex]
+		self.controls.poe2ExportPath:SetText(BuildExportPoE2.BuildPath(buildName, spec and spec.treeVersion, self.controls.poe2ExportPath.buf))
+	end
+	self.controls.sectionPoE2Export = new("SectionControl"):SectionControl({ "TOPLEFT", self.controls.sectionBuild, "BOTTOMLEFT", true }, { 0, 18, 650, 310 }, "Export to in-game build planner")
 	self.controls.poe2ExportDesc = new("LabelControl"):LabelControl({"TOPLEFT",self.controls.sectionPoE2Export,"TOPLEFT"}, {6, 14, 0, 16}, "^7Save this build as a .build file the in-game build planner can load.")
 	self.controls.poe2ExportDesc2 = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.poe2ExportDesc, "BOTTOMLEFT" }, { 0, 2, 0, 14 }, "^8Each file holds one passive tree, one skill set and one item set.")
 
-	self.controls.buildPlannerBuildName = new("EditControl"):EditControl({ "TOPLEFT", self.controls.poe2ExportDesc2, "BOTTOMLEFT" }, { 0, 8, 200, 20 }, nil, "Build name", nil, nil)
+	self.controls.buildPlannerBuildName = new("EditControl"):EditControl({ "TOPLEFT", self.controls.poe2ExportDesc2, "BOTTOMLEFT" }, { 0, 8, 200, 20 }, nil, "Build name", nil, nil, function()
+		updateBuildPlannerPath()
+	end)
 	self.controls.buildPlannerBuildName:SetPlaceholder("Unnamed Build")
 	self.controls.buildPlannerAuthorName = new("EditControl"):EditControl({"LEFT",self.controls.buildPlannerBuildName,"RIGHT"}, {8, 0, 200, 20}, nil, "Author name", nil, nil)
 	self.controls.buildPlannerAuthorName:SetPlaceholder("Author")
 	self.controls.buildPlannerSetsLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerBuildName, "BOTTOMLEFT" }, { 0, 8, 0, 16 }, "^7Sets to export:")
 	self.controls.buildPlannerSpec = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.buildPlannerSetsLabel, "BOTTOMLEFT" }, { 0, 2, 180, 20 }, {}, function(index, value)
 		self.exportSpecIndex = value.key
+		updateBuildPlannerPath()
 	end, "^7Which passive tree to export")
 	self.controls.buildPlannerSkillSet = new("DropDownControl"):DropDownControl({ "LEFT", self.controls.buildPlannerSpec, "RIGHT" }, { 8, 0, 180, 20 }, {}, function(index, value)
 		self.exportSkillSetId = value.key
@@ -375,8 +384,27 @@ function ImportTabClass:ImportTab(build)
 
 	self.controls.buildPlannerDescLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerSpec, "BOTTOMLEFT" }, { 0, 8, 0, 16 }, "^7Description:")
 	self.controls.buildPlannerDescription = new("EditControl"):EditControl({"TOPLEFT",self.controls.buildPlannerDescLabel,"BOTTOMLEFT"}, {0, 8, 560, 64}, "", nil, "^%C\t\n", nil, nil, 16)
-	self.controls.poe2ExportPath = new("EditControl"):EditControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 8, 560, 20 }, BuildExportPoE2.DefaultPath(self.build), "Path", nil, 260)
-	self.controls.poe2ExportSave = new("ButtonControl"):ButtonControl({ "TOPLEFT", self.controls.poe2ExportPath, "BOTTOMLEFT" }, { 0, 8, 140, 20 }, "Export Selected Sets", function()
+	self.controls.poe2ExportPath = new("EditControl"):EditControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 8, 560, 20 }, BuildExportPoE2.BuildPath(self.controls.buildPlannerBuildName.placeholder), "Path", nil, 260)
+	updateBuildPlannerPath()
+	self.controls.poe2ExportPath.shown = function() return self.controls.poe2ExportShowPath.state end
+	self.controls.poe2ExportPathDisplay = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 10, 0, 16 }, function()
+		return "^8Save location: " .. BuildExportPoE2.DisplayPath(self.controls.poe2ExportPath.buf)
+	end)
+	self.controls.poe2ExportPathDisplay.shown = function() return not self.controls.poe2ExportShowPath.state end
+	local function displayPath(path)
+		return self.controls.poe2ExportShowPath.state and path or BuildExportPoE2.DisplayPath(path)
+	end
+	self.controls.poe2ExportOpenFolder = new("ButtonControl"):ButtonControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 36, 110, 20 }, "Open Folder", function()
+		local path = self.controls.poe2ExportPath.buf
+		local directory = path:match("^(.*[/\\])") or "."
+		local err = OpenURL(directory)
+		if err then
+			main:OpenMessagePopup("Error", "Couldn't open the folder:\n" .. displayPath(directory) .. "\n\n" .. err)
+		end
+	end)
+	self.controls.poe2ExportOpenFolder.tooltipText = "^7Open the BuildPlanner export folder."
+	self.controls.poe2ExportShowPath = new("CheckBoxControl"):CheckBoxControl({ "LEFT", self.controls.poe2ExportOpenFolder, "RIGHT" }, { 120, 1, 18 }, "Show full path", nil, "^7Reveal the editable absolute save path.", false)
+	self.controls.poe2ExportSave = new("ButtonControl"):ButtonControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 64, 140, 20 }, "Export Selected Sets", function()
 		local path = self.controls.poe2ExportPath.buf
 		local function doWrite()
 			local ok, err = BuildExportPoE2.WriteFile(self.build, path, self:GetBuildPlannerMetadata(), {
@@ -385,16 +413,16 @@ function ImportTabClass:ImportTab(build)
 				itemSetId = self.exportItemSetId,
 			})
 			if not ok then
-				main:OpenMessagePopup("Error", "Couldn't save the build file:\n"..err.."\nMake sure the save folder exists and is writable.")
+				main:OpenMessagePopup("Error", "Couldn't save the build file to:\n" .. displayPath(path) .. "\n\n" .. err .. "\nMake sure the save folder exists and is writable.")
 			else
-				main:OpenMessagePopup("Success", string.format("Build file exported successfully to:\n%s", path))
+				main:OpenMessagePopup("Success", string.format("Build file exported successfully to:\n%s", displayPath(path)))
 			end
 		end
 		-- Confirm overwrite if the file already exists.
 		local existing = io.open(path, "r")
 		if existing then
 			existing:close()
-			main:OpenConfirmPopup("Overwrite?", "A file already exists at:\n" .. path .. "\n\nOverwrite it?", "Overwrite", doWrite)
+			main:OpenConfirmPopup("Overwrite?", "A file already exists at:\n" .. displayPath(path) .. "\n\nOverwrite it?", "Overwrite", doWrite)
 		else
 			doWrite()
 		end
@@ -408,8 +436,11 @@ function ImportTabClass:ImportTab(build)
 		local loadouts = BuildExportPoE2.GetLoadouts(self.build)
 		local function doWrite()
 			local written, errors = BuildExportPoE2.WriteAllLoadouts(self.build, path, self:GetBuildPlannerMetadata(), loadouts)
-			local msg = s_format("Wrote %d file(s) to:\n%s", #written, path:match("^(.*[/\\])") or ".")
-			msg ..= s_format("\n%s", t_concat(written, "\n"))
+			local displayedPaths = {}
+			for _, writtenPath in ipairs(written) do
+				t_insert(displayedPaths, displayPath(writtenPath))
+			end
+			local msg = s_format("Wrote %d file(s):\n%s", #written, t_concat(displayedPaths, "\n"))
 			if #errors > 0 then
 				msg = msg .. s_format("\n\n%d failed:\n%s", #errors, t_concat(errors, "\n"))
 			end
@@ -417,11 +448,12 @@ function ImportTabClass:ImportTab(build)
 		end
 		local existingFiles = {}
 		for _, loadout in ipairs(loadouts) do
-			local loadoutPath = BuildExportPoE2.LoadoutPath(path, loadout.fileName or loadout.name)
+			local spec = BuildExportPoE2.ResolveSelection(self.build, loadout)
+			local loadoutPath = BuildExportPoE2.LoadoutPath(path, loadout.fileName or loadout.name, spec and spec.treeVersion)
 			local existing = io.open(loadoutPath, "r")
 			if existing then
 				existing:close()
-				t_insert(existingFiles, loadoutPath:match("([^/\\]+)$") or loadoutPath)
+				t_insert(existingFiles, loadoutPath:match("([^/\\]+)$"))
 			end
 		end
 		if #existingFiles > 0 then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -359,7 +359,7 @@ function ImportTabClass:ImportTab(build)
 		local spec = self.build.treeTab and self.build.treeTab.specList[self.exportSpecIndex]
 		self.controls.poe2ExportPath:SetText(BuildExportPoE2.BuildPath(buildName, spec and spec.treeVersion, self.controls.poe2ExportPath.buf))
 	end
-	self.controls.sectionPoE2Export = new("SectionControl"):SectionControl({ "TOPLEFT", self.controls.sectionBuild, "BOTTOMLEFT", true }, { 0, 18, 650, 310 }, "Export to in-game build planner")
+	self.controls.sectionPoE2Export = new("SectionControl"):SectionControl({ "TOPLEFT", self.controls.sectionBuild, "BOTTOMLEFT", true }, { 0, 18, 650, 330 }, "Export to in-game build planner")
 	self.controls.poe2ExportDesc = new("LabelControl"):LabelControl({"TOPLEFT",self.controls.sectionPoE2Export,"TOPLEFT"}, {6, 14, 0, 16}, "^7Save this build as a .build file the in-game build planner can load.")
 	self.controls.poe2ExportDesc2 = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.poe2ExportDesc, "BOTTOMLEFT" }, { 0, 2, 0, 14 }, "^8Each file holds one passive tree, one skill set and one item set.")
 
@@ -369,8 +369,10 @@ function ImportTabClass:ImportTab(build)
 	self.controls.buildPlannerBuildName:SetPlaceholder("Unnamed Build")
 	self.controls.buildPlannerAuthorName = new("EditControl"):EditControl({"LEFT",self.controls.buildPlannerBuildName,"RIGHT"}, {8, 0, 200, 20}, nil, "Author name", nil, nil)
 	self.controls.buildPlannerAuthorName:SetPlaceholder("Author")
-	self.controls.buildPlannerSetsLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerBuildName, "BOTTOMLEFT" }, { 0, 8, 0, 16 }, "^7Sets to export:")
-	self.controls.buildPlannerSpec = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.buildPlannerSetsLabel, "BOTTOMLEFT" }, { 0, 2, 180, 20 }, {}, function(index, value)
+	self.controls.buildPlannerTreeLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerBuildName, "BOTTOMLEFT" }, { 0, 8, 0, 16 }, "^7Tree")
+	self.controls.buildPlannerSkillLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerBuildName, "BOTTOMLEFT" }, { 188, 8, 0, 16 }, "^7Skill")
+	self.controls.buildPlannerItemLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerBuildName, "BOTTOMLEFT" }, { 376, 8, 0, 16 }, "^7Item")
+	self.controls.buildPlannerSpec = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.buildPlannerTreeLabel, "BOTTOMLEFT" }, { 0, 2, 180, 20 }, {}, function(index, value)
 		self.exportSpecIndex = value.key
 		updateBuildPlannerPath()
 	end, "^7Which passive tree to export")
@@ -380,9 +382,13 @@ function ImportTabClass:ImportTab(build)
 	self.controls.buildPlannerItemSet = new("DropDownControl"):DropDownControl({ "LEFT", self.controls.buildPlannerSkillSet, "RIGHT" }, { 8, 0, 180, 20 }, {}, function(index, value)
 		self.exportItemSetId = value.key
 	end, "^7Which item set to export")
+	self.controls.buildPlannerUseGeneratedItemText = new("CheckBoxControl"):CheckBoxControl({ "TOPLEFT", self.controls.buildPlannerSpec, "BOTTOMLEFT" }, { 0, 2, 18 }, "Generated text for empty item notes", function()
+		self.build.modFlag = true
+	end, "^7For items without a note, generate a note that contains the current mods, item name and item base", true)
+	self.controls.buildPlannerUseGeneratedItemText.labelRight = true
 	self:RefreshBuildPlannerSets()
 
-	self.controls.buildPlannerDescLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerSpec, "BOTTOMLEFT" }, { 0, 8, 0, 16 }, "^7Description:")
+	self.controls.buildPlannerDescLabel = new("LabelControl"):LabelControl({ "TOPLEFT", self.controls.buildPlannerSpec, "BOTTOMLEFT" }, { 0, 28, 0, 16 }, "^7Description:")
 	self.controls.buildPlannerDescription = new("EditControl"):EditControl({"TOPLEFT",self.controls.buildPlannerDescLabel,"BOTTOMLEFT"}, {0, 8, 560, 64}, "", nil, "^%C\t\n", nil, nil, 16)
 	self.controls.poe2ExportPath = new("EditControl"):EditControl({ "TOPLEFT", self.controls.buildPlannerDescription, "BOTTOMLEFT" }, { 0, 8, 560, 20 }, BuildExportPoE2.BuildPath(self.controls.buildPlannerBuildName.placeholder), "Path", nil, 260)
 	updateBuildPlannerPath()
@@ -480,6 +486,7 @@ function ImportTabClass:GetBuildPlannerMetadata()
 		name = self.controls.buildPlannerBuildName.buf ~= "" and self.controls.buildPlannerBuildName.buf or self.controls.buildPlannerBuildName.placeholder,
 		author = self.controls.buildPlannerAuthorName.buf ~= "" and self.controls.buildPlannerAuthorName.buf or self.controls.buildPlannerAuthorName.placeholder,
 		description = self.controls.buildPlannerDescription.buf,
+		useGeneratedItemText = self.controls.buildPlannerUseGeneratedItemText.state,
 	}
 end
 
@@ -555,6 +562,7 @@ function ImportTabClass:Load(xml, fileName)
 	self.importLink = xml.attrib.importLink
 	self.controls.enablePartyExportBuffs.state = xml.attrib.exportParty == "true"
 	self.build.partyTab.enableExportBuffs = self.controls.enablePartyExportBuffs.state
+	self.controls.buildPlannerUseGeneratedItemText.state = xml.attrib.useGeneratedItemText ~= "false"
 	if self.lastAccountHash then
 		for accountName in pairs(main.gameAccounts) do
 			if common.sha1(accountName) == self.lastAccountHash then
@@ -572,6 +580,7 @@ function ImportTabClass:Save(xml)
 		lastAccountHash = self.lastAccountHash,
 		lastCharacterHash = self.lastCharacterHash,
 		exportParty = tostring(self.controls.enablePartyExportBuffs.state),
+		useGeneratedItemText = tostring(self.controls.buildPlannerUseGeneratedItemText.state),
 		importLink = self.importLink
 	}
 

--- a/src/Classes/ItemSlotControl.lua
+++ b/src/Classes/ItemSlotControl.lua
@@ -41,7 +41,10 @@ function ItemSlotClass:ItemSlotControl(anchor, x, y, itemsTab, slotName, slotLab
 				itemsTab.build.buildFlag = true
 			end)
 		end)
-		self.controls.noteButton.tooltipText = function() return self.note or "Add a note for this item slot" end
+		self.controls.noteButton.tooltipFunc = function(tooltip)
+			tooltip:Clear()
+			tooltip:AddBuildPlannerNote(14, self.note and self.note ~= "" and self.note or "Add a note for this item slot")
+		end
 	end
 	if slotName:match("Flask") then
 		self.controls.activate = new("CheckBoxControl"):CheckBoxControl({ "RIGHT", self, "LEFT" }, { -2, 0, 20 }, nil, function(state)

--- a/src/Classes/ItemSlotControl.lua
+++ b/src/Classes/ItemSlotControl.lua
@@ -8,6 +8,7 @@ local t_insert = table.insert
 local m_min = math.min
 
 local itemSlotHelper = LoadModule("Modules/ItemSlotHelper")
+local BuildExportPoE2 = LoadModule("Modules/BuildExportPoE2")
 ---@class ItemSlotControl: DropDownControl
 local ItemSlotClass = newClass("ItemSlotControl", "DropDownControl")
 
@@ -34,12 +35,13 @@ function ItemSlotClass:ItemSlotControl(anchor, x, y, itemsTab, slotName, slotLab
 	self.slotNum = tonumber(slotName:match("%d+$") or slotName:match("%d+"))
 	if data.buildFileInventorySlotMap[slotName] then
 		self.controls.noteButton = new("ButtonControl"):ButtonControl({"LEFT",self,"RIGHT"}, {2, 0, 20, 20}, "~", function()
+			local item = itemsTab.items[self.selItemId]
 			main:OpenNoteEditPopup(self.slotName, self.note or "", function(note)
 				self.note = note
 				itemsTab:PopulateSlots()
 				itemsTab:AddUndoState()
 				itemsTab.build.buildFlag = true
-			end)
+			end, item and BuildExportPoE2.ItemAdditionalText(item))
 		end)
 		self.controls.noteButton.tooltipFunc = function(tooltip)
 			tooltip:Clear()

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -2010,7 +2010,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build, incSmallPassi
 		tooltip:AddSeparator(10)
 		tooltip:AddLine(14, colorCodes.TIP.."Shift + Right-Click to add a build note (PoE2 .build export)")
 		if existing and existing ~= "" then
-			tooltip:AddLine(14, "^7Note: "..existing)
+			tooltip:AddBuildPlannerNote(14, existing, "^7Note: ")
 		end
 	end
 end

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -5,8 +5,11 @@
 --
 local ipairs = ipairs
 local t_insert = table.insert
+local t_concat = table.concat
 local m_max = math.max
 local m_floor = math.floor
+local s_find = string.find
+local s_format = string.format
 local s_gmatch = string.gmatch
 
 -- Constants
@@ -128,13 +131,104 @@ function TooltipClass:AddLine(size, text, font, background)
 				self.blocks[#self.blocks].height = self.blocks[#self.blocks].height + size + 2
 			end
 			if self.maxWidth then
+				local activeColour
 				for _, wrappedLine in ipairs(main:WrapString(line, size, self.maxWidth - H_PAD)) do
+					if activeColour then wrappedLine = activeColour .. wrappedLine end
+					for pos, code in s_gmatch(wrappedLine, "()%^(.)") do
+						if code == "x" and wrappedLine:sub(pos + 2, pos + 7):match("^%x%x%x%x%x%x$") then
+							activeColour = wrappedLine:sub(pos, pos + 7)
+						elseif code == "7" then
+							activeColour = nil
+						end
+					end
+					if activeColour then wrappedLine = wrappedLine .. "^7" end
 					t_insert(self.lines, { size = size, text = wrappedLine, block = #self.blocks, font = fontToUse, center = self.center, background = background })
 				end
 			else
 				t_insert(self.lines, { size = size, text = line, block = #self.blocks, font = fontToUse, center = self.center, background = background })
 			end
 		end
+	end
+end
+
+function TooltipClass:AddBuildPlannerNote(size, text, prefix)
+	-- BuildPlanner colours can be nested, so restore the parent colour after each child.
+	local lineStyles = { }
+	local function parse(start, finish, colour, startsLine, endsLine)
+		local out, pos = { }, start
+		local function append(value)
+			t_insert(out, colour and value:gsub("\n", "^7\n" .. colour) or value)
+		end
+		while pos <= finish do
+			local tagStart = s_find(text, "<", pos, true)
+			if not tagStart or tagStart > finish then
+				append(text:sub(pos, finish))
+				break
+			end
+			append(text:sub(pos, tagStart - 1))
+			local tagEnd = s_find(text, ">", tagStart + 1, true)
+			local tag = tagEnd and tagEnd <= finish and text:sub(tagStart + 1, tagEnd - 1):lower()
+			local newColour
+			if tag == "red" then
+				newColour = "^xFF0000"
+			elseif tag then
+				local r, g, b = tag:match("^rgb%(%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)$")
+				if r and tonumber(r) <= 255 and tonumber(g) <= 255 and tonumber(b) <= 255 then
+					newColour = s_format("^x%02X%02X%02X", tonumber(r), tonumber(g), tonumber(b))
+				end
+			end
+			local isMarkup = newColour or tag == "r" or tag == "b" or tag == "i" or tag == "u" or tag == "s" or tag == "m" or tag == "l"
+			local openBrace = tagEnd and tagEnd + 1
+			local validMarkup = isMarkup and text:sub(openBrace, openBrace) == "{"
+			local closeBrace, depth = openBrace, 0
+			if validMarkup then
+				depth, closeBrace = 1, openBrace + 1
+				while closeBrace <= finish and depth > 0 do
+					local char = text:sub(closeBrace, closeBrace)
+					if char == "{" then depth += 1 elseif char == "}" then depth -= 1 end
+					closeBrace += 1
+				end
+			end
+			if validMarkup and depth == 0 then
+				local coversLineStart = tagStart == start and startsLine or text:sub(tagStart - 1, tagStart - 1) == "\n"
+				local coversLineEnd = closeBrace - 1 == finish and endsLine or text:sub(closeBrace, closeBrace) == "\n"
+				if not newColour and coversLineStart and coversLineEnd then
+					local font, lineSize
+					if tag == "b" then font = "VAR BOLD" elseif tag == "i" then font = "FONTIN SC ITALIC" elseif tag == "r" then font = false end
+					if tag == "s" then lineSize = m_floor(size * 0.75 + 0.5) elseif tag == "m" then lineSize = size elseif tag == "l" then lineSize = m_floor(size * 1.25 + 0.5) end
+					if font ~= nil or lineSize then
+						local line = 1
+						for _ in text:sub(1, tagStart - 1):gmatch("\n") do line += 1 end
+						local lastLine = line
+						for _ in text:sub(tagStart, closeBrace - 1):gmatch("\n") do lastLine += 1 end
+						for index = line, lastLine do
+							lineStyles[index] = lineStyles[index] or { }
+							if font ~= nil then lineStyles[index].font = font end
+							if lineSize then lineStyles[index].size = lineSize end
+						end
+					end
+				end
+				if newColour then t_insert(out, newColour) end
+				t_insert(out, parse(openBrace + 1, closeBrace - 2, newColour or colour, coversLineStart, coversLineEnd))
+				if newColour then t_insert(out, colour or "^7") end
+				pos = closeBrace
+			elseif tagEnd and tagEnd <= finish then
+				append(text:sub(tagStart, tagEnd))
+				pos = tagEnd + 1
+			else
+				append(text:sub(tagStart, finish))
+				break
+			end
+		end
+		return t_concat(out)
+	end
+
+	local renderedText = parse(1, #text, nil, true, true)
+	local line = 1
+	for renderedLine in (renderedText .. "\n"):gmatch("([^\n]*)\n") do
+		local style = lineStyles[line]
+		self:AddLine(style and style.size or size, (line == 1 and (prefix or "") or "") .. renderedLine, style and style.font)
+		line += 1
 	end
 end
 

--- a/src/Modules/BuildExportPoE2.lua
+++ b/src/Modules/BuildExportPoE2.lua
@@ -200,7 +200,7 @@ end
 
 -- Builds a styled hint for non-unique gear. Implicit/rune/enchant mods are
 -- italicised to set them apart from explicit mods, matching PoE convention.
-local function itemAdditionalText(item)
+function M.ItemAdditionalText(item)
 	local parts = { itemHeader(item) }
 	local function appendPlain(modLines)
 		if not modLines then return end
@@ -227,7 +227,7 @@ local function itemAdditionalText(item)
 	return text
 end
 
-local function buildItems(itemsTab, itemSet)
+local function buildItems(itemsTab, itemSet, useGeneratedItemText)
 	local out = {}
 	if not itemsTab or not itemSet then return out end
 	for pobSlotName, mapping in pairs(data.buildFileInventorySlotMap) do
@@ -235,7 +235,7 @@ local function buildItems(itemsTab, itemSet)
 		local item = slotEntry and slotEntry.selItemId and slotEntry.selItemId ~= 0
 			and itemsTab.items[slotEntry.selItemId]
 		local note = slotEntry and slotEntry.note ~= "" and slotEntry.note
-		if item or note then
+		if note or item and useGeneratedItemText then
 			local entry = {
 				inventory_id = mapping.id,
 				slot_x = mapping.slot_x,
@@ -243,14 +243,7 @@ local function buildItems(itemsTab, itemSet)
 			-- the unique_name field shows a larger header when you don't have the matching unique
 			-- equipped in the slot, but since we show the full item name in the additional
 			-- text, it doesn't really do anything useful here
-			if item then
-				entry.additional_text = itemAdditionalText(item)
-				if note then
-					entry.additional_text = entry.additional_text .. "\n\n" .. note
-				end
-			else
-				entry.additional_text = note
-			end
+			entry.additional_text = note or M.ItemAdditionalText(item)
 
 			t_insert(out, entry)
 		end
@@ -304,7 +297,7 @@ function M.BuildTable(build, metadata, selection)
 
 	root.passives = buildPassives(spec)
 	root.skills = buildSkills(skillSet)
-	root.inventory_slots = buildItems(build.itemsTab, itemSet)
+	root.inventory_slots = buildItems(build.itemsTab, itemSet, metadata.useGeneratedItemText ~= false)
 	return root
 end
 
@@ -360,6 +353,7 @@ function M.WriteAllLoadouts(build, basePath, metadata, loadouts)
 			name = s_format("%s - %s", metadata and metadata.name or build.buildName, loadout.name),
 			author = metadata and metadata.author,
 			description = metadata and metadata.description,
+			useGeneratedItemText = metadata and metadata.useGeneratedItemText,
 		}
 		local ok, err = M.WriteFile(build, path, loadoutMeta, loadout)
 		if ok then

--- a/src/Modules/BuildExportPoE2.lua
+++ b/src/Modules/BuildExportPoE2.lua
@@ -24,6 +24,10 @@ local function safeFilename(name)
 	return name
 end
 
+local function treeVersionSuffix(treeVersion)
+	return treeVersion and " [" .. tostring(treeVersion):gsub("_", ".") .. "]" or ""
+end
+
 function M.DefaultDir()
 	local home = os.getenv("USERPROFILE") or (GetScriptPath() .. "/../") or ""
 	local sep = home:find("\\") and "\\" or "/"
@@ -31,18 +35,28 @@ function M.DefaultDir()
 	     .. "Path of Exile 2" .. sep .. "BuildPlanner" .. sep
 end
 
-function M.DefaultPath(build)
-	return M.DefaultDir() .. safeFilename(build.buildName) .. ".build"
+function M.BuildPath(buildName, treeVersion, path)
+	local dir = path and (path:match("^(.*[/\\])") or "") or M.DefaultDir()
+	return dir .. safeFilename(buildName) .. treeVersionSuffix(treeVersion) .. ".build"
+end
+
+function M.DisplayPath(path)
+	local defaultDir = M.DefaultDir()
+	local sep = defaultDir:find("\\") and "\\" or "/"
+	if path:sub(1, #defaultDir):lower() == defaultDir:lower() then
+		local fileName = path:sub(#defaultDir + 1)
+		return "..." .. sep .. "Path of Exile 2" .. sep .. "BuildPlanner" .. (fileName ~= "" and sep .. fileName or "")
+	end
+	return "..." .. sep .. (path:gsub("[/\\]+$", ""):match("([^/\\]+)$") or "")
 end
 
 --- Insert a loadout name before the extension: "My Build.build" -> "My Build - Leveling.build"
-function M.LoadoutPath(basePath, loadoutName)
+function M.LoadoutPath(basePath, loadoutName, treeVersion)
 	local suffix = " - " .. safeFilename(loadoutName)
 	local stem, ext = basePath:match("^(.*)(%.[^%./\\]*)$")
-	if stem then
-		return stem .. suffix .. ext
-	end
-	return basePath .. suffix
+	stem, ext = stem or basePath, ext or ""
+	local versionSuffix = treeVersion and treeVersionSuffix(treeVersion) or stem:match("( %[%d+%.%d+%])$") or ""
+	return stem:gsub(" %[%d+%.%d+%]$", "") .. suffix .. versionSuffix .. ext
 end
 
 local function buildAscendancy(spec)
@@ -312,8 +326,8 @@ function M.WriteFile(build, path, metadata, selection)
 	-- Best-effort: ensure the target directory exists.
 	local dir = path:match("^(.*[/\\])")
 	if dir then MakeDir(dir) end
-	local file, fileError = io.open(path, "w")
-	if not file then return nil, "Couldn't open '" .. path .. "': " .. tostring(fileError) end
+	local file = io.open(path, "w")
+	if not file then return nil, "Couldn't open the file for writing." end
 	file:write(json)
 	file:close()
 	return path
@@ -330,10 +344,11 @@ function M.WriteAllLoadouts(build, basePath, metadata, loadouts)
 	local pending = {}
 	local pathNames = {}
 	for _, loadout in ipairs(loadouts) do
-		local path = M.LoadoutPath(basePath, loadout.fileName or loadout.name)
+		local spec = M.ResolveSelection(build, loadout)
+		local path = M.LoadoutPath(basePath, loadout.fileName or loadout.name, spec and spec.treeVersion)
 		local pathKey = path:lower()
 		if pathNames[pathKey] then
-			return written, { s_format("Loadouts '%s' and '%s' export to the same file: %s", pathNames[pathKey], loadout.name, path) }
+			return written, { s_format("Loadouts '%s' and '%s' export to the same file: %s", pathNames[pathKey], loadout.name, path:match("([^/\\]+)$")) }
 		end
 		pathNames[pathKey] = loadout.name
 		t_insert(pending, { path = path, loadout = loadout })
@@ -350,7 +365,7 @@ function M.WriteAllLoadouts(build, basePath, metadata, loadouts)
 		if ok then
 			t_insert(written, ok)
 		else
-			t_insert(errors, err)
+			t_insert(errors, path:match("([^/\\]+)$") .. ": " .. err)
 		end
 	end
 	return written, errors

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1738,7 +1738,7 @@ local noteColorCodes = {
 	"INTELLIGENCE", "POSITIVE", "NEGATIVE", "WARNING", "TIP", "CURRENCY",
 }
 local markupButtonsPerRow = 6
-function main:OpenNoteEditPopup(title, initial, onSave)
+function main:OpenNoteEditPopup(title, initial, onSave, generatedText)
 	local controls = { }
 	local function insertMarkup(openTag)
 		local edit = controls.edit
@@ -1776,19 +1776,38 @@ function main:OpenNoteEditPopup(title, initial, onSave)
 		controls["color" .. code].forceTooltip = true
 	end
 
-	controls.edit = new("EditControl"):EditControl(nil, { 0, 198, 598, 120 }, initial or "", nil, "^%C\t\n", 960, function(buf)
+	local editY = generatedText and 222 or 198
+	if generatedText then
+		controls.addItemText = new("ButtonControl"):ButtonControl({ "TOPLEFT", nil, "TOPLEFT" }, { 14, 198, 120, 18 }, "Add Item Text", function()
+			controls.edit:Insert(generatedText)
+			return controls.edit
+		end)
+		controls.addItemText.tooltipText = "Insert the generated item text at the caret"
+		controls.addItemText.forceTooltip = true
+	end
+	controls.edit = new("EditControl"):EditControl(nil, { 0, editY, 598, 240 }, initial or "", nil, "^%C\t\n", nil, function(buf)
 		controls.save.enabled = true
 	end, 16)
-	controls.save = new("ButtonControl"):ButtonControl(nil, { -45, 328, 80, 20 }, "Save", function()
+	local buttonY = editY + 250
+	controls.save = new("ButtonControl"):ButtonControl(nil, { -45, buttonY, 80, 20 }, "Save", function()
 		local buf = controls.edit.buf
 		if buf == "" then buf = nil end
 		onSave(buf)
 		main:ClosePopup()
 	end)
-	controls.cancel = new("ButtonControl"):ButtonControl(nil, { 45, 328, 80, 20 }, "Cancel", function()
+	controls.save.tooltipFunc = function(tooltip)
+		tooltip:Clear()
+		if controls.edit.buf ~= "" then
+			tooltip:AddBuildPlannerNote(14, controls.edit.buf)
+		else
+			tooltip:AddLine(14, "Save an empty note to remove it.")
+		end
+	end
+	controls.save.forceTooltip = true
+	controls.cancel = new("ButtonControl"):ButtonControl(nil, { 45, buttonY, 80, 20 }, "Cancel", function()
 		main:ClosePopup()
 	end)
-	self:OpenPopup(624, 368, title or "Edit Note", controls, "save", "edit", "cancel")
+	self:OpenPopup(624, buttonY + 40, title or "Edit Note", controls, "save", "edit", "cancel")
 end
 
 function main:OpenNewFolderPopup(path, onClose)


### PR DESCRIPTION
### Description of the problem being solved:
Uses the entered build name for the exported filename.
Appends the passive tree version to filenames, for example `Build Name [0.5].build`.
Places loadout names before the tree version, for example `Build Name - Leveling [0.5].build`.
Hides the full save path by default to avoid exposing personal information during streams.
Adds a Show full path checkbox.
Adds an Open Folder button below the save location.
Shows a formatted tooltip with the colours and bold / italic / size if they are on a new line
Adds a config option when exporting the build to add the item rolls to a note if that item note is empty
Adds a button that adds the item note into the edit box
Hovering over the save button now shows the formatted text
Doubled the height of the note text box


### Before screenshot:
<img width="655" height="301" alt="image" src="https://github.com/user-attachments/assets/bf5eef46-156b-47e4-8df2-c4c1fc052c2f" />
<img width="653" height="399" alt="image" src="https://github.com/user-attachments/assets/3283c5f2-64fc-4bea-ada7-f70241e223cf" />


### After screenshot:
<img width="662" height="352" alt="image" src="https://github.com/user-attachments/assets/fd05bf62-f5de-41d9-a5fd-3ef63b216cfe" />
<img width="842" height="667" alt="image" src="https://github.com/user-attachments/assets/163ea4c3-6a5d-4bcc-bea2-00799035d90d" />

