### PR TITLE
Add more type hints for mods and calculations

### DIFF
--- a/src/Classes/ModDB.lua
+++ b/src/Classes/ModDB.lua
@@ -20,6 +20,8 @@ local mod_createMod = modLib.createMod
 ---@class ModDB: ModStore
 local ModDBClass = newClass("ModDB", "ModStore")
 
+---@param parent? ModStore
+---@return ModDB
 function ModDBClass:ModDB(parent)
 	self:ModStore(parent)
 	self.mods = { }

--- a/src/Classes/ModList.lua
+++ b/src/Classes/ModList.lua
@@ -19,6 +19,8 @@ local mod_createMod = modLib.createMod
 ---@class ModList: ModStore
 local ModListClass = newClass("ModList", "ModStore")
 
+---@param parent? ModStore
+---@return ModList
 function ModListClass:ModList(parent)
 	self:ModStore(parent)
 	return self

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -33,7 +33,31 @@ end })
 ---@field keywordFlags number?
 ---@field skillName string?
 ---@field source string?
+---@class TabulatedMod
+---@field value any
+---@field mod Mod
 ---@class ModStore
+---@field ScaleAddMod fun(self: ModStore, mod: Mod, scale: number, roundToNearest?: boolean)
+---@field CopyList fun(self: ModStore, modList: Mod[])
+---@field ScaleAddList fun(self: ModStore, modList: Mod[], scale: number, roundToNearest?: boolean)
+---@field NewMod fun(self: ModStore, modName: string, modType: NumericModTypes|"FLAG"|"LIST", modVal?: any, sourceOrTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@field ReplaceMod fun(self: ModStore, modName: string, modType: NumericModTypes|"FLAG"|"LIST", modVal?: any, sourceOrTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@field ConvertMod fun(self: ModStore, oldName: string, modName: string, modType: NumericModTypes|"FLAG"|"LIST", modVal?: any, sourceOrTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@field Combine fun(self: ModStore, modType: NumericModTypes|"FLAG"|"LIST", cfg: ModCfg?, ...: string): any
+---@field Sum fun(self: ModStore, modType: NumericModTypes, cfg: ModCfg?, ...: string): number
+---@field SumPositiveValues fun(self: ModStore, modType: NumericModTypes, cfg: ModCfg?, modName: string, ...: string): number
+---@field SumNegativeValues fun(self: ModStore, modType: NumericModTypes, cfg: ModCfg?, modName: string, ...: string): number
+---@field More fun(self: ModStore, cfg: ModCfg?, ...: string): number
+---@field Flag fun(self: ModStore, cfg: ModCfg?, ...: string): boolean?
+---@field Override fun(self: ModStore, cfg: ModCfg?, ...: string): any
+---@field List fun(self: ModStore, cfg: ModCfg?, ...: string): any[]
+---@field Tabulate fun(self: ModStore, modType: NumericModTypes|"FLAG"|"LIST"|nil, cfg: ModCfg?, ...: string): TabulatedMod[]
+---@field Max fun(self: ModStore, cfg: ModCfg?, ...: string): number?
+---@field HasMod fun(self: ModStore, modType: NumericModTypes|"FLAG"|"LIST", cfg: ModCfg?, ...: string): boolean
+---@field GetCondition fun(self: ModStore, var: string, cfg?: ModCfg, noMod?: boolean): boolean
+---@field GetMultiplier fun(self: ModStore, var: string, cfg?: ModCfg, noMod?: boolean): number
+---@field GetStat fun(self: ModStore, stat: string, cfg?: ModCfg): number
+---@field EvalMod fun(self: ModStore, mod: Mod, cfg?: ModCfg, globalLimits?: table): any
 local ModStoreClass = newClass("ModStore")
 
 function ModStoreClass:ModStore(parent)
@@ -109,9 +133,9 @@ function ModStoreClass:ScaleAddList(modList, scale, roundToNearest)
 end
 
 --- Creates a new mod and adds it to this store.
----@overload fun(self: ModStore, modName: string, modType: NumericModTypes, modVal?: number, sourceOrModTag?: string|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
----@overload fun(self: ModStore, modName: string, modType: "FLAG", modVal: boolean, sourceOrModTag?: string|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
----@overload fun(self: ModStore, modName: string, modType: "LIST", modVal: any, sourceOrModTag?: string|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@overload fun(self: ModStore, modName: string, modType: NumericModTypes, modVal?: number, sourceOrModTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@overload fun(self: ModStore, modName: string, modType: "FLAG", modVal: boolean|number, sourceOrModTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
+---@overload fun(self: ModStore, modName: string, modType: "LIST", modVal: any, sourceOrModTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag)
 ---@param ... any @Parameters to be passed along to the modLib.createMod function
 function ModStoreClass:NewMod(...)
 	self:AddMod(mod_createMod(...))
@@ -149,6 +173,10 @@ function ModStoreClass:ConvertMod(oldName, ...)
 	end
 end
 
+---@param modType NumericModTypes|"FLAG"|"LIST"
+---@param cfg? ModCfg
+---@param ... string
+---@return any
 function ModStoreClass:Combine(modType, cfg, ...)
 	if modType == "MORE" then
 		return self:More(cfg, ...)
@@ -165,7 +193,7 @@ function ModStoreClass:Combine(modType, cfg, ...)
 	end
 end
 
----@param modType string
+---@param modType NumericModTypes
 ---@param cfg? ModCfg
 ---@param ... string
 ---@return number
@@ -184,9 +212,11 @@ end
 --- Returns the value of all positive modifiers to a mod added together, ignoring any negative modifiers.
 --- Works by creating a table using Tabulate and then filtering for positive values.
 ---
---- @param modType string # the mod type for which we want to create the table, e.g. "INC" or "MORE"
---- @param cfg table | nil # passed configuration, may be nil
---- @param modName string # the name of the mod for which we want to create the table, e.g. "FlaskRecoveryRate", "ActionSpeed", ...
+---@param modType NumericModTypes The modifier type, such as "INC" or "MORE"
+---@param cfg? ModCfg
+---@param modName string
+---@param ... string
+---@return number
 function ModStoreClass:SumPositiveValues(modType, cfg, modName, ...)
 	local total = 0
 	local modTable = self:Tabulate(modType, cfg, modName)
@@ -201,9 +231,11 @@ end
 --- Returns the value of all negative modifiers to a mod added together, ignoring any negative modifiers.
 --- Works by creating a table using Tabulate and then filtering for negative values.
 ---
---- @param modType string # the mod type for which we want to create the table, e.g. "INC" or "MORE"
---- @param cfg table | nil # passed configuration, may be nil
---- @param modName string # the name of the mod for which we want to create the table, e.g. "FlaskRecoveryRate", "ActionSpeed", ...
+---@param modType NumericModTypes The modifier type, such as "INC" or "MORE"
+---@param cfg? ModCfg
+---@param modName string
+---@param ... string
+---@return number
 function ModStoreClass:SumNegativeValues(modType, cfg, modName, ...)
 	local total = 0
 	local modTable = self:Tabulate(modType, cfg, modName)
@@ -229,6 +261,9 @@ function ModStoreClass:More(cfg, ...)
 	return self:MoreInternal(self, cfg, flags, keywordFlags, source, ...)
 end
 
+---@param cfg? ModCfg
+---@param ... string
+---@return boolean?
 function ModStoreClass:Flag(cfg, ...)
 	local flags, keywordFlags = 0, 0
 	local source
@@ -270,10 +305,10 @@ function ModStoreClass:List(cfg, ...)
 	return result
 end
 
----@param modType string
+---@param modType? NumericModTypes|"FLAG"|"LIST"
 ---@param cfg? ModCfg
 ---@param ... string
----@return table[]
+---@return TabulatedMod[]
 function ModStoreClass:Tabulate(modType, cfg, ...)
 	local flags, keywordFlags = 0, 0
 	local source
@@ -282,11 +317,15 @@ function ModStoreClass:Tabulate(modType, cfg, ...)
 		keywordFlags = cfg.keywordFlags or 0
 		source = cfg.source
 	end
+	---@type TabulatedMod[]
 	local result = { }
 	self:TabulateInternal(self, result, modType, cfg, flags, keywordFlags, source, ...)
 	return result
 end
 
+---@param cfg? ModCfg
+---@param ... string
+---@return number?
 function ModStoreClass:Max(cfg, ...)
 	local max
 	for _, value in ipairs(self:Tabulate("MAX", cfg, ...)) do
@@ -302,7 +341,7 @@ end
 ---  Checks if a mod exists with the given properties.
 ---  Useful for determining if the other aggregate functions will find
 ---  anything to aggregate.
----@param modType string @Mod type to match
+---@param modType NumericModTypes|"FLAG"|"LIST" @Mod type to match
 ---@param cfg? ModCfg configuration to use - contains flags, keywordFlags, and source to match
 ---@param ... string @Mod name(s) to check for.
 ---@return boolean @true if the mod is found, false otherwise.

--- a/src/Classes/PartyTab.lua
+++ b/src/Classes/PartyTab.lua
@@ -10,6 +10,7 @@ local t_insert = table.insert
 local m_max = math.max
 
 ---@class PartyTab: ControlHost, Control
+---@field actor PartyActor
 local PartyTabClass = newClass("PartyTab", "ControlHost", "Control")
 
 function PartyTabClass:PartyTab(build)

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["AlchemistsBoonPlayer"] = {
 	name = "Alchemist's Boon",
 	baseTypeName = "Alchemist's Boon",

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["ArcPlayer"] = {
 	name = "Arc",
 	baseTypeName = "Arc",

--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["AncestralCryPlayer"] = {
 	name = "Ancestral Cry",
 	baseTypeName = "Ancestral Cry",

--- a/src/Data/Skills/minion.lua
+++ b/src/Data/Skills/minion.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["MeleeAtAnimationSpeed"] = {
 	name = "Basic Attack",
 	hidden = true,

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["TriggeredAbyssalApparitionPlayer"] = {
 	name = "Abyssal Apparition",
 	baseTypeName = "Abyssal Apparition",

--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 --ABTT = Add Buff to Target Triggered
 --CGE = Monster Cast Ground Effect
 --DTT = Detach Dash to Target

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["SupportAdhesiveGrenadesPlayer"] = {
 	name = "Adhesive Grenades I",
 	description = "Supports Grenade Skills. Grenades from Supported Skills do not bounce, instead halting movement where they intially land, but doing lower damage when they detonate.",

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["SupportAbidingHexPlayer"] = {
 	name = "Abiding Hex",
 	description = "Supports Curse Skills you cast yourself. Supported Skills will consume Power Charges on use, gaining significant Curse duration if they do. Cannot Support Skills which consume Power Charges.",

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -5,6 +5,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 			return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 skills["SupportAftershockChancePlayer"] = {
 	name = "Aftershock I",
 	description = "Supports Slams you use yourself, giving them a chance to create an Aftershock.",

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill AlchemistsBoonPlayer
 #set AlchemistsBoonPlayer
 #flags area aura

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill ArcPlayer
 #set ArcPlayer
 #flags spell chaining projectile

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill AncestralCryPlayer
 #set AncestralCryPlayer
 #flags warcry area duration

--- a/src/Export/Skills/minion.txt
+++ b/src/Export/Skills/minion.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill MeleeAtAnimationSpeed
 #set MeleeAtAnimationSpeed
 #flags attack melee

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #from tree
 #skill TriggeredAbyssalApparitionPlayer
 #set TriggeredAbyssalApparitionPlayer

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 --ABTT = Add Buff to Target Triggered
 --CGE = Monster Cast Ground Effect
 --DTT = Detach Dash to Target

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -3,6 +3,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill SupportAdhesiveGrenadesPlayer
 #set SupportAdhesiveGrenadesPlayer
 statMap = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill SupportAbidingHexPlayer
 #set SupportAbidingHexPlayer
 #mods

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -4,6 +4,7 @@
 -- Skill data (c) Grinding Gear Games
 --
 return function(skills, mod, flag, skill)
+---@cast mod SkillModFunction
 #skill SupportAftershockChancePlayer
 #set SupportAftershockChancePlayer
 #mods

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -143,7 +143,7 @@ end
 -- Create an active skill using the given active gem and list of support gems
 -- It will determine the base flag set, and check which of the support gems can support this skill
 function calcs.createActiveSkill(activeEffect, supportList, env, actor, socketGroup, summonSkill)
-	---@class ActiveSkill
+	---@type ActiveSkill
 	local activeSkill = {
 		activeEffect = activeEffect,
 		supportList = supportList,

--- a/src/Modules/CalcBase.lua
+++ b/src/Modules/CalcBase.lua
@@ -82,12 +82,152 @@ return calcs
 ---@field MainHand Breakdown?
 ---@field OffHand Breakdown?
 
+---@class PartyActor
+---@field output Output
+---@field modDB ModDB
+---@field Aura table
+---@field Curse table
+---@field Warcry table
+---@field Link table
+
 ---@class Actor
 ---@field output Output
 ---@field modDB ModDB
+---@field level number
 ---@field enemy Actor?
+---@field player Actor?
+---@field parent Actor?
+---@field partyMembers PartyActor?
 ---@field breakdown? Breakdown?
+---@field activeSkillList? ActiveSkill[]
+---@field mainSkill? ActiveSkill
+---@field itemList? table<string, Item>
+---@field weaponData1? table
+---@field weaponData2? table
+---@field weaponRange1 number?
+---@field weaponRange2 number?
+---@field minionData table?
+---@field type string?
+---@field hostile boolean?
+---@field uses table<string, boolean>?
+---@field itemSet table?
+---@field lifeTable number[]?
+---@field hiddenDamageFixup number?
+---@field appliedEnemyModifiers table?
+---@field damageShiftTable table?
+---@field damageOverTimeShiftTable table?
+---@field spectreLifeList table[]?
+---@field companionLifeList table[]?
+---@field reserved_LifeBase number?
+---@field reserved_LifePercent number?
+---@field reserved_ManaBase number?
+---@field reserved_ManaPercent number?
+---@field reserved_SpiritBase number?
+---@field reserved_SpiritPercent number?
+---@field uncancellable_LifeReservation number?
+---@field uncancellable_ManaReservation number?
+---@field uncancellable_SpiritReservation number?
 
 ---@class ActiveSkill
+---@field activeEffect table
+---@field supportList table[]
+---@field actor Actor
+---@field summonSkill? ActiveSkill
+---@field socketGroup? table
+---@field skillData table<string, any>
+---@field skillTypes table<number, boolean>
+---@field minionSkillTypes? table<number, boolean>
+---@field effectList table[]
+---@field buffList table[]
+---@field baseSkillModList ModList
 ---@field skillModList ModList
+---@field extraSkillModList? Mod[]
 ---@field skillCfg ModCfg
+---@field weapon1Cfg? ModCfg
+---@field weapon2Cfg? ModCfg
+---@field weapon1Flags number
+---@field weapon2Flags number
+---@field minion? Actor
+---@field minionList? string[]
+---@field mirage? table
+---@field slotName? string
+---@field skillPart? number
+---@field skillPartName? string
+---@field skillTotemId? number
+---@field activeMineCount? number
+---@field activeStageCount? number
+---@field disableReason? string
+---@field triggeredBy? table
+---@field infoMessage? string
+---@field infoMessage2? string
+---@field infoTrigger? string
+---@field buffSkill? boolean
+---@field minionBuffSkill? boolean
+---@field totemBuffSkill? boolean
+---@field debuffSkill? boolean
+---@field conversionTable? table
+---@field gainTable? table
+---@field decayCfg? ModCfg
+---@field dotCfg? ModCfg
+
+---@class Env
+---@field build Build
+---@field data table
+---@field configInput table<string, any>
+---@field configPlaceholder table<string, any>
+---@field calcsInput table<string, any>
+---@field mode CalcEnvMode
+---@field buildBreakdown boolean
+---@field spec PassiveSpec
+---@field classId number
+---@field modDB ModDB
+---@field enemyDB ModDB
+---@field itemModDB ModDB
+---@field player Actor
+---@field enemy Actor
+---@field minion? Actor
+---@field partyMembers? PartyActor
+---@field enemyLevel number
+---@field mode_buffs boolean
+---@field mode_combat boolean
+---@field mode_effective boolean
+---@field allocNodes table<number, Node>
+---@field useAltGemQualityStats boolean?
+---@field requirementsTableItems table[]
+---@field requirementsTableGems table[]
+---@field requirementsTable table[]
+---@field radiusJewelList table[]
+---@field extraRadiusNodeList table
+---@field grantedSkills table[]
+---@field grantedSkillsNodes table[]
+---@field grantedSkillsItems table[]
+---@field explodeSources table[]
+---@field itemWarnings table<string, table>
+---@field flasks table<Item, boolean>
+---@field charms table<Item, boolean>
+---@field grantedPassives table<number, boolean>
+---@field auxSkillList ActiveSkill[]
+---@field mainSocketGroup number
+---@field crossLinkedSupportGroups table<string, string[]>
+---@field keystonesAdded? table<string, boolean>
+---@field buffs? table<string, ModList>
+---@field minionBuffs? table<string, ModList>
+---@field debuffs? table<string, ModList>
+---@field curseSlots? table[]
+---@field limitedSkills? table<string, boolean>
+---@field talismanModList? ModList
+---@field theIronMass? ModList
+---@field weaponModList1? ModList
+---@field sourceGemPropertyInfo? table<any, TabulatedMod[]>
+---@field override? CalcOverride
+---@field virtuousMoteSkillCount? table<string, number>
+---@field skillsUsed? table<string, boolean>
+---@field conditionsUsed? table<string, Mod[]>
+---@field enemyConditionsUsed? table<string, Mod[]>
+---@field minionConditionsUsed? table<string, Mod[]>
+---@field multipliersUsed? table<string, Mod[]>
+---@field enemyMultipliersUsed? table<string, Mod[]>
+---@field perStatsUsed? table<string, Mod[]>
+---@field enemyPerStatsUsed? table<string, Mod[]>
+---@field tagTypesUsed? table<string, Mod[]>
+---@field modsUsed? table<string, Mod[]>

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -21,10 +21,10 @@ local m_huge = math.huge
 --- getCachedOutputValue
 ---  retrieves a value specified by key from a cached version of skill
 ---  specified by @uuid or if not found in cache computes teh cache.
---- @param env table
---- @param activeSkill table active skill to be used as main when calculating output values
---- @param ... table keys to values to be returned (Note: EmmyLua does not natively support documenting variadic parameters)
---- @return table unpacked table containing the desired values
+---@param env Env
+---@param activeSkill ActiveSkill Active skill to use as main when calculating output values
+---@param ... string Keys of values to return
+---@return any ... Cached output values
 local function getCachedOutputValue(env, activeSkill, ...)
 	local uuid = cacheSkillUUID(activeSkill, env)
 	if not GlobalCache.cachedData[env.mode][uuid] or env.mode == "CALCULATOR" then
@@ -143,6 +143,7 @@ local legacies = {
 }
 
 -- Merge keystone modifiers
+---@param env Env
 local function mergeKeystones(env)
 	for _, modObj in ipairs(env.modDB:Tabulate("LIST", nil, "Keystone")) do
 		if not env.keystonesAdded[modObj.value] and env.spec.tree.keystoneMap[modObj.value] then
@@ -156,7 +157,7 @@ local function mergeKeystones(env)
 end
 -- Add certain weapon base stats to output for use as "Stat" in mods like Tactician's ""Watch How I Do It" Ascendancy notable" and Amazon's "Penetrate"
 -- Note: This might run into issues with Energy Blade, Shapeshifting or similar mechanics that could "replace" the weapon items, but it's hard to test because PoE2 doesn't have those mechanics yet
----@param actor table
+---@param actor Actor
 local function addWeaponBaseStats(actor)
 	local output = actor.output
 	local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"} -- Note: we're using local dmgTypeList vars a lot, might be better to eventually just use a global since it presumably won't change
@@ -179,7 +180,7 @@ local function addWeaponBaseStats(actor)
 end
 
 -- Generic radius/area calculator for a given key prefix (e.g. "Presence", "Surrounded")
----@param actor table
+---@param actor Actor
 ---@param key string  -- e.g. "Presence" or "Surrounded"
 local function calcBuffRadius(actor, key)
 	local radiusKey, areaKey , modKey = key .. "Radius", key .. "Area", key .. "Mod"
@@ -212,8 +213,8 @@ local function calcBuffRadius(actor, key)
 	end
 end
 -- Calculate attributes, and set conditions
----@param env table
----@param actor table
+---@param env Env
+---@param actor Actor
 local function doActorAttribsConditions(env, actor)
 	local modDB = actor.modDB
 	---@class Output
@@ -561,6 +562,8 @@ local function determineCursePriority(curseName, activeSkill)
 	return basePriority + socketPriority + slotPriority + sourcePriority
 end
 
+---@param actor Actor
+---@param clearCache? boolean
 local function applyEnemyModifiers(actor, clearCache)
 	if clearCache or not actor.appliedEnemyModifiers then
 		actor.appliedEnemyModifiers = { }
@@ -578,6 +581,8 @@ local function applyEnemyModifiers(actor, clearCache)
 end
 
 -- Process enemy modifiers and other buffs
+---@param env Env
+---@param actor Actor
 local function doActorMisc(env, actor)
 	local modDB = actor.modDB
 	local enemyDB = actor.enemy.modDB
@@ -854,6 +859,8 @@ local function doActorMisc(env, actor)
 end
 
 -- Process charges
+---@param env Env
+---@param actor Actor
 local function doActorCharges(env, actor)
 	local modDB = actor.modDB
 	---@class Output
@@ -1011,6 +1018,8 @@ local function doActorCharges(env, actor)
 end
 
 
+---@param actor Actor
+---@return number
 function calcs.actionSpeedMod(actor)
 	local modDB = actor.modDB
 	local minimumActionSpeed = modDB:Max(nil, "MinimumActionSpeed") or 0
@@ -1037,6 +1046,8 @@ end
 
 -- Initialises a minion's modifier database with its base stats (life, defences, resists),
 -- monster type mods, tamed beast mods and player-granted mods, for the given owning skill
+---@param env Env
+---@param activeSkill ActiveSkill
 local function initMinionModDB(env, activeSkill)
 	local skillFlags
 	if env.mode == "CALCS" then
@@ -1146,6 +1157,9 @@ local function initMinionModDB(env, activeSkill)
 	end
 end
 
+---@param modList ModList
+---@param skillCfg ModCfg
+---@param minion Actor
 local function addMinionModifiers(modList, skillCfg, minion)
 	for _, value in ipairs(modList:List(skillCfg, "MinionModifier")) do
 		if not value.type or minion.type == value.type then
@@ -1163,6 +1177,8 @@ end
 -- 6. Processes buffs and debuffs
 -- 7. Processes charges and misc buffs (doActorCharges, doActorMisc)
 -- 8. Calculates defence and offence stats (calcs.defence, calcs.offence)
+---@param env Env
+---@param skipEHP? boolean
 function calcs.perform(env, skipEHP)
 	---@type ModDB
 	local modDB = env.modDB

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -644,6 +644,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 	local cachedPlayerDB = specEnv and specEnv.cachedPlayerDB or nil
 	local cachedEnemyDB = specEnv and specEnv.cachedEnemyDB or nil
 	local cachedMinionDB = specEnv and specEnv.cachedMinionDB or nil
+	---@type Env?
 	local env = specEnv and specEnv.env or nil
 	local accelerate = specEnv and specEnv.accelerate or { }
 
@@ -654,8 +655,6 @@ function calcs.initEnv(build, mode, override, specEnv)
 	local classStats = nil
 
 	if not env then
-		---@class Env
-		---@field minion Actor?
 		env = { }
 		env.build = build
 		env.data = build.data

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2162,6 +2162,7 @@ local modTagList = {
 	["for each spider's web on the enemy"] = { tag = { type = "Multiplier", actor = "enemy", var = "Spider's WebStack" } },
 }
 
+---@type CreateModFunction
 local mod = modLib.createMod
 --- Creates a mod with type "FLAG" and value true
 ---@overload fun(name: string, sourceOrModTag?: string|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag): Mod

--- a/src/Modules/ModTools.lua
+++ b/src/Modules/ModTools.lua
@@ -20,13 +20,39 @@ modLib = { }
 --- "Flag" is only used with CanNotUseItem
 ---@alias NumericModTypes "INC"|"MORE"|"BASE"|"OVERRIDE"|"MAX"|"CHANCE"|"DUMMY"|"Flag"|"MIN"
 
--- Massive discriminated union. Todo: probably has to be built with an LLM for a start
----@class ModTag
----@field type string
+---@alias OtherModTagType "ActorCondition"|"BaseFlag"|"DisablesItem"|"DistanceRamp"|"GemTag"|"Global"|"GlobalEffect"|"IgnoreCond"|"InSlot"|"ItemCondition"|"KeywordFlagAnd"|"Limit"|"ModFlagOr"|"MonsterTag"|"Multiplier"|"MultiplierThreshold"|"PercentStat"|"SkillId"|"SkillName"|"SkillPart"|"SkillType"|"SlotName"|"SlotNumber"|"SocketedIn"|"StatThreshold"
 
----@overload fun(modName: string, modType: NumericModTypes, modVal?: number, sourceOrTag: string|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
----@overload fun(modName: string, modType: "FLAG", modVal: boolean, sourceOrModTag: string|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
----@overload fun(modName: string, modType: "LIST", modVal: any[]|any, sourceOrModTag: string|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
+---@class ConditionModTag
+---@field type "Condition"
+---@field var? string
+---@field varList? string[]
+---@field neg? boolean
+
+---@class PerStatModTag
+---@field type "PerStat"
+---@field stat? string
+---@field statList? string[]
+---@field actor? string
+---@field div? number
+---@field divVar? string
+---@field limit? number
+---@field limitVar? string
+---@field limitTotal? boolean
+---@field base? number
+---@field globalLimit? number
+---@field globalLimitKey? string
+
+---@class OtherModTag
+---@field type OtherModTagType
+---@field [string] any
+
+---@alias ModTag ConditionModTag|PerStatModTag|OtherModTag
+---@alias SkillModFunction fun(modName: string, modType: NumericModTypes|"FLAG"|"LIST", modVal?: any, flags?: number, keywordFlags?: number, ...: ModTag): Mod
+---@alias CreateModFunction fun(modName: string, modType: NumericModTypes|"FLAG"|"LIST", modVal?: any, sourceOrTag?: string|number|ModTag, flagsOrModTag?: number|ModTag, keywordFlagsOrModTag?: number|ModTag, ...: ModTag): Mod
+
+---@overload fun(modName: string, modType: NumericModTypes, modVal?: number, sourceOrTag: string|number|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
+---@overload fun(modName: string, modType: "FLAG", modVal: boolean|number, sourceOrModTag: string|number|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
+---@overload fun(modName: string, modType: "LIST", modVal: any[]|any, sourceOrModTag: string|number|ModTag?, flagsOrModTag: number|ModTag?, keywordFlagsOrModTag: number|ModTag?, ...: ModTag)
 ---@return Mod
 function modLib.createMod(modName, modType, modVal, ...)
 	local flags = 0


### PR DESCRIPTION
### Description of the problem being solved:
Add types for mod creation, mod tags, ModStore methods, and calculation structures.

Type ModDB and ModList constructor returns, define Tabulate results, and describe Env, Actor, and ActiveSkill fields so autocomplete works throughout the calculation code.
Add the required casts to ModParser and generated skill files, including their export templates.
