### PR TITLE
Fix trader row hiding logic

### DIFF
--- a/spec/System/TestTradeQuery_spec.lua
+++ b/spec/System/TestTradeQuery_spec.lua
@@ -7,6 +7,60 @@ describe("TradeQuery", function ()
 		mock_queryGen = new("TradeQueryGenerator"):TradeQueryGenerator({ itemsTab = {} })
 	end)
 
+	describe("result dropdown tooltipFunc", function()
+		-- Builds a TradeQuery with the strict minimum needed for
+		-- PriceItemRowDisplay to construct row 1 without exploding. Only the
+		-- two itemsTab subtables read by the slot lookup at the top of
+		-- PriceItemRowDisplay need to be created here; everything else either
+		-- lives behind a callback we never trigger, or is already initialized
+		-- by the TradeQuery constructor.
+		local function newTradeQuery(state)
+			local tq                  = new("TradeQuery"):TradeQuery({ itemsTab = {} })
+			tq.itemsTab.activeItemSet = {}
+			tq.itemsTab.slots         = {}
+			tq.slotTables[1]          = { slotName = "Ring 1" }
+			if state.resultTbl then tq.resultTbl = state.resultTbl end
+			if state.sortedResultTbl then tq.sortedResultTbl = state.sortedResultTbl end
+			return tq
+		end
+		-- Builds row 1 of the trader UI and returns the dropdown that owns the
+		-- tooltipFunc we want to exercise.
+		local function buildRow1Dropdown(tq)
+			tq:PriceItemRowDisplay(1, nil, 0, 20)
+			return tq.controls.resultDropdown1
+		end
+
+		it("returns early when sortedResultTbl[row_idx] is missing", function()
+			-- No sorted results at all -> first guard must short-circuit.
+			local tq = newTradeQuery({})
+			local dropdown = buildRow1Dropdown(tq)
+			local tooltip = new("Tooltip"):Tooltip()
+
+			assert.has_no.errors(function()
+				dropdown.tooltipFunc(tooltip, "DROP", 1, nil)
+			end)
+			assert.are.equal(0, #tooltip.lines)
+		end)
+
+		it("returns early when the backing result entry has been cleared", function()
+			-- The dropdown must be built against a valid result so that
+			-- PriceItemRowDisplay's construction loop succeeds; we wipe
+			-- resultTbl[1] only afterwards, to simulate a stale tooltip
+			-- callback firing after the results were invalidated.
+			local tq = newTradeQuery({
+				resultTbl = { [1] = { [1] = { item_string = "Rarity: RARE\nBehemoth Hold\nGold Ring", amount = 1, currency = "chaos" } } },
+				sortedResultTbl = { [1] = { { index = 1 } } },
+			})
+			local dropdown = buildRow1Dropdown(tq)
+			tq.resultTbl[1] = {}
+			local tooltip = new("Tooltip"):Tooltip()
+
+			assert.has_no.errors(function()
+				dropdown.tooltipFunc(tooltip, "DROP", 1, nil)
+			end)
+			assert.are.equal(0, #tooltip.lines)
+		end)
+	end)
 	describe("ReduceOutput", function()
 		it("uses selected minion stats for weighted result comparison", function()
 			mock_tradeQuery.statSortSelectionList = { { stat = "AverageDamage" } }

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -578,10 +578,12 @@ Highest Weight - Displays the order retrieved from trade]]
 	-- dynamically hide rows that are above or below the scrollBar
 	local hideRowFunc = function(self, index)
 		if scrollBarShown then
-			-- 22 items fit in the scrollBar "box" so as the offset moves, we need to dynamically show what is within the boundaries
-			if (index < 23 and (self.controls.scrollBar.offset < ((row_height + row_vertical_padding)*(index-1) + row_vertical_padding))) or
+			local rowWithPadding = row_height + row_vertical_padding
+			-- this many items fit in the scrollBar "box" so as the offset moves, we need to dynamically show what is within the boundaries
+			local maxItemsInView = math.floor(self.controls.scrollBar.height / rowWithPadding) - 2
+			if (index <= maxItemsInView and (self.controls.scrollBar.offset < (rowWithPadding * (index - 1) + row_vertical_padding))) or
 				-- the second and in this applies if we have more than 44 slots because we need to hide the next "page" of rows as they go above the line, e.g. #23 could be above or below the "box"
-				(index >= 23 and (self.controls.scrollBar.offset > (row_height + row_vertical_padding)*(index-22) and self.controls.scrollBar.offset < (row_height + row_vertical_padding)*(index-1))) then
+				(index >= maxItemsInView + 1 and (self.controls.scrollBar.offset > rowWithPadding * (index - maxItemsInView) and self.controls.scrollBar.offset < rowWithPadding * (index - 1))) then
 				return true
 			end
 		else

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -839,7 +839,6 @@ function TradeQueryClass:GetResultEvaluation(row_idx, result_index, calcFunc, ba
 
 	local slotTbl = self.slotTables[row_idx]
 	local jewelNodeId = slotTbl.nodeId or slotTbl.selectedJewelNodeId
-	local slotName = jewelNodeId and "Jewel " .. tostring(jewelNodeId) or slotTbl.slotName
 	if slotTbl.slotName == "Megalomaniac" then
 		local addedNodes = {}
 		for nodeName in (result.item_string.."\r\n"):gmatch("Allocates (.-)\r?\n") do
@@ -853,6 +852,7 @@ function TradeQueryClass:GetResultEvaluation(row_idx, result_index, calcFunc, ba
 		local weight = self.tradeQueryGenerator.WeightedRatioOutputs(baseOutput, output, self.statSortSelectionList)
 		result.evaluation = {{ output = output, weight = weight }}
 	else
+		local slotName = jewelNodeId and "Jewel " .. tostring(jewelNodeId) or slotTbl.slotName
 		local item = new("Item"):Item(result.item_string)
 
 		local output = self:ReduceOutput(calcFunc({ repSlotName = slotName, repItem = item }))


### PR DESCRIPTION
### Description of the problem being solved:

Fixes megalomaniac trade not working at all. I don't think anyone is using this because it's been broken for a while. A test was added for this

Also fixes row hiding logic which was not dynamic based on the popup height and was acting kind of funny

### Steps taken to verify a working solution:
- Changes manually confirmed to work

### Link to a build that showcases this PR:

https://poe.ninja/poe2/builds/runesofaldur/character/BansheesVeil-4479/sotsunakuwRoA?i=1&search=items%3DThe%2BAdorned Adorned Enthusiast

### Before screenshot:

### After screenshot:
