### PR TITLE
Fix more side bar breakdowns

### DIFF
--- a/spec/System/TestBuildDisplayStats_spec.lua
+++ b/spec/System/TestBuildDisplayStats_spec.lua
@@ -32,6 +32,38 @@ describe("Build display stats", function()
 		end
 	end)
 
+	it("links resource sidebar stats to their breakdowns", function()
+		local expectedBreakdowns = {
+			LifeUnreserved = "LifeReserved",
+			LifeUnreservedPercent = "LifeReserved",
+			ManaUnreserved = "ManaReserved",
+			ManaUnreservedPercent = "ManaReserved",
+			SpiritUnreserved = "SpiritReserved",
+			SpiritUnreservedPercent = "SpiritReserved",
+			LifeLeechGainRate = "LifeLeech",
+			ManaLeechGainRate = "ManaLeech",
+			EnergyShieldLeechGainRate = "EnergyShieldLeech",
+		}
+		for _, statData in ipairs(build.displayStats) do
+			if expectedBreakdowns[statData.stat] then
+				assert.are.equal(expectedBreakdowns[statData.stat], statData.breakdown, statData.stat)
+				expectedBreakdowns[statData.stat] = nil
+			end
+		end
+		assert.is_nil(next(expectedBreakdowns))
+	end)
+
+	it("shows a breakdown for life reserved by a modifier", function()
+		build.itemsTab:CreateDisplayItemFromRaw("New Item\nGold Ring\nReserves 25% of Life")
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		local lifeLine = getSidebarLine("Unreserved Life")
+		assert.are.equal("LifeReserved", lifeLine.breakdown)
+		build:SetDisplayStat({ line = lifeLine, x = 0, y = 0, width = 300 }, false)
+		assert.is_true(build.controls.breakdown.shown)
+	end)
+
 	it("uses aggregate breakdowns for dual-wield attacks", function()
 		build.skillsTab:PasteSocketGroup("skillId:MeleeMaceMacePlayer Mace Strike 20/0  1")
 		build.itemsTab:CreateDisplayItemFromRaw("New Item\nMarauding Mace\nQuality: 0\n20% increased Attack Speed")

--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -16,7 +16,7 @@ local defenseIgnoredSections = { "Base from Gear", "Inc. from Tree" }
 ---@field label? string                  Display label shown before the value
 ---@field fmt? string                    C-style format spec applied to the value, e.g. "d", ".1f", ".2f%%", "+d%%"
 ---@field breakdown? string              Override key for the sidebar breakdown. Should be set if the stat/childStat names don't match up with the breakdown names, or if the breakdown is conditional, but the cell isn't.
----@field modNames string[]?             Modifier names to show in the breakdown popup. This should only be used if the breakdown itself doesn't list the mods. E.g. Life doesn't. Additionally, you can set this to "" when breakdown is also set to always show the cell info, even if the breakdown itself is nil.
+---@field modNames string[]?             Modifier names to show in the breakdown popup. This should only be used if the breakdown itself doesn't list the mods. E.g. Life doesn't. Additionally, you can set this to { "" } when breakdown is also set to always show the cell info, even if the breakdown itself is nil.
 ---@field ignoredSections string[]?      A list of breakdown sections which shouldn't be shown. Useful to avoid duplicated info.
 ---@field color? string                  Colour escape code for the label (e.g. colorCodes.LIFE)
 ---@field flag? string                   Only show when the main skill has this skill flag
@@ -152,9 +152,9 @@ local displayStats = {
 	{ },
 	{ stat = "Life", label = "Total Life", fmt = "d", color = colorCodes.LIFE, compPercent = true, modNames = { "Life" }, ignoredSections = { "Base from Gear", "Inc. from Tree" } },
 	{ stat = "Spec:LifeInc", label = "%Inc Life", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v > 0 and o.Life > 1 end },
-	{ stat = "LifeUnreserved", label = "Unreserved Life", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.Life end, compPercent = true, warnFunc = function(v) return v <= 0 and "Your unreserved Life is below 1" end },
+	{ stat = "LifeUnreserved", label = "Unreserved Life", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.Life end, compPercent = true, warnFunc = function(v) return v <= 0 and "Your unreserved Life is below 1" end, breakdown = "LifeReserved", modNames = { "" } },
 	{ stat = "LifeRecoverable", label = "Life Recoverable", fmt = "d", color = colorCodes.LIFE, condFunc = function(v,o) return v < o.LifeUnreserved end, },
-	{ stat = "LifeUnreservedPercent", label = "Unreserved Life", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v < 100 end },
+	{ stat = "LifeUnreservedPercent", label = "Unreserved Life", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v < 100 end, breakdown = "LifeReserved", modNames = { "" } },
 	{ stat = "LifeRegenRecovery", label = "Life Regen", fmt = ".1f", color = colorCodes.LIFE, condFunc = function(v, o) return o.LifeRecovery <= 0 and o.LifeRegenRecovery ~= 0 end, breakdown = "LifeRegenRecovery" },
 	{ stat = "LifeRegenRecovery", label = "Life Recovery", fmt = ".1f", color = colorCodes.LIFE, condFunc = function(v, o) return o.LifeRecovery > 0 and o.LifeRegenRecovery ~= 0 end, breakdown = "LifeRegenRecovery" },
 	{ stat = "LifeLeechGainRate", label = "Life Leech/On Hit Rate", fmt = ".1f", color = colorCodes.LIFE, compPercent = true, breakdown = "LifeLeech" },
@@ -162,23 +162,23 @@ local displayStats = {
 	{ },
 	{ stat = "Mana", label = "Total Mana", fmt = "d", color = colorCodes.MANA, compPercent = true, modNames = { "Mana" }, ignoredSections = { "Base from Gear", "Inc. from Tree" } },
 	{ stat = "Spec:ManaInc", label = "%Inc Mana from Tree", color = colorCodes.MANA, fmt = "d%%" },
-	{ stat = "ManaUnreserved", label = "Unreserved Mana", fmt = "d", color = colorCodes.MANA, condFunc = function(v,o) return v < o.Mana end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Mana is negative" end },
+	{ stat = "ManaUnreserved", label = "Unreserved Mana", fmt = "d", color = colorCodes.MANA, condFunc = function(v,o) return v < o.Mana end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Mana is negative" end, breakdown = "ManaReserved" },
 	{ stat = "ManaUnreservedPercent", label = "Unreserved Mana", fmt = "d%%", color = colorCodes.MANA, condFunc = function(v, o) return v < 100 end, breakdown = "ManaReserved" },
 	{ stat = "ManaRegenRecovery", label = "Mana Regen", fmt = ".1f", color = colorCodes.MANA, condFunc = function(v,o) return o.ManaRecovery <= 0 and o.ManaRegenRecovery ~= 0 end },
 	{ stat = "ManaRegenRecovery", label = "Mana Recovery", fmt = ".1f", color = colorCodes.MANA, condFunc = function(v,o) return o.ManaRecovery > 0 and o.ManaRegenRecovery ~= 0 end },
-	{ stat = "ManaLeechGainRate", label = "Mana Leech/On Hit Rate", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
+	{ stat = "ManaLeechGainRate", label = "Mana Leech/On Hit Rate", fmt = ".1f", color = colorCodes.MANA, compPercent = true, breakdown = "ManaLeech" },
 	{ stat = "ManaLeechGainPerHit", label = "Mana Leech/Gain per Hit", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
 	{ },
-	{ stat = "Spirit", label = "Total Spirit", fmt = "d", color = colorCodes.SPIRIT, compPercent = true, ignoredSections = { "Inc. from Tree", "Base from Gear" }, modNames = { "Spirit" } },
+	{ stat = "Spirit", label = "Total Spirit", fmt = "d", color = colorCodes.SPIRIT, compPercent = true, ignoredSections = defenseIgnoredSections, modNames = { "Spirit" } },
 	{ stat = "SpiritUnreserved", label = "Unreserved Spirit", fmt = "d", color = colorCodes.SPIRIT, condFunc = function(v, o) return v < o.Spirit end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Spirit is negative" end, breakdown = "SpiritReserved" },
-	{ stat = "SpiritUnreservedPercent", label = "Unreserved Spirit", fmt = "d%%", color = colorCodes.SPIRIT, condFunc = function(v,o) return v < 100 end },
+	{ stat = "SpiritUnreservedPercent", label = "Unreserved Spirit", fmt = "d%%", color = colorCodes.SPIRIT, condFunc = function(v,o) return v < 100 end, breakdown = "SpiritReserved" },
 	{ },
 	{ stat = "EnergyShield", label = "Energy Shield", fmt = "d", color = colorCodes.ES, compPercent = true, modNames = { "EnergyShield", "Defences" }, ignoredSections = defenseIgnoredSections },
 	{ stat = "EnergyShieldRecoveryCap", label = "Recoverable ES", color = colorCodes.ES, fmt = "d", condFunc = function(v,o) return o.CappingES end },
 	{ stat = "Spec:EnergyShieldInc", label = "%Inc ES from Tree", color = colorCodes.ES, fmt = "d%%" },
 	{ stat = "EnergyShieldRegenRecovery", label = "ES Regen", color = colorCodes.ES, fmt = ".1f", condFunc = function(v,o) return o.EnergyShieldRecovery <= 0 and o.EnergyShieldRegenRecovery ~= 0 end },
 	{ stat = "EnergyShieldRegenRecovery", label = "ES Recovery", color = colorCodes.ES, fmt = ".1f", condFunc = function(v,o) return o.EnergyShieldRecovery > 0 and o.EnergyShieldRegenRecovery ~= 0 end },
-	{ stat = "EnergyShieldLeechGainRate", label = "ES Leech/On Hit Rate", color = colorCodes.ES, fmt = ".1f", compPercent = true },
+	{ stat = "EnergyShieldLeechGainRate", label = "ES Leech/On Hit Rate", color = colorCodes.ES, fmt = ".1f", compPercent = true, breakdown = "EnergyShieldLeech" },
 	{ stat = "EnergyShieldLeechGainPerHit", label = "ES Leech/Gain per Hit", color = colorCodes.ES, fmt = ".1f", compPercent = true },
 	{ },
 	{ stat = "Rage", label = "Rage", fmt = "d", color = colorCodes.RAGE, compPercent = true },

--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -16,7 +16,7 @@ local defenseIgnoredSections = { "Base from Gear", "Inc. from Tree" }
 ---@field label? string                  Display label shown before the value
 ---@field fmt? string                    C-style format spec applied to the value, e.g. "d", ".1f", ".2f%%", "+d%%"
 ---@field breakdown? string              Override key for the sidebar breakdown. Should be set if the stat/childStat names don't match up with the breakdown names, or if the breakdown is conditional, but the cell isn't.
----@field modNames string[]?             Modifier names to show in the breakdown popup. This should only be used if the breakdown itself doesn't list the mods. E.g. Life doesn't.
+---@field modNames string[]?             Modifier names to show in the breakdown popup. This should only be used if the breakdown itself doesn't list the mods. E.g. Life doesn't. Additionally, you can set this to "" when breakdown is also set to always show the cell info, even if the breakdown itself is nil.
 ---@field ignoredSections string[]?      A list of breakdown sections which shouldn't be shown. Useful to avoid duplicated info.
 ---@field color? string                  Colour escape code for the label (e.g. colorCodes.LIFE)
 ---@field flag? string                   Only show when the main skill has this skill flag
@@ -125,11 +125,11 @@ local displayStats = {
 	{ stat = "RagePerSecondCost", label = "Rage Cost per second", fmt = ".2f", color = colorCodes.RAGE, pool = "Rage", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.RagePerSecondHasCost end },
 	{ stat = "SoulCost", label = "Soul Cost", fmt = "d", color = colorCodes.RAGE, pool = "Soul", compPercent = true, lowerIsBetter = true, condFunc = function(v,o) return o.SoulHasCost end },
 	{ },
-	{ stat = "Str", label = "Strength", color = colorCodes.STRENGTH, fmt = "d", breakdown = "Str" },
+	{ stat = "Str", label = "Strength", color = colorCodes.STRENGTH, fmt = "d", breakdown = "Str", modNames = { "" } },
 	{ stat = "ReqStr", label = "Strength Required", color = colorCodes.STRENGTH, fmt = "d", lowerIsBetter = true, condFunc = function(v,o) return v > o.Str end, warnFunc = function(v,o) return "You do not meet the Strength requirement of " .. (o.ReqStrItem.source == "Item" and o.ReqStrItem.sourceItem.name or o.ReqStrItem.source == "Gem" and o.ReqStrItem.sourceGem.nameSpec or o.ReqStrItem.source == "Support Gems" and "your total Strength support gems.") end },
-	{ stat = "Dex", label = "Dexterity", color = colorCodes.DEXTERITY, fmt = "d", breakdown = "Dex" },
+	{ stat = "Dex", label = "Dexterity", color = colorCodes.DEXTERITY, fmt = "d", breakdown = "Dex", modNames = { "" } },
 	{ stat = "ReqDex", label = "Dexterity Required", color = colorCodes.DEXTERITY, fmt = "d", lowerIsBetter = true, condFunc = function(v,o) return v > o.Dex end, warnFunc = function(v,o) return "You do not meet the Dexterity requirement of " .. (o.ReqDexItem.source == "Item" and o.ReqDexItem.sourceItem.name or o.ReqDexItem.source == "Gem" and o.ReqDexItem.sourceGem.nameSpec or o.ReqDexItem.source == "Support Gems" and "your total Dexterity support gems.") end },
-	{ stat = "Int", label = "Intelligence", color = colorCodes.INTELLIGENCE, fmt = "d", breakdown = "Int" },
+	{ stat = "Int", label = "Intelligence", color = colorCodes.INTELLIGENCE, fmt = "d", breakdown = "Int", modNames = { "" } },
 	{ stat = "ReqInt", label = "Intelligence Required", color = colorCodes.INTELLIGENCE, fmt = "d", lowerIsBetter = true, condFunc = function(v,o) return v > o.Int end, warnFunc = function(v,o) return "You do not meet the Intelligence requirement of " .. (o.ReqIntItem.source == "Item" and o.ReqIntItem.sourceItem.name or o.ReqIntItem.source == "Gem" and o.ReqIntItem.sourceGem.nameSpec or o.ReqIntItem.source == "Support Gems" and "your total Intelligence support gems.") end },
 	{ },
 	{ stat = "Devotion", label = "Devotion", color = colorCodes.RARE, fmt = "d" },
@@ -169,8 +169,8 @@ local displayStats = {
 	{ stat = "ManaLeechGainRate", label = "Mana Leech/On Hit Rate", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
 	{ stat = "ManaLeechGainPerHit", label = "Mana Leech/Gain per Hit", fmt = ".1f", color = colorCodes.MANA, compPercent = true },
 	{ },
-	{ stat = "Spirit", label = "Total Spirit", fmt = "d", color = colorCodes.SPIRIT, compPercent = true },
-	{ stat = "SpiritUnreserved", label = "Unreserved Spirit", fmt = "d", color = colorCodes.SPIRIT, condFunc = function(v,o) return v < o.Spirit end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Spirit is negative" end },
+	{ stat = "Spirit", label = "Total Spirit", fmt = "d", color = colorCodes.SPIRIT, compPercent = true, ignoredSections = { "Inc. from Tree", "Base from Gear" }, modNames = { "Spirit" } },
+	{ stat = "SpiritUnreserved", label = "Unreserved Spirit", fmt = "d", color = colorCodes.SPIRIT, condFunc = function(v, o) return v < o.Spirit end, compPercent = true, warnFunc = function(v) return v < 0 and "Your unreserved Spirit is negative" end, breakdown = "SpiritReserved" },
 	{ stat = "SpiritUnreservedPercent", label = "Unreserved Spirit", fmt = "d%%", color = colorCodes.SPIRIT, condFunc = function(v,o) return v < 100 end },
 	{ },
 	{ stat = "EnergyShield", label = "Energy Shield", fmt = "d", color = colorCodes.ES, compPercent = true, modNames = { "EnergyShield", "Defences" }, ignoredSections = defenseIgnoredSections },
@@ -197,7 +197,7 @@ local displayStats = {
 	{ stat = "ProjectileEvadeChance", label = "Projectile Evade Chance", fmt = "d%%", color = colorCodes.EVASION, condFunc = function(v,o) return v > 0 and o.splitEvade end },
 	{ stat = "SpellEvadeChance", label = "Spell Evade Chance", fmt = "d%%", color = colorCodes.EVASION, condFunc = function(v,o) return v > 0 and o.splitEvade end },
 	{ stat = "SpellProjectileEvadeChance", label = "Spell Proj. Evade Chance", fmt = "d%%", color = colorCodes.EVASION, condFunc = function(v,o) return v > 0 and o.splitEvade end },
-	{ stat = "DeflectionRating", label = "Deflection Rating", fmt = "d", color = colorCodes.EVASION, compPercent = true },
+	{ stat = "DeflectionRating", label = "Deflection Rating", fmt = "d", color = colorCodes.EVASION, compPercent = true, modNames = { "EvasionGainAsDeflection", "ArmourGainAsDeflection", "DeflectionRating" }, breakdown = "" },
 	{ stat = "DeflectChance", label = "Deflect Chance", fmt = "d%%", color = colorCodes.EVASION, compPercent = true },
 	{ },
 	{ stat = "Armour", label = "Armour", fmt = "d", compPercent = true, modNames = { "Armour", "ArmourAndEvasion", "Defences", "ArmourDefense" }, ignoredSections = defenseIgnoredSections },

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -969,7 +969,7 @@ function calcs.defence(env, actor)
 		breakdown.Spirit = { slots = { } }
 	end
 	if actor == env.minion or actor == env.player then
-		calcs.doActorLifeManaSpirit(actor)
+		calcs.doActorLifeManaSpirit(actor, true)
 		calcs.doActorLifeManaSpiritReservation(actor)
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -456,7 +456,7 @@ local function doActorAttribsConditions(env, actor)
 	-- Calculate attributes
 	local calculateAttributes = function()
 		for pass = 1, 2 do -- Calculate twice because of circular dependency (X attribute higher than Y attribute)
-			for _, stat in pairs({"Str","Dex","Int"}) do
+			for _, stat in ipairs({ "Str", "Dex", "Int" }) do
 				output[stat] = m_max(round(calcLib.val(modDB, stat)), 0)
 				if breakdown then
 					breakdown[stat] = breakdown.simple(nil, nil, output[stat], stat)

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1680,7 +1680,7 @@ return {
 { 1, "Spirit", 2, colorCodes.SPIRIT, {{ defaultCollapsed = false, label = "Spirit", data = {
 	extra = "{0:output:SpiritUnreserved}/{0:output:Spirit}",
 	notFlag = "minionSkill",
-	{ label = "Base from Gear", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE", modSource = "Item" }, }, },
+	{ label = "Base from Gear", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE", modSource = "Item", skipSideBarIndex = true }, }, },
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC", modSource = "Tree" }, }, },
 	{ label = "Total Base", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE" }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC" }, }, },

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1599,7 +1599,7 @@ return {
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = "Life", modType = "INC", }, }, },
 	{ label = "Total More", { format = "{0:mod:1}%", { modName = "Life", modType = "MORE", }, }, },
 	{ label = "Total", { format = "{0:output:Life}", { breakdown = "Life" }, }, },
-	{ label = "Reserved", { format = "{0:output:LifeReserved} ({0:output:LifeReservedPercent}%)", { breakdown = "LifeReserved" }, }, },
+	{ label = "Reserved", { format = "{0:output:LifeReserved} ({0:output:LifeReservedPercent}%)", { breakdown = "LifeReserved" }, { modName = "ExtraLifeReserved" }, }, },
 	{ label = "Unreserved", { format = "{0:output:LifeUnreserved} ({0:output:LifeUnreservedPercent}%)" }, },
 	{ label = "Total Recoverable", haveOutput = "CappingLife", { format = "{0:output:LifeRecoverable}", { breakdown = "LifeUnreserved" }, }, },
 	{ label = "Recharge Rate", haveOutput = "EnergyShieldRechargeAppliesToLife", { format = "{1:output:LifeRecharge}", 
@@ -1680,7 +1680,7 @@ return {
 { 1, "Spirit", 2, colorCodes.SPIRIT, {{ defaultCollapsed = false, label = "Spirit", data = {
 	extra = "{0:output:SpiritUnreserved}/{0:output:Spirit}",
 	notFlag = "minionSkill",
-	{ label = "Base from Gear", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE", modSource = "Item", skipSideBarIndex = true }, }, },
+	{ label = "Base from Gear", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE", modSource = "Item" }, }, },
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC", modSource = "Tree" }, }, },
 	{ label = "Total Base", { format = "{0:mod:1}", { modName = "Spirit", modType = "BASE" }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = "Spirit", modType = "INC" }, }, },


### PR DESCRIPTION
### Description of the problem being solved:

Fixes:
- attributes not showing mod list when the breakdown doesn't exist (which is when you only have base mods)
- spirit not being linked to a breakdown. This had the same issue as defences. There was also a bug where the breakdown was being output twice.
- mana and ES leech not being linked like life leech
- Life reservation and other reservation inconsistencies

### Steps taken to verify a working solution:
- Many things hovered

### After screenshot:
<img width="803" height="353" alt="image" src="https://github.com/user-attachments/assets/a6af3743-13c7-4792-ae42-5923cde14ca7" />
<img width="618" height="187" alt="image" src="https://github.com/user-attachments/assets/e431c0b7-5801-46bc-8459-ad61bf5ecf1c" />
<img width="707" height="158" alt="image" src="https://github.com/user-attachments/assets/23e95225-8381-4f2e-ab7e-cd827bfa2096" />
