### PR TITLE
Port versioned unique variant groups from PoB 1

### DIFF
--- a/spec/System/TestItemVariants_spec.lua
+++ b/spec/System/TestItemVariants_spec.lua
@@ -1,0 +1,340 @@
+describe("Versioned item variants", function()
+	local groupedRaw = [[
+		Rarity: Unique
+		Grouped Test Item
+		Gold Ring
+		Version: Pre 0.4.0
+		Version: Current
+		Variant: Life
+		Variant: Energy Shield
+		Variant: Mana
+		Variant: Armour
+		Implicits: 0
+		{version:1}{variant:1}{group:1,2}{tags:life}+10 to maximum Life
+		{version:2}{variant:2}{group:1,2}{tags:defences}+20 to maximum Energy Shield
+		{variant:3}{group:1,2}{tags:mana}+30 to maximum Mana
+		{variant:4}{group:1,2}{tags:defences}+40 to Armour
+	]]
+
+	it("defaults to the current version with distinct options from a shared pool", function()
+		local item = new("Item"):Item(groupedRaw)
+		assert.same({ "Pre 0.4.0", "Current" }, item.versionList)
+		assert.equals(2, item.selectedVersion)
+		assert.same({ 2, 3 }, item.variantGroupSelections)
+		assert.same({ 2, 3, 4 }, item:GetVariantGroupOptions(1, false))
+		assert.same({ 2, 4 }, item:GetVariantGroupOptions(1, true))
+		assert.equals(0, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "EnergyShield"))
+		assert.equals(30, item.baseModList:Sum("BASE", nil, "Mana"))
+		assert.is_false(item:FindModifierSubstring("life", "Ring 1"))
+		assert.is_true(item:FindModifierSubstring("mana", "Ring 1"))
+	end)
+
+	it("ignores disabled modifiers in the selected variant groups", function()
+		local item = new("Item"):Item(groupedRaw)
+		local manaLine
+		for _, modLine in ipairs(item.explicitModLines) do
+			if modLine.line:find("maximum Mana", 1, true) then
+				manaLine = modLine
+				break
+			end
+		end
+		assert.is_not_nil(manaLine)
+		manaLine.disabled = true
+		assert.is_true(item:CheckModLineVariant(manaLine))
+		assert.is_false(item:FindModifierSubstring("mana", "Ring 1"))
+	end)
+
+	it("preserves eligible selections and replaces unavailable selections when changing version", function()
+		local item = new("Item"):Item(groupedRaw)
+		item.variantGroupSelections = { 3, 2 }
+		item.selectedVersion = 1
+		item:NormaliseVariantSelections()
+		assert.same({ 3, 1 }, item.variantGroupSelections)
+		item:BuildAndParseRaw()
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(0, item.baseModList:Sum("BASE", nil, "EnergyShield"))
+		assert.equals(30, item.baseModList:Sum("BASE", nil, "Mana"))
+	end)
+
+	it("round trips selected versions, groups, catalyst tags and ranges", function()
+		local item = new("Item"):Item(groupedRaw)
+		item.selectedVersion = 1
+		item.variantGroupSelections = { 1, 4 }
+		item.explicitModLines[1].line = "+(10-20) to maximum Life"
+		item.explicitModLines[1].range = 0.25
+		item:BuildAndParseRaw()
+		assert.matches("Selected Version: 1", item.raw, 1, true)
+		assert.matches("Selected Variant Group: 1=1", item.raw, 1, true)
+		assert.matches("{version:1}{variant:1}{group:1,2}{tags:life}", item.raw, 1, true)
+		local restored = new("Item"):Item(item.raw)
+		assert.same({ 1, 4 }, restored.variantGroupSelections)
+		assert.same({ "life" }, restored.explicitModLines[1].modTags)
+		assert.equals(0.25, restored.explicitModLines[1].range)
+		assert.equals(item.baseModList:Sum("BASE", nil, "Life"), restored.baseModList:Sum("BASE", nil, "Life"))
+	end)
+
+	it("preserves selection tags on each line of a multiline modifier", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Multiline Test
+			Diamond
+			Version: Legacy
+			Version: Current
+			Variant: Effect
+			Implicits: 0
+			{version:2}{variant:1}{group:1}100% increased Effect of Jewel Socket Passive Skills
+			{version:2}{variant:1}{group:1}containing Corrupted Magic Jewels
+		]])
+		assert.equals(1, #item.explicitModLines)
+		item:BuildAndParseRaw()
+		assert.matches("\n{version:2}{variant:1}{group:1}containing Corrupted Magic Jewels", item.raw, 1, true)
+		assert.is_nil(item.explicitModLines[1].extra)
+	end)
+
+	it("supports groups without versions and sparse group IDs", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Sparse Test
+			Gold Ring
+			Variant: Life
+			Variant: Mana
+			Implicits: 0
+			{variant:1}{group:2}+10 to maximum Life
+			{variant:2}{group:4}+20 to maximum Mana
+		]])
+		assert.is_nil(item.selectedVersion)
+		assert.same({ [2] = 1, [4] = 2 }, item.variantGroupSelections)
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
+		item:BuildAndParseRaw()
+		assert.same({ [2] = 1, [4] = 2 }, new("Item"):Item(item.raw).variantGroupSelections)
+	end)
+
+	it("supports version-only items and clamps invalid saved versions", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Version Test
+			Gold Ring
+			Version: Legacy
+			Version: Current
+			Selected Version: 99
+			Implicits: 0
+			{version:1}+10 to maximum Life
+			{version:2}+20 to maximum Life
+		]])
+		assert.equals(2, item.selectedVersion)
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Life"))
+		item:BuildAndParseRaw()
+		assert.equals(20, new("Item"):Item(item.raw).baseModList:Sum("BASE", nil, "Life"))
+	end)
+
+	it("applies the selected version's modifier magnitude on the first parse", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Magnitude Test
+			Gold Ring
+			Version: Legacy
+			Version: Current
+			Implicits: 0
+			{version:1}{range:0.5}100% increased explicit modifier magnitudes
+			{version:2}{range:0.5}200% increased explicit modifier magnitudes
+			{tags:life}+(10-10) to maximum Life
+		]])
+		assert.equals(30, item.baseModList:Sum("BASE", nil, "Life"))
+		item.selectedVersion = 1
+		item:BuildAndParseRaw()
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Life"))
+	end)
+
+	it("selects versioned bases and preserves their tags without variants", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Base Test
+			Version: Legacy
+			Version: Current
+			Selected Version: 99
+			{version:1}Gold Ring
+			{version:2}Iron Ring
+			Implicits: 0
+			+10 to maximum Life
+		]])
+		assert.equals("Iron Ring", item.baseName)
+		item.selectedVersion = 1
+		item:BuildAndParseRaw()
+		assert.equals("Gold Ring", item.baseName)
+		assert.matches("{version:2}Iron Ring", item.raw, 1, true)
+		assert.equals("Gold Ring", new("Item"):Item(item.raw).baseName)
+	end)
+
+	it("selects grouped bases on the first parse", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Base Test
+			Variant: Gold
+			Variant: Iron
+			Selected Variant Group: 1=99
+			{variant:1}{group:1}Gold Ring
+			{variant:2}{group:1}Iron Ring
+			Implicits: 0
+			+10 to maximum Life
+		]])
+		assert.equals("Gold Ring", item.baseName)
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
+		item.variantGroupSelections[1] = 2
+		item:BuildAndParseRaw()
+		assert.equals("Iron Ring", item.baseName)
+	end)
+
+	it("applies grouped rune socket overrides on the first parse", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Rune Test
+			Grand Regalia
+			Variant: Weapon
+			Variant: Armour
+			Implicits: 0
+			{variant:1}{group:1}This item gains bonuses from Socketed Items as though it was a Weapon
+			{variant:2}{group:1}This item gains bonuses from Socketed Items as though it was Body Armour
+		]])
+		assert.equals("weapon", item.socketedAugmentTypeOverride)
+		item.variantGroupSelections[1] = 2
+		item:BuildAndParseRaw()
+		assert.equals("body armour", item.socketedAugmentTypeOverride)
+	end)
+
+	it("keeps Controlled Metamorphosis radius independent of its version", function()
+		local raw
+		for _, unique in ipairs(data.uniques.jewel) do
+			if unique:match("^Controlled Metamorphosis\n") then
+				raw = unique
+				break
+			end
+		end
+		assert.is_not_nil(raw)
+		local item = new("Item"):Item(raw)
+		assert.equals(2, item.selectedVersion)
+		assert.same({ 4 }, item.variantGroupSelections)
+		assert.equals(0, item.baseModList:Sum("BASE", nil, "ChaosResist"))
+		for radius = 1, 8 do
+			item.variantGroupSelections[1] = radius
+			item.selectedVersion = 2
+			item:BuildAndParseRaw()
+			local radiusIndex = item.jewelData.radiusIndex
+			assert.is_not_nil(radiusIndex)
+			item.selectedVersion = 1
+			item:BuildAndParseRaw()
+			assert.equals(radiusIndex, item.jewelData.radiusIndex)
+			assert.equals(radiusIndex, item.jewelRadiusIndex)
+			assert.is_true(item.baseModList:Sum("BASE", nil, "ChaosResist") < 0)
+			assert.same({ radius }, new("Item"):Item(item.raw).variantGroupSelections)
+		end
+	end)
+
+	describe("item editor", function()
+		before_each(newBuild)
+
+		it("updates reusable pools when changing version or selection", function()
+			build.itemsTab:CreateDisplayItemFromRaw(groupedRaw)
+			local controls = build.itemsTab.controls
+			local version = controls.displayItemVersion
+			local group1 = controls.displayItemVariant
+			local group2 = controls.displayItemAltVariant
+			assert.is_true(version:IsShown())
+			assert.equals(2, version.selIndex)
+			assert.equals("Energy Shield", group1.list[1].label)
+			assert.equals("Mana", group2.list[1].label)
+			group2:SetSel(2)
+			group1:SetSel(2)
+			assert.same({ 3, 4 }, build.itemsTab.displayItem.variantGroupSelections)
+			version:SetSel(1)
+			assert.same({ 3, 4 }, build.itemsTab.displayItem.variantGroupSelections)
+			assert.equals("Life", group1.list[1].label)
+			assert.equals("Life", group2.list[1].label)
+			local tooltip = new("Tooltip"):Tooltip()
+			build.itemsTab:AddItemTooltip(tooltip, build.itemsTab.displayItem, nil, true)
+			local text = ""
+			for _, line in ipairs(tooltip.lines) do
+				text = text .. (line.text or "") .. "\n"
+			end
+			assert.matches("Version: Pre 0.4.0", text, 1, true)
+			assert.matches("Variants: Mana, Armour", text, 1, true)
+		end)
+
+		it("disables exhausted pools and restores legacy controls", function()
+			build.itemsTab:CreateDisplayItemFromRaw([[
+				Rarity: Unique
+				Exhausted Pool
+				Gold Ring
+				Variant: Life
+				Implicits: 0
+				{variant:1}{group:1,2}+10 to maximum Life
+			]])
+			local controls = build.itemsTab.controls
+			assert.is_true(controls.displayItemAltVariant:IsShown())
+			assert.is_false(controls.displayItemAltVariant:IsEnabled())
+			assert.equals("No available variants", controls.displayItemAltVariant.list[1].label)
+			assert.equals(10, build.itemsTab.displayItem.baseModList:Sum("BASE", nil, "Life"))
+			build.itemsTab:CreateDisplayItemFromRaw([[
+				Rarity: Unique
+				Legacy Test
+				Gold Ring
+				Variant: Life
+				Variant: Mana
+				Implicits: 0
+				{variant:1}+10 to maximum Life
+				{variant:2}+20 to maximum Mana
+			]])
+			assert.is_false(controls.displayItemVersion:IsShown())
+			assert.is_true(controls.displayItemVariant:IsEnabled())
+			assert.is_falsy(controls.displayItemAltVariant:IsShown())
+			controls.displayItemVariant:SetSel(1)
+			assert.equals(10, build.itemsTab.displayItem.baseModList:Sum("BASE", nil, "Life"))
+		end)
+
+		it("hides inactive groups and restores their selections when changing version", function()
+			build.itemsTab:CreateDisplayItemFromRaw([[
+				Rarity: Unique
+				Changing Pools
+				Gold Ring
+				Version: Legacy
+				Version: Current
+				Variant: Life
+				Variant: Mana
+				Variant: Armour
+				Implicits: 0
+				{version:1}{variant:1}{group:2}+10 to maximum Life
+				{version:2}{variant:2}{group:4}+20 to maximum Mana
+				{variant:3}{group:7}+30 to Armour
+			]])
+			local controls = build.itemsTab.controls
+			assert.equals(4, controls.displayItemVariant.variantGroupId)
+			assert.equals(7, controls.displayItemAltVariant.variantGroupId)
+			controls.displayItemVersion:SetSel(1)
+			assert.equals(2, controls.displayItemVariant.variantGroupId)
+			assert.equals(7, controls.displayItemAltVariant.variantGroupId)
+			assert.equals("Life", controls.displayItemVariant.list[1].label)
+			controls.displayItemVersion:SetSel(2)
+			assert.equals(4, controls.displayItemVariant.variantGroupId)
+			assert.equals("Mana", controls.displayItemVariant.list[1].label)
+			assert.equals(2, build.itemsTab.displayItem.variantGroupSelections[4])
+		end)
+
+		it("saves and loads group selections in build XML", function()
+			build.itemsTab:CreateDisplayItemFromRaw(groupedRaw)
+			local item = build.itemsTab.displayItem
+			item.selectedVersion = 1
+			item.variantGroupSelections = { 4, 1 }
+			item:BuildAndParseRaw()
+			build.itemsTab:AddDisplayItem()
+			local xml = { }
+			build.itemsTab:Save(xml)
+			newBuild()
+			build.itemsTab:Load(xml)
+			local restored = build.itemsTab.items[build.itemsTab.itemOrderList[1]]
+			assert.equals(1, restored.selectedVersion)
+			assert.same({ 4, 1 }, restored.variantGroupSelections)
+			assert.equals(10, restored.baseModList:Sum("BASE", nil, "Life"))
+		end)
+	end)
+end)

--- a/spec/System/TestItemVariants_spec.lua
+++ b/spec/System/TestItemVariants_spec.lua
@@ -61,8 +61,8 @@ describe("Versioned item variants", function()
 
 	it("keeps an independent variant selection when versions and variants exist", function()
 		local item = new("Item"):Item(ungroupedRaw)
-		assert.is_true(item.usesVariantGroups)
-		assert.is_true(item.hasUngroupedVariants)
+		assert.is_true(item:HasIndependentVariants())
+		assert.is_false(item:HasVariantGroups())
 		assert.equals(2, item.selectedVersion)
 		assert.equals(2, item.variant)
 		assert.same({ }, item.variantGroupSelections)
@@ -230,11 +230,11 @@ describe("Versioned item variants", function()
 		local item = new("Item"):Item([[
 			Rarity: Unique
 			Base Test
+			{variant:1}{group:1}Gold Ring
+			{variant:2}{group:1}Iron Ring
 			Variant: Gold
 			Variant: Iron
 			Selected Variant Group: 1=99
-			{variant:1}{group:1}Gold Ring
-			{variant:2}{group:1}Iron Ring
 			Implicits: 0
 			+10 to maximum Life
 		]])
@@ -249,14 +249,14 @@ describe("Versioned item variants", function()
 		local item = new("Item"):Item([[
 			Rarity: Unique
 			Independent Base Test
+			{version:1}{variant:1}Gold Ring
+			{version:2}{variant:2}Iron Ring
 			Version: Legacy
 			Version: Current
 			Selected Version: 2
 			Variant: Gold
 			Variant: Iron
 			Selected Variant: 2
-			{version:1}{variant:1}Gold Ring
-			{version:2}{variant:2}Iron Ring
 			Implicits: 0
 			+10 to maximum Life
 		]])

--- a/spec/System/TestItemVariants_spec.lua
+++ b/spec/System/TestItemVariants_spec.lua
@@ -15,6 +15,20 @@ describe("Versioned item variants", function()
 		{variant:3}{group:1,2}{tags:mana}+30 to maximum Mana
 		{variant:4}{group:1,2}{tags:defences}+40 to Armour
 	]]
+	local ungroupedRaw = [[
+		Rarity: Unique
+		Ungrouped Variant Test Item
+		Gold Ring
+		Version: Legacy
+		Version: Current
+		Selected Variant: 2
+		Variant: Life
+		Variant: Mana
+		Variant: Unreferenced
+		Implicits: 0
+		{variant:1}{tags:life}+10 to maximum Life
+		{variant:2}{tags:mana}+20 to maximum Mana
+	]]
 
 	it("defaults to the current version with distinct options from a shared pool", function()
 		local item = new("Item"):Item(groupedRaw)
@@ -43,6 +57,51 @@ describe("Versioned item variants", function()
 		manaLine.disabled = true
 		assert.is_true(item:CheckModLineVariant(manaLine))
 		assert.is_false(item:FindModifierSubstring("mana", "Ring 1"))
+	end)
+
+	it("keeps an independent variant selection when versions and variants exist", function()
+		local item = new("Item"):Item(ungroupedRaw)
+		assert.is_true(item.usesVariantGroups)
+		assert.is_true(item.hasUngroupedVariants)
+		assert.equals(2, item.selectedVersion)
+		assert.equals(2, item.variant)
+		assert.same({ }, item.variantGroupSelections)
+		assert.same({ }, item.variantGroups)
+		assert.equals(0, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
+		item:BuildAndParseRaw()
+		assert.is_nil(item.raw:find("{group:", 1, true))
+		assert.matches("Selected Variant: 2", item.raw, 1, true)
+		assert.equals(2, item.variant)
+	end)
+
+	it("normalises an invalid independent variant selection", function()
+		local item = new("Item"):Item(ungroupedRaw:gsub("Selected Variant: 2", "Selected Variant: 99"))
+		assert.equals(3, item.variant)
+		assert.matches("Selected Variant: 3", item:BuildRaw(), 1, true)
+	end)
+
+	it("keeps ungrouped variants available independently of version", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Implicit Availability Test
+			Gold Ring
+			Version: Legacy
+			Version: Current
+			Variant: Life
+			Variant: Mana
+			Variant: Always Available
+			Implicits: 0
+			{version:1}{variant:1}+10 to maximum Life
+			{version:2}{variant:2}+20 to maximum Mana
+		]])
+		assert.equals(3, item.variant)
+		item.selectedVersion = 1
+		item:NormaliseVariantSelections()
+		assert.equals(3, item.variant)
+		item.variant = 1
+		item:BuildAndParseRaw()
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
 	end)
 
 	it("preserves eligible selections and replaces unavailable selections when changing version", function()
@@ -186,6 +245,28 @@ describe("Versioned item variants", function()
 		assert.equals("Iron Ring", item.baseName)
 	end)
 
+	it("selects a base from independent version and variant dimensions", function()
+		local item = new("Item"):Item([[
+			Rarity: Unique
+			Independent Base Test
+			Version: Legacy
+			Version: Current
+			Selected Version: 2
+			Variant: Gold
+			Variant: Iron
+			Selected Variant: 2
+			{version:1}{variant:1}Gold Ring
+			{version:2}{variant:2}Iron Ring
+			Implicits: 0
+			+10 to maximum Life
+		]])
+		assert.equals("Iron Ring", item.baseName)
+		item.selectedVersion = 1
+		item.variant = 1
+		item:BuildAndParseRaw()
+		assert.equals("Gold Ring", item.baseName)
+	end)
+
 	it("applies grouped rune socket overrides on the first parse", function()
 		local item = new("Item"):Item([[
 			Rarity: Unique
@@ -212,12 +293,14 @@ describe("Versioned item variants", function()
 			end
 		end
 		assert.is_not_nil(raw)
+		assert.is_nil(raw:find("{group:", 1, true))
 		local item = new("Item"):Item(raw)
 		assert.equals(2, item.selectedVersion)
-		assert.same({ 4 }, item.variantGroupSelections)
+		assert.equals(4, item.variant)
+		assert.same({ }, item.variantGroupSelections)
 		assert.equals(0, item.baseModList:Sum("BASE", nil, "ChaosResist"))
 		for radius = 1, 8 do
-			item.variantGroupSelections[1] = radius
+			item.variant = radius
 			item.selectedVersion = 2
 			item:BuildAndParseRaw()
 			local radiusIndex = item.jewelData.radiusIndex
@@ -227,12 +310,37 @@ describe("Versioned item variants", function()
 			assert.equals(radiusIndex, item.jewelData.radiusIndex)
 			assert.equals(radiusIndex, item.jewelRadiusIndex)
 			assert.is_true(item.baseModList:Sum("BASE", nil, "ChaosResist") < 0)
-			assert.same({ radius }, new("Item"):Item(item.raw).variantGroupSelections)
+			assert.equals(radius, new("Item"):Item(item.raw).variant)
 		end
 	end)
 
 	describe("item editor", function()
 		before_each(newBuild)
+
+		it("shows independent version and variant dropdowns", function()
+			build.itemsTab:CreateDisplayItemFromRaw(ungroupedRaw)
+			local controls = build.itemsTab.controls
+			assert.is_true(controls.displayItemVersion:IsShown())
+			assert.is_true(controls.displayItemVariant:IsShown())
+			assert.is_nil(controls.displayItemVariant.variantGroupId)
+			assert.equals(3, #controls.displayItemVariant.list)
+			assert.equals("Mana", controls.displayItemVariant.list[2])
+			controls.displayItemVariant:SetSel(1)
+			assert.equals(1, build.itemsTab.displayItem.variant)
+			assert.equals(10, build.itemsTab.displayItem.baseModList:Sum("BASE", nil, "Life"))
+			controls.displayItemVersion:SetSel(1)
+			assert.equals(1, build.itemsTab.displayItem.variant)
+			assert.equals(10, build.itemsTab.displayItem.baseModList:Sum("BASE", nil, "Life"))
+			assert.is_nil(build.itemsTab.displayItem.raw:find("{group:", 1, true))
+			local tooltip = new("Tooltip"):Tooltip()
+			build.itemsTab:AddItemTooltip(tooltip, build.itemsTab.displayItem, nil, true)
+			local text = ""
+			for _, line in ipairs(tooltip.lines) do
+				text = text .. (line.text or "") .. "\n"
+			end
+			assert.matches("Version: Legacy", text, 1, true)
+			assert.matches("Variant: Life", text, 1, true)
+		end)
 
 		it("updates reusable pools when changing version or selection", function()
 			build.itemsTab:CreateDisplayItemFromRaw(groupedRaw)

--- a/spec/System/TestUniqueVariantExport_spec.lua
+++ b/spec/System/TestUniqueVariantExport_spec.lua
@@ -1,0 +1,107 @@
+describe("Unique variant export", function()
+	-- Run the real exporter against in-memory files without requiring GGPK data
+	-- or overwriting any generated unique databases.
+	local function export(source, base, mods, tables)
+		local outputs = { }
+		local env = setmetatable({
+			table = setmetatable({ containsId = true }, { __index = table }),
+			print = function() end,
+			LoadModule = function(path)
+				if path:find("/Bases/", 1, true) then
+					return function(bases) bases["Gold Ring"] = base end
+				end
+				return path:find("ModItemExclusive", 1, true) and mods or { }
+			end,
+			dat = function(name)
+				return tables and tables[name] or { GetRow = function() end }
+			end,
+			io = {
+				open = function(path, mode)
+					if mode == "r" then
+						return { close = function() end }
+					end
+					local output = { }
+					outputs[path] = output
+					return {
+						write = function(_, ...) table.insert(output, table.concat({ ... })) end,
+						close = function() end,
+					}
+				end,
+				lines = function(path)
+					return (path == "Uniques/ring.lua" and source or ""):gmatch("[^\n]+")
+				end,
+			},
+		}, { __index = _G })
+		setfenv(assert(loadfile("Export/Scripts/uModsToText.lua")), env)()
+		return table.concat(outputs["../Data/Uniques/ring.lua"])
+	end
+
+	it("preserves versions and reusable groups on translated and literal modifiers", function()
+		local result = export([=[return {
+[[
+Export Test
+Gold Ring
+Version: Legacy
+Version: Current
+Variant: Life and Mana
+Variant: Armour
+Selected Variant Group: 1=1
+{version:2}{variant:1}{group:1,2}{fractured}TestMod
+{version:1}{variant:2}{group:1,2}+30 to Armour
+]],
+}]=], { req = { level = 1 } }, {
+			TestMod = { "+10 to maximum Life", "+20 to maximum Mana", modTags = { "life" }, statOrder = { 1, 2 } },
+		})
+		assert.matches("Version: Legacy\nVersion: Current", result, 1, true)
+		assert.matches("Selected Variant Group: 1=1", result, 1, true)
+		assert.matches("{version:2}{variant:1}{group:1,2}{tags:life}{fractured}+10 to maximum Life", result, 1, true)
+		assert.matches("{version:2}{variant:1}{group:1,2}{tags:life}{fractured}+20 to maximum Mana", result, 1, true)
+		assert.matches("{version:1}{variant:2}{group:1,2}+30 to Armour", result, 1, true)
+		local item = new("Item"):Item(assert(loadstring(result))()[1])
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
+	end)
+
+	it("replaces a base implicit with versioned implicit lines", function()
+		local result = export([=[return {
+[[
+Implicit Test
+Gold Ring
+Version: Legacy
+Version: Current
+{version:1}TestImplicit
+{version:2}TestImplicit
+]],
+}]=], { req = { level = 1 }, implicit = "+10 to maximum Life" }, {
+			TestImplicit = { "+10 to maximum Life", modTags = { "life" }, statOrder = { 1 } },
+		})
+		assert.matches("Implicits: 2", result, 1, true)
+		assert.matches("{version:1}{tags:life}+10 to maximum Life", result, 1, true)
+		assert.matches("{version:2}{tags:life}+10 to maximum Life", result, 1, true)
+		local item = new("Item"):Item(assert(loadstring(result))()[1])
+		assert.equals(10, item.baseModList:Sum("BASE", nil, "Life"))
+		assert.equals(2, #item.implicitModLines)
+	end)
+
+	it("preserves selection tags on granted skills", function()
+		local rawMod = { Level = 1 }
+		local result = export([=[return {
+[[
+Skill Test
+Gold Ring
+Version: Current
+Variant: Skill
+{version:1}{variant:1}{group:1}SkillMod
+]],
+}]=], { req = { level = 1 } }, { }, {
+			Mods = { GetRow = function(_, _, name) return name == "SkillMod" and rawMod or nil end },
+			ModGrantedSkills = { GetRow = function()
+				return { SkillGem = {
+					IsSupport = true,
+					GemEffects = { { GrantedEffect = { ActiveSkill = { DisplayName = "Test Skill" } } } },
+				} }
+			end },
+		})
+		assert.matches("Implicits: 1\n{version:1}{variant:1}{group:1}Grants Skill: Test Skill", result, 1, true)
+	end)
+end)

--- a/spec/System/TestUniqueVariantExport_spec.lua
+++ b/spec/System/TestUniqueVariantExport_spec.lua
@@ -84,7 +84,7 @@ Variant: Mana
 		assert.is_nil(result:find("{group:", 1, true))
 		local item = new("Item"):Item(assert(loadstring(result))()[1])
 		assert.equals(2, item.variant)
-		assert.is_true(item.hasUngroupedVariants)
+		assert.is_true(item:HasIndependentVariants())
 		assert.same({ }, item.variantGroups)
 		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
 	end)

--- a/spec/System/TestUniqueVariantExport_spec.lua
+++ b/spec/System/TestUniqueVariantExport_spec.lua
@@ -62,6 +62,33 @@ Selected Variant Group: 1=1
 		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
 	end)
 
+	it("preserves independent versioned variants without adding group tags", function()
+		local result = export([=[return {
+[[
+Independent Variant Export Test
+Gold Ring
+Version: Legacy
+Version: Current
+Selected Variant: 2
+Variant: Life
+Variant: Mana
+{variant:1}TestMod
+{variant:2}+20 to maximum Mana
+]],
+}]=], { req = { level = 1 } }, {
+			TestMod = { "+10 to maximum Life", modTags = { "life" }, statOrder = { 1 } },
+		})
+		assert.matches("Version: Legacy\nVersion: Current", result, 1, true)
+		assert.matches("{variant:1}{tags:life}+10 to maximum Life", result, 1, true)
+		assert.matches("{variant:2}+20 to maximum Mana", result, 1, true)
+		assert.is_nil(result:find("{group:", 1, true))
+		local item = new("Item"):Item(assert(loadstring(result))()[1])
+		assert.equals(2, item.variant)
+		assert.is_true(item.hasUngroupedVariants)
+		assert.same({ }, item.variantGroups)
+		assert.equals(20, item.baseModList:Sum("BASE", nil, "Mana"))
+	end)
+
 	it("replaces a base implicit with versioned implicit lines", function()
 		local result = export([=[return {
 [[

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -301,6 +301,47 @@ local function specToNumber(s)
 	return n and tonumber(n)
 end
 
+local function parseItemSpec(line)
+	local specName, specVal = line:match("^([%a %(%)]+:?): (.+)$")
+	if specName == "Class:" then
+		specName = "Requires Class"
+	elseif not specName then
+		specName, specVal = line:match("^(Requires %a+) (.+)$")
+	end
+	return specName, specVal
+end
+
+local function parseIdSpec(spec, positiveOnly)
+	local ids = { }
+	for id in (spec or ""):gmatch("%d+") do
+		id = tonumber(id)
+		if not positiveOnly or id > 0 then
+			ids[id] = true
+		end
+	end
+	return ids
+end
+
+local variantSelectionSpecNames = {
+	["Version"] = true,
+	["Variant"] = true,
+	["Selected Version"] = true,
+	["Selected Variant Group"] = true,
+	["Selected Variant"] = true,
+}
+
+function ItemClass:HasVariantGroups()
+	return self.variantGroups and next(self.variantGroups) ~= nil or false
+end
+
+function ItemClass:HasIndependentVariants()
+	return self.versionList ~= nil and self.variantList ~= nil and not self:HasVariantGroups()
+end
+
+function ItemClass:UsesVersionedOrGroupedVariants()
+	return self.versionList ~= nil or self:HasVariantGroups()
+end
+
 function ItemClass:IsVariantGroupOptionEligible(groupId, variantId)
 	local group = self.variantGroups and self.variantGroups[groupId]
 	local versions = group and group[variantId]
@@ -337,7 +378,7 @@ function ItemClass:NormaliseVariantSelections()
 	else
 		self.selectedVersion = nil
 	end
-	if self.hasUngroupedVariants then
+	if self:HasIndependentVariants() then
 		self.variant = m_max(1, m_min(#self.variantList, self.variant or #self.variantList))
 	end
 	self.variantGroupSelections = self.variantGroupSelections or { }
@@ -399,7 +440,7 @@ end
 
 local getRangedModList
 -- Parse raw item data and extract item name, base type, quality, and modifiers
-function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
+function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.raw = raw
 	self.name = "?"
 	self.namePrefix = ""
@@ -500,10 +541,79 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 	local implicitLines = 0
 	self.variantList = nil
 	self.versionList = nil
+	-- group ID -> variant ID -> eligible version IDs; version 0 means every version.
+	---@type table<number, table<number, table<number, boolean>>>
 	self.variantGroups = { }
 	self.variantGroupSelections = self.variantGroupSelections or { }
-	self.usesVariantGroups = false
-	self.hasUngroupedVariants = false
+	-- Resolve selection metadata first because tagged base lines can precede it.
+	-- The main parser reuses these parsed tag tables when it builds each ModLine.
+	local selectionTagsByLine = { }
+	for lineIndex, rawLine in ipairs(self.rawLines) do
+		local specName, specVal = parseItemSpec(rawLine)
+		if variantSelectionSpecNames[specName] then
+			if specName == "Version" then
+				self.versionList = self.versionList or { }
+				t_insert(self.versionList, specVal)
+			elseif specName == "Variant" then
+				self.variantList = self.variantList or { }
+				-- This has to be kept for backwards compatibility
+				local _, name = specVal:match("{([%w_]+)}(.+)")
+				t_insert(self.variantList, name or specVal)
+			elseif specName == "Selected Version" then
+				self.selectedVersion = specToNumber(specVal)
+			elseif specName == "Selected Variant Group" then
+				local groupId, variantId = specVal:match("^(%d+)%s*=%s*(%d+)$")
+				if groupId and variantId then
+					self.variantGroupSelections[tonumber(groupId)] = tonumber(variantId)
+				end
+			elseif specName == "Selected Variant" then
+				self.variant = specToNumber(specVal)
+			end
+		end
+
+		local variantSpec = rawLine:match("{variant:([^}]*)}")
+		local versionSpec = rawLine:match("{version:([^}]*)}")
+		local groupSpec = rawLine:match("{group:([^}]*)}")
+		if variantSpec or versionSpec or groupSpec then
+			local selectionTags = {
+				line = rawLine,
+				variantList = variantSpec and parseIdSpec(variantSpec) or nil,
+				versionList = versionSpec and parseIdSpec(versionSpec) or nil,
+				variantGroupList = groupSpec and parseIdSpec(groupSpec, true) or nil,
+			}
+			selectionTagsByLine[lineIndex] = selectionTags
+		end
+	end
+	for _, selectionTags in pairsSortByKey(selectionTagsByLine) do
+		if selectionTags.variantGroupList and (not selectionTags.variantList or not next(selectionTags.variantList)) then
+			ConPrintf("Grouped item line has no variant: %s", selectionTags.line)
+		elseif selectionTags.variantGroupList then
+			for groupId in pairs(selectionTags.variantGroupList) do
+				local group = self.variantGroups[groupId] or { }
+				self.variantGroups[groupId] = group
+				for variantId in pairs(selectionTags.variantList) do
+					if self.variantList and self.variantList[variantId] then
+						local versions = group[variantId] or { }
+						group[variantId] = versions
+						if selectionTags.versionList then
+							for versionId in pairs(selectionTags.versionList) do
+								if self.versionList and self.versionList[versionId] then
+									versions[versionId] = true
+								end
+							end
+						else
+							versions[0] = true
+						end
+					else
+						ConPrintf("Grouped item line references unknown variant %d: %s", variantId, selectionTags.line)
+					end
+				end
+			end
+		end
+	end
+	if self:UsesVersionedOrGroupedVariants() then
+		self:NormaliseVariantSelections()
+	end
 	self.prefixes = { }
 	self.suffixes = { }
 	self.requirements = { }
@@ -516,20 +626,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 	local flaskBuffLines
 	local charmBuffLines
 	local deferJewelRadiusIndexAssignment
-	-- Version headers use the new selection path, while variants without any
-	-- explicit group tags remain a separate, legacy-style selection.
-	local hasExplicitVariantGroups = false
-	for groupSpec in raw:gmatch("{group:([^}]+)}") do
-		for groupId in groupSpec:gmatch("%d+") do
-			if tonumber(groupId) > 0 then
-				hasExplicitVariantGroups = true
-				break
-			end
-		end
-		if hasExplicitVariantGroups then
-			break
-		end
-	end
 	local gameModeStage = "FINDIMPLICIT"
 	local foundExplicit, foundImplicit
 	local linePrefix = ""
@@ -651,14 +747,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 				self.requirements.level = tonumber(levelReq)
 				goto continue
 			end
-			local specName, specVal = line:match("^([%a %(%)]+:?): (.+)$")
-			if specName then
-				if specName == "Class:" then
-					specName = "Requires Class"
-				end
-			else
-				specName, specVal = line:match("^(Requires %a+) (.+)$")
-			end
+			local specName, specVal = parseItemSpec(line)
 			if specName then
 				if specName == "Unique ID" then
 					self.uniqueID = specVal
@@ -708,25 +797,8 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 					end
 				elseif specName == "Limited to" and self.type == "Jewel" then
 					self.limit = specToNumber(specVal)
-				elseif specName == "Version" then
-					if not self.versionList then
-						self.versionList = { }
-					end
-					t_insert(self.versionList, specVal)
-					self.usesVariantGroups = true
-					self.hasUngroupedVariants = self.variantList and not hasExplicitVariantGroups or false
-				elseif specName == "Variant" then
-					if not self.variantList then
-						self.variantList = { }
-					end
-					-- This has to be kept for backwards compatibility
-					local ver, name = specVal:match("{([%w_]+)}(.+)")
-					if ver then
-						t_insert(self.variantList, name)
-					else
-						t_insert(self.variantList, specVal)
-					end
-					self.hasUngroupedVariants = self.versionList and not hasExplicitVariantGroups or false
+				elseif variantSelectionSpecNames[specName] then
+					-- Parsed before item lines so tagged bases and modifiers see the final selection.
 				elseif specName == "Talisman Tier" then
 					self.talismanTier = specToNumber(specVal)
 				elseif specName == "Armour" or specName == "Evasion Rating" or specName == "Evasion" or specName == "Energy Shield" or specName == "Ward" then
@@ -764,19 +836,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 					self.hasAltVariant4 = true
 				elseif specName == "Has Alt Variant Five" then
 					self.hasAltVariant5 = true
-				elseif specName == "Selected Version" then
-					if not normalisedSelections then
-						self.selectedVersion = specToNumber(specVal)
-					end
-					self.usesVariantGroups = true
-				elseif specName == "Selected Variant Group" then
-					local groupId, variantId = specVal:match("^(%d+)%s*=%s*(%d+)$")
-					if not normalisedSelections and groupId and variantId then
-						self.variantGroupSelections[tonumber(groupId)] = tonumber(variantId)
-						self.usesVariantGroups = true
-					end
-				elseif specName == "Selected Variant" then
-					self.variant = specToNumber(specVal)
 				elseif specName == "Selected Alt Variant" then
 					self.variantAlt = specToNumber(specVal)
 				elseif specName == "Selected Alt Variant Two" then
@@ -861,29 +920,15 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 			if not specName or foundExplicit or foundImplicit or lineIsBaseImplicit then
 				---@type ModLine
 				local modLine = { modTags = {} }
+				local selectionTags = selectionTagsByLine[l]
 
 				line = line:gsub("{(%a*):?([^}]*)}", function(k,val)
 					if k == "variant" then
-						modLine.variantList = { }
-						for varId in val:gmatch("%d+") do
-							modLine.variantList[tonumber(varId)] = true
-						end
+						modLine.variantList = selectionTags and selectionTags.variantList or parseIdSpec(val)
 					elseif k == "version" then
-						modLine.versionList = { }
-						for versionId in val:gmatch("%d+") do
-							modLine.versionList[tonumber(versionId)] = true
-						end
-						self.usesVariantGroups = true
+						modLine.versionList = selectionTags and selectionTags.versionList or parseIdSpec(val)
 					elseif k == "group" then
-						modLine.variantGroupList = { }
-						for groupId in val:gmatch("%d+") do
-							groupId = tonumber(groupId)
-							if groupId and groupId > 0 then
-								modLine.variantGroupList[groupId] = true
-								hasExplicitVariantGroups = true
-							end
-						end
-						self.usesVariantGroups = true
+						modLine.variantGroupList = selectionTags and selectionTags.variantGroupList or parseIdSpec(val, true)
 					elseif k == "tags" then
 						for tag in val:gmatch("[%a_]+") do
 							t_insert(modLine.modTags, tag)
@@ -899,34 +944,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 
 					return ""
 				end)
-				if modLine.variantGroupList then
-					if not modLine.variantList then
-						ConPrintf("Grouped item line has no variant: %s", line)
-					else
-						for groupId in pairs(modLine.variantGroupList) do
-							local group = self.variantGroups[groupId] or { }
-							self.variantGroups[groupId] = group
-							for variantId in pairs(modLine.variantList) do
-								if self.variantList and self.variantList[variantId] then
-									local versions = group[variantId] or { }
-									group[variantId] = versions
-									if modLine.versionList then
-										for versionId in pairs(modLine.versionList) do
-											if self.versionList and self.versionList[versionId] then
-												versions[versionId] = true
-											end
-										end
-									else
-										versions[0] = true
-									end
-								else
-									ConPrintf("Grouped item line references unknown variant %d: %s", variantId, line)
-								end
-							end
-						end
-					end
-				end
-
 				line = line:gsub(" %((%l+)%)", function(k)
 					if lineFlags[k] then
 						modLine[k] = true
@@ -1012,12 +1029,10 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 						versionList = modLine.versionList,
 						variantGroupList = modLine.variantGroupList,
 					}
-					if self.usesVariantGroups and self.versionList and not self.selectedVersion then
-						self.selectedVersion = #self.versionList
-					end
 					-- Set the actual base if variant matches or doesn't have variants
-					local baseMatches = self.usesVariantGroups and self:CheckModLineVariant(modLine)
-						or (not self.usesVariantGroups and (not self.variant or not modLine.variantList or modLine.variantList[self.variant]))
+					local usesVersionedOrGroupedVariants = self:UsesVersionedOrGroupedVariants()
+					local baseMatches = usesVersionedOrGroupedVariants and self:CheckModLineVariant(modLine)
+						or (not usesVersionedOrGroupedVariants and (not self.variant or not modLine.variantList or modLine.variantList[self.variant]))
 					if baseMatches then
 						self.baseName = baseName
 						if not (self.rarity == "NORMAL" or self.rarity == "MAGIC") then
@@ -1274,34 +1289,6 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 		::continue::
 		l = l + 1
 	end
-	self.hasUngroupedVariants = self.versionList and self.variantList and not hasExplicitVariantGroups or false
-	if self.usesVariantGroups then
-		-- Resolve selections before inferring runes or applying modifier magnitudes.
-		self:NormaliseVariantSelections()
-		local baseLine = self.baseLines[self.baseName]
-		if not normalisedSelections and (not self.base or baseLine and not self:CheckModLineVariant(baseLine)) then
-			for _, baseLine in pairs(self.baseLines) do
-				if self:CheckModLineVariant(baseLine) then
-					-- A grouped base may precede the rest of its pool. Parse it again
-					-- with the complete, normalised selection to initialise its properties.
-					return self:ParseRaw(raw, rarity, highQuality, true)
-				end
-			end
-		end
-		self.socketedAugmentTypeOverride = nil
-		self.socketedSoulCoreTypes = { }
-		for _, modLines in ipairs({ self.enchantModLines, self.implicitModLines, self.explicitModLines }) do
-			for _, modLine in ipairs(modLines) do
-				if self:CheckModLineVariant(modLine) then
-					if modLine.socketedAugmentTypeOverride then
-						self.socketedAugmentTypeOverride = modLine.socketedAugmentTypeOverride
-					elseif modLine.socketedSoulCoreType then
-						self.socketedSoulCoreTypes[modLine.socketedSoulCoreType] = true
-					end
-				end
-			end
-		end
-	end
 	if self.baseName and self.title then
 		self.name = self.title .. ", " .. self.baseName:gsub(" %(.+%)","")
 	end
@@ -1542,7 +1529,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 		-- apply mod magnitude boost to matching mods
 		if #self.modMagnitudeMods > 0 then
 			for _, modMagnitudeMod in ipairs(self.modMagnitudeMods) do
-				if self.usesVariantGroups and not self:CheckModLineVariant(modMagnitudeMod.sourceLine) then
+				if self:UsesVersionedOrGroupedVariants() and not self:CheckModLineVariant(modMagnitudeMod.sourceLine) then
 					continue
 				end
 				local modLists
@@ -1682,7 +1669,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 			end
 		end
 	end
-	if not self.usesVariantGroups and self.variantList then
+	if not self:UsesVersionedOrGroupedVariants() and self.variantList then
 		self.variant = m_min(#self.variantList, self.variant or #self.variantList)
 		if self.hasAltVariant then
 			self.variantAlt = m_min(#self.variantList, self.variantAlt or #self.variantList)
@@ -1748,6 +1735,7 @@ end
 
 function ItemClass:BuildRaw()
 	local rawLines = { }
+	local usesVersionedOrGroupedVariants = self:UsesVersionedOrGroupedVariants()
 	if self.runeModLines and self.runeModLines[1] then
 		self:ApplySocketedRuneDisplayScalars()
 	end
@@ -1896,9 +1884,9 @@ function ItemClass:BuildRaw()
 		for _, variantName in ipairs(self.variantList) do
 			t_insert(rawLines, "Variant: " .. variantName)
 		end
-		if self.hasUngroupedVariants then
+		if self:HasIndependentVariants() then
 			t_insert(rawLines, "Selected Variant: " .. self.variant)
-		elseif self.usesVariantGroups then
+		elseif usesVersionedOrGroupedVariants then
 			for groupId in pairsSortByKey(self.variantGroups) do
 				local variantId = self.variantGroupSelections[groupId]
 				if variantId then
@@ -1914,23 +1902,23 @@ function ItemClass:BuildRaw()
 				writeModLine(baseLine)
 			end
 		end
-		if not self.usesVariantGroups and self.hasAltVariant then
+		if not usesVersionedOrGroupedVariants and self.hasAltVariant then
 			t_insert(rawLines, "Has Alt Variant: true")
 			t_insert(rawLines, "Selected Alt Variant: " .. self.variantAlt)
 		end
-		if not self.usesVariantGroups and self.hasAltVariant2 then
+		if not usesVersionedOrGroupedVariants and self.hasAltVariant2 then
 			t_insert(rawLines, "Has Alt Variant Two: true")
 			t_insert(rawLines, "Selected Alt Variant Two: " .. self.variantAlt2)
 		end
-		if not self.usesVariantGroups and self.hasAltVariant3 then
+		if not usesVersionedOrGroupedVariants and self.hasAltVariant3 then
 			t_insert(rawLines, "Has Alt Variant Three: true")
 			t_insert(rawLines, "Selected Alt Variant Three: " .. self.variantAlt3)
 		end
-		if not self.usesVariantGroups and self.hasAltVariant4 then
+		if not usesVersionedOrGroupedVariants and self.hasAltVariant4 then
 			t_insert(rawLines, "Has Alt Variant Four: true")
 			t_insert(rawLines, "Selected Alt Variant Four: " .. self.variantAlt4)
 		end
-		if not self.usesVariantGroups and self.hasAltVariant5 then
+		if not usesVersionedOrGroupedVariants and self.hasAltVariant5 then
 			t_insert(rawLines, "Has Alt Variant Five: true")
 			t_insert(rawLines, "Selected Alt Variant Five: " .. self.variantAlt5)
 		end
@@ -2164,7 +2152,7 @@ function ItemClass:Craft()
 end
 
 function ItemClass:CheckModLineVariant(modLine)
-	if self.usesVariantGroups then
+	if self:UsesVersionedOrGroupedVariants() then
 		if modLine.versionList and (not self.selectedVersion or not modLine.versionList[self.selectedVersion]) then
 			return false
 		end
@@ -2180,7 +2168,7 @@ function ItemClass:CheckModLineVariant(modLine)
 			end
 			return false
 		end
-		if self.hasUngroupedVariants and modLine.variantList then
+		if self:HasIndependentVariants() and modLine.variantList then
 			return modLine.variantList[self.variant] or false
 		end
 		return not modLine.variantList
@@ -2195,7 +2183,7 @@ function ItemClass:CheckModLineVariant(modLine)
 end
 
 function ItemClass:GetModLineVariantCount(modLine)
-	if self.usesVariantGroups or not self.allowDuplicateVariants or not modLine.variantList then
+	if self:UsesVersionedOrGroupedVariants() or not self.allowDuplicateVariants or not modLine.variantList then
 		return self:CheckModLineVariant(modLine) and 1 or 0
 	end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -269,17 +269,7 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 	end
 
 	for _,v in pairs(modLines) do
-		local currentVariant = false
-		if v.variantList then
-			for variant, enabled in pairs(v.variantList) do
-				if enabled and variant == self.variant then
-					currentVariant = true
-				end
-			end
-		else
-			currentVariant = true
-		end
-		if not v.disabled and currentVariant then
+		if not v.disabled and self:CheckModLineVariant(v) then
 			if v.line:lower():find(substring) and not v.line:lower():find(substring .. " modifier") then
 				local excluded = false
 				if data.itemTagSpecialExclusionPattern[substring] and data.itemTagSpecialExclusionPattern[substring][itemSlotName] then
@@ -296,7 +286,7 @@ function ItemClass:FindModifierSubstring(substring, itemSlotName)
 			end
 			if data.itemTagSpecial[substring] and data.itemTagSpecial[substring][itemSlotName] then
 				for _, specialMod in ipairs(data.itemTagSpecial[substring][itemSlotName]) do
-					if v.line:lower():find(specialMod:lower()) and (not v.variantList or v.variantList[self.variant]) then
+					if v.line:lower():find(specialMod:lower()) then
 						return true
 					end
 				end
@@ -309,6 +299,76 @@ end
 local function specToNumber(s)
 	local n = s:match("^([%+%-]?[%d%.]+)")
 	return n and tonumber(n)
+end
+
+function ItemClass:IsVariantGroupOptionEligible(groupId, variantId)
+	local group = self.variantGroups and self.variantGroups[groupId]
+	local versions = group and group[variantId]
+	return versions and (versions[0] or self.selectedVersion and versions[self.selectedVersion]) or false
+end
+
+function ItemClass:GetVariantGroupOptions(groupId, excludeSelected)
+	local options = { }
+	if not self.variantGroups or not self.variantGroups[groupId] then
+		return options
+	end
+	local used = { }
+	if excludeSelected then
+		for otherGroupId in pairsSortByKey(self.variantGroups) do
+			if otherGroupId ~= groupId then
+				local variantId = self.variantGroupSelections[otherGroupId]
+				if variantId and self:IsVariantGroupOptionEligible(otherGroupId, variantId) then
+					used[variantId] = true
+				end
+			end
+		end
+	end
+	for variantId = 1, #self.variantList do
+		if self:IsVariantGroupOptionEligible(groupId, variantId) and not used[variantId] then
+			t_insert(options, variantId)
+		end
+	end
+	return options
+end
+
+function ItemClass:NormaliseVariantSelections()
+	if self.versionList and #self.versionList > 0 then
+		self.selectedVersion = m_max(1, m_min(#self.versionList, self.selectedVersion or #self.versionList))
+	else
+		self.selectedVersion = nil
+	end
+	self.variantGroupSelections = self.variantGroupSelections or { }
+	for groupId in pairs(self.variantGroupSelections) do
+		if not self.variantGroups[groupId] then
+			self.variantGroupSelections[groupId] = nil
+		end
+	end
+
+	local used = { }
+	local needsSelection = { }
+	for groupId in pairsSortByKey(self.variantGroups) do
+		if #self:GetVariantGroupOptions(groupId, false) > 0 then
+			local selected = self.variantGroupSelections[groupId]
+			if selected and self:IsVariantGroupOptionEligible(groupId, selected) and not used[selected] then
+				used[selected] = true
+			else
+				t_insert(needsSelection, groupId)
+			end
+		end
+	end
+	for _, groupId in ipairs(needsSelection) do
+		local selected
+		for _, variantId in ipairs(self:GetVariantGroupOptions(groupId, false)) do
+			if not used[variantId] then
+				selected = variantId
+				break
+			end
+		end
+		self.variantGroupSelections[groupId] = selected
+		if selected then
+			used[selected] = true
+		end
+	end
 end
 
 function ItemClass:GetUniqueDBItem()
@@ -336,7 +396,7 @@ end
 
 local getRangedModList
 -- Parse raw item data and extract item name, base type, quality, and modifiers
-function ItemClass:ParseRaw(raw, rarity, highQuality)
+function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 	self.raw = raw
 	self.name = "?"
 	self.namePrefix = ""
@@ -436,6 +496,10 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 	self.modMagnitudeMods = {}
 	local implicitLines = 0
 	self.variantList = nil
+	self.versionList = nil
+	self.variantGroups = { }
+	self.variantGroupSelections = self.variantGroupSelections or { }
+	self.usesVariantGroups = false
 	self.prefixes = { }
 	self.suffixes = { }
 	self.requirements = { }
@@ -626,6 +690,12 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					end
 				elseif specName == "Limited to" and self.type == "Jewel" then
 					self.limit = specToNumber(specVal)
+				elseif specName == "Version" then
+					if not self.versionList then
+						self.versionList = { }
+					end
+					t_insert(self.versionList, specVal)
+					self.usesVariantGroups = true
 				elseif specName == "Variant" then
 					if not self.variantList then
 						self.variantList = { }
@@ -674,6 +744,17 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					self.hasAltVariant4 = true
 				elseif specName == "Has Alt Variant Five" then
 					self.hasAltVariant5 = true
+				elseif specName == "Selected Version" then
+					if not normalisedSelections then
+						self.selectedVersion = specToNumber(specVal)
+					end
+					self.usesVariantGroups = true
+				elseif specName == "Selected Variant Group" then
+					local groupId, variantId = specVal:match("^(%d+)%s*=%s*(%d+)$")
+					if not normalisedSelections and groupId and variantId then
+						self.variantGroupSelections[tonumber(groupId)] = tonumber(variantId)
+						self.usesVariantGroups = true
+					end
 				elseif specName == "Selected Variant" then
 					self.variant = specToNumber(specVal)
 				elseif specName == "Selected Alt Variant" then
@@ -767,6 +848,21 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						for varId in val:gmatch("%d+") do
 							modLine.variantList[tonumber(varId)] = true
 						end
+					elseif k == "version" then
+						modLine.versionList = { }
+						for versionId in val:gmatch("%d+") do
+							modLine.versionList[tonumber(versionId)] = true
+						end
+						self.usesVariantGroups = true
+					elseif k == "group" then
+						modLine.variantGroupList = { }
+						for groupId in val:gmatch("%d+") do
+							groupId = tonumber(groupId)
+							if groupId and groupId > 0 then
+								modLine.variantGroupList[groupId] = true
+							end
+						end
+						self.usesVariantGroups = true
 					elseif k == "tags" then
 						for tag in val:gmatch("[%a_]+") do
 							t_insert(modLine.modTags, tag)
@@ -782,6 +878,33 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 
 					return ""
 				end)
+				if modLine.variantGroupList then
+					if not modLine.variantList then
+						ConPrintf("Grouped item line has no variant: %s", line)
+					else
+						for groupId in pairs(modLine.variantGroupList) do
+							local group = self.variantGroups[groupId] or { }
+							self.variantGroups[groupId] = group
+							for variantId in pairs(modLine.variantList) do
+								if self.variantList and self.variantList[variantId] then
+									local versions = group[variantId] or { }
+									group[variantId] = versions
+									if modLine.versionList then
+										for versionId in pairs(modLine.versionList) do
+											if self.versionList and self.versionList[versionId] then
+												versions[versionId] = true
+											end
+										end
+									else
+										versions[0] = true
+									end
+								else
+									ConPrintf("Grouped item line references unknown variant %d: %s", variantId, line)
+								end
+							end
+						end
+					end
+				end
 
 				line = line:gsub(" %((%l+)%)", function(k)
 					if lineFlags[k] then
@@ -862,9 +985,19 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				end
 				if base then
 					-- Items with variants can have multiple bases
-					self.baseLines[baseName] = { line = baseName, variantList = modLine.variantList }
+					self.baseLines[baseName] = {
+						line = baseName,
+						variantList = modLine.variantList,
+						versionList = modLine.versionList,
+						variantGroupList = modLine.variantGroupList,
+					}
+					if self.usesVariantGroups and self.versionList and not self.selectedVersion then
+						self.selectedVersion = #self.versionList
+					end
 					-- Set the actual base if variant matches or doesn't have variants
-					if not self.variant or not modLine.variantList or modLine.variantList[self.variant] then
+					local baseMatches = self.usesVariantGroups and self:CheckModLineVariant(modLine)
+						or (not self.usesVariantGroups and (not self.variant or not modLine.variantList or modLine.variantList[self.variant]))
+					if baseMatches then
 						self.baseName = baseName
 						if not (self.rarity == "NORMAL" or self.rarity == "MAGIC") then
 							self.title = self.name
@@ -1046,7 +1179,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 							local modType
 							local quality = increaseOrDecrease == "increased" and tonumber(amount) or -tonumber(amount)
 							if modTagsString == "explicit physical and chaos damage" then
-								table.insert(self.modMagnitudeMods, { tags = { "damage" }, anyTags = { "physical", "chaos" }, quality = quality, modType = "explicit" })
+								table.insert(self.modMagnitudeMods, { tags = { "damage" }, anyTags = { "physical", "chaos" }, quality = quality, modType = "explicit", sourceLine = modLine })
 							else
 								-- explicit elemental damage -> tags = {elemental, damage}, modType = explicit
 								for word in (modTagsString .. " "):gmatch("%S+") do
@@ -1058,7 +1191,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 										table.insert(modTags, word)
 									end
 								end
-								table.insert(self.modMagnitudeMods, { tags = modTags, quality = quality, multiplier = multiplier, modType = modType })
+								table.insert(self.modMagnitudeMods, { tags = modTags, quality = quality, multiplier = multiplier, modType = modType, sourceLine = modLine })
 							end
 							break
 						end
@@ -1119,6 +1252,33 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		end
 		::continue::
 		l = l + 1
+	end
+	if self.usesVariantGroups then
+		-- Resolve selections before inferring runes or applying modifier magnitudes.
+		self:NormaliseVariantSelections()
+		local baseLine = self.baseLines[self.baseName]
+		if not normalisedSelections and (not self.base or baseLine and not self:CheckModLineVariant(baseLine)) then
+			for _, baseLine in pairs(self.baseLines) do
+				if self:CheckModLineVariant(baseLine) then
+					-- A grouped base may precede the rest of its pool. Parse it again
+					-- with the complete, normalised selection to initialise its properties.
+					return self:ParseRaw(raw, rarity, highQuality, true)
+				end
+			end
+		end
+		self.socketedAugmentTypeOverride = nil
+		self.socketedSoulCoreTypes = { }
+		for _, modLines in ipairs({ self.enchantModLines, self.implicitModLines, self.explicitModLines }) do
+			for _, modLine in ipairs(modLines) do
+				if self:CheckModLineVariant(modLine) then
+					if modLine.socketedAugmentTypeOverride then
+						self.socketedAugmentTypeOverride = modLine.socketedAugmentTypeOverride
+					elseif modLine.socketedSoulCoreType then
+						self.socketedSoulCoreTypes[modLine.socketedSoulCoreType] = true
+					end
+				end
+			end
+		end
 	end
 	if self.baseName and self.title then
 		self.name = self.title .. ", " .. self.baseName:gsub(" %(.+%)","")
@@ -1360,6 +1520,9 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		-- apply mod magnitude boost to matching mods
 		if #self.modMagnitudeMods > 0 then
 			for _, modMagnitudeMod in ipairs(self.modMagnitudeMods) do
+				if self.usesVariantGroups and not self:CheckModLineVariant(modMagnitudeMod.sourceLine) then
+					continue
+				end
 				local modLists
 				if modMagnitudeMod.modType then
 					modLists = { self[modMagnitudeMod.modType .. "ModLines"] }
@@ -1369,7 +1532,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				for _, mods in ipairs(modLists) do
 					for _, mod in ipairs(mods or {}) do
 						-- avoid scaling variant lines which are not active
-						if mod.variantList and (self:GetModLineVariantCount(mod) == 0) or mod.unscalable then
+						if self:GetModLineVariantCount(mod) == 0 or mod.unscalable then
 							continue
 						end
 						-- Modifiers that grant skills are not affected by modifier magnitude.
@@ -1497,7 +1660,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 			end
 		end
 	end
-	if self.variantList then
+	if not self.usesVariantGroups and self.variantList then
 		self.variant = m_min(#self.variantList, self.variant or #self.variantList)
 		if self.hasAltVariant then
 			self.variantAlt = m_min(#self.variantList, self.variantAlt or #self.variantList)
@@ -1626,6 +1789,16 @@ function ItemClass:BuildRaw()
 	end
 	local function writeModLine(modLine)
 		local line = modLine.line
+		local function prependToAllLines(prefix)
+			line = prefix .. line:gsub("\n", "\n" .. prefix)
+		end
+		local function makeIdSpec(idList)
+			local ids = { }
+			for id in pairsSortByKey(idList) do
+				t_insert(ids, id)
+			end
+			return table.concat(ids, ",")
+		end
 		-- confusingly, in-game rune modifiers DO have the scaling baked into the value, while
 		-- everything else does not. this matches that behaviour in PoB
 		if modLine.augmentType or modLine.rune then
@@ -1671,52 +1844,81 @@ function ItemClass:BuildRaw()
 		if modLine.unscalable then
 			line = "{unscalable}" .. line
 		end
-		if modLine.variantList then
-			local varSpec
-			for varId in pairs(modLine.variantList) do
-				varSpec = (varSpec and varSpec .. "," or "") .. varId
-			end
-			local var = "{variant:" .. varSpec .. "}"
-			line = var .. line:gsub("\n", "\n" .. var) -- Variants that go over 1 line need to have the gsub to fix there being no "variant:" at the start
+		local hasNewSelection = modLine.versionList or modLine.variantGroupList
+		if hasNewSelection and modLine.modTags and #modLine.modTags > 0 then
+			line = "{tags:" .. table.concat(modLine.modTags, ",") .. "}" .. line
 		end
-		if modLine.modTags and #modLine.modTags > 0 then
+		if modLine.variantGroupList then
+			prependToAllLines("{group:" .. makeIdSpec(modLine.variantGroupList) .. "}")
+		end
+		if modLine.variantList then
+			prependToAllLines("{variant:" .. makeIdSpec(modLine.variantList) .. "}")
+		end
+		if modLine.versionList then
+			prependToAllLines("{version:" .. makeIdSpec(modLine.versionList) .. "}")
+		end
+		if not hasNewSelection and modLine.modTags and #modLine.modTags > 0 then
 			line = "{tags:" .. table.concat(modLine.modTags, ",") .. "}" .. line
 		end
 		t_insert(rawLines, line)
+	end
+	if self.versionList then
+		for _, versionName in ipairs(self.versionList) do
+			t_insert(rawLines, "Version: " .. versionName)
+		end
+		if self.selectedVersion then
+			t_insert(rawLines, "Selected Version: " .. self.selectedVersion)
+		end
 	end
 	if self.variantList then
 		for _, variantName in ipairs(self.variantList) do
 			t_insert(rawLines, "Variant: " .. variantName)
 		end
-		t_insert(rawLines, "Selected Variant: " .. self.variant)
+		if self.usesVariantGroups then
+			for groupId in pairsSortByKey(self.variantGroups) do
+				local variantId = self.variantGroupSelections[groupId]
+				if variantId then
+					t_insert(rawLines, "Selected Variant Group: " .. groupId .. "=" .. variantId)
+				end
+			end
+		else
+			t_insert(rawLines, "Selected Variant: " .. self.variant)
+		end
 
-		for _, baseLine in pairs(self.baseLines) do
-			if baseLine.variantList then
+		for _, baseLine in pairs(self.baseLines or { }) do
+			if baseLine.variantList or baseLine.versionList or baseLine.variantGroupList then
 				writeModLine(baseLine)
 			end
 		end
-		if self.hasAltVariant then
+		if not self.usesVariantGroups and self.hasAltVariant then
 			t_insert(rawLines, "Has Alt Variant: true")
 			t_insert(rawLines, "Selected Alt Variant: " .. self.variantAlt)
 		end
-		if self.hasAltVariant2 then
+		if not self.usesVariantGroups and self.hasAltVariant2 then
 			t_insert(rawLines, "Has Alt Variant Two: true")
 			t_insert(rawLines, "Selected Alt Variant Two: " .. self.variantAlt2)
 		end
-		if self.hasAltVariant3 then
+		if not self.usesVariantGroups and self.hasAltVariant3 then
 			t_insert(rawLines, "Has Alt Variant Three: true")
 			t_insert(rawLines, "Selected Alt Variant Three: " .. self.variantAlt3)
 		end
-		if self.hasAltVariant4 then
+		if not self.usesVariantGroups and self.hasAltVariant4 then
 			t_insert(rawLines, "Has Alt Variant Four: true")
 			t_insert(rawLines, "Selected Alt Variant Four: " .. self.variantAlt4)
 		end
-		if self.hasAltVariant5 then
+		if not self.usesVariantGroups and self.hasAltVariant5 then
 			t_insert(rawLines, "Has Alt Variant Five: true")
 			t_insert(rawLines, "Selected Alt Variant Five: " .. self.variantAlt5)
 		end
 		if self.allowDuplicateVariants then
 			t_insert(rawLines, "Allow Duplicate Variants: true")
+		end
+	end
+	if not self.variantList then
+		for _, baseLine in pairs(self.baseLines or { }) do
+			if baseLine.versionList or baseLine.variantGroupList then
+				writeModLine(baseLine)
+			end
 		end
 	end
 	if self.quality then
@@ -1938,6 +2140,24 @@ function ItemClass:Craft()
 end
 
 function ItemClass:CheckModLineVariant(modLine)
+	if self.usesVariantGroups then
+		if modLine.versionList and (not self.selectedVersion or not modLine.versionList[self.selectedVersion]) then
+			return false
+		end
+		if modLine.variantGroupList then
+			if not modLine.variantList then
+				return false
+			end
+			for groupId in pairs(modLine.variantGroupList) do
+				local selectedVariant = self.variantGroupSelections[groupId]
+				if selectedVariant and modLine.variantList[selectedVariant] then
+					return true
+				end
+			end
+			return false
+		end
+		return not modLine.variantList
+	end
 	return not modLine.variantList
 		or modLine.variantList[self.variant]
 		or (self.hasAltVariant and modLine.variantList[self.variantAlt])
@@ -1948,7 +2168,7 @@ function ItemClass:CheckModLineVariant(modLine)
 end
 
 function ItemClass:GetModLineVariantCount(modLine)
-	if not self.allowDuplicateVariants or not modLine.variantList then
+	if self.usesVariantGroups or not self.allowDuplicateVariants or not modLine.variantList then
 		return self:CheckModLineVariant(modLine) and 1 or 0
 	end
 

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -337,6 +337,9 @@ function ItemClass:NormaliseVariantSelections()
 	else
 		self.selectedVersion = nil
 	end
+	if self.hasUngroupedVariants then
+		self.variant = m_max(1, m_min(#self.variantList, self.variant or #self.variantList))
+	end
 	self.variantGroupSelections = self.variantGroupSelections or { }
 	for groupId in pairs(self.variantGroupSelections) do
 		if not self.variantGroups[groupId] then
@@ -500,6 +503,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 	self.variantGroups = { }
 	self.variantGroupSelections = self.variantGroupSelections or { }
 	self.usesVariantGroups = false
+	self.hasUngroupedVariants = false
 	self.prefixes = { }
 	self.suffixes = { }
 	self.requirements = { }
@@ -512,6 +516,20 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 	local flaskBuffLines
 	local charmBuffLines
 	local deferJewelRadiusIndexAssignment
+	-- Version headers use the new selection path, while variants without any
+	-- explicit group tags remain a separate, legacy-style selection.
+	local hasExplicitVariantGroups = false
+	for groupSpec in raw:gmatch("{group:([^}]+)}") do
+		for groupId in groupSpec:gmatch("%d+") do
+			if tonumber(groupId) > 0 then
+				hasExplicitVariantGroups = true
+				break
+			end
+		end
+		if hasExplicitVariantGroups then
+			break
+		end
+	end
 	local gameModeStage = "FINDIMPLICIT"
 	local foundExplicit, foundImplicit
 	local linePrefix = ""
@@ -696,6 +714,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 					end
 					t_insert(self.versionList, specVal)
 					self.usesVariantGroups = true
+					self.hasUngroupedVariants = self.variantList and not hasExplicitVariantGroups or false
 				elseif specName == "Variant" then
 					if not self.variantList then
 						self.variantList = { }
@@ -707,6 +726,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 					else
 						t_insert(self.variantList, specVal)
 					end
+					self.hasUngroupedVariants = self.versionList and not hasExplicitVariantGroups or false
 				elseif specName == "Talisman Tier" then
 					self.talismanTier = specToNumber(specVal)
 				elseif specName == "Armour" or specName == "Evasion Rating" or specName == "Evasion" or specName == "Energy Shield" or specName == "Ward" then
@@ -860,6 +880,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 							groupId = tonumber(groupId)
 							if groupId and groupId > 0 then
 								modLine.variantGroupList[groupId] = true
+								hasExplicitVariantGroups = true
 							end
 						end
 						self.usesVariantGroups = true
@@ -1253,6 +1274,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality, normalisedSelections)
 		::continue::
 		l = l + 1
 	end
+	self.hasUngroupedVariants = self.versionList and self.variantList and not hasExplicitVariantGroups or false
 	if self.usesVariantGroups then
 		-- Resolve selections before inferring runes or applying modifier magnitudes.
 		self:NormaliseVariantSelections()
@@ -1874,7 +1896,9 @@ function ItemClass:BuildRaw()
 		for _, variantName in ipairs(self.variantList) do
 			t_insert(rawLines, "Variant: " .. variantName)
 		end
-		if self.usesVariantGroups then
+		if self.hasUngroupedVariants then
+			t_insert(rawLines, "Selected Variant: " .. self.variant)
+		elseif self.usesVariantGroups then
 			for groupId in pairsSortByKey(self.variantGroups) do
 				local variantId = self.variantGroupSelections[groupId]
 				if variantId then
@@ -2155,6 +2179,9 @@ function ItemClass:CheckModLineVariant(modLine)
 				end
 			end
 			return false
+		end
+		if self.hasUngroupedVariants and modLine.variantList then
+			return modLine.variantList[self.variant] or false
 		end
 		return not modLine.variantList
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -412,6 +412,20 @@ holding Shift will put it in the second.]])
 	-- Section: Variant(s)
 
 	self.controls.displayItemSectionVariant = new("Control"):Control({ "TOPLEFT", self.controls.addDisplayItem, "BOTTOMLEFT" }, { 0, 8, 0, function()
+		if not self.displayItem then
+			return 0
+		end
+		if self.displayItem.usesVariantGroups then
+			local rows = self.displayItem.versionList and #self.displayItem.versionList > 1 and 1 or 0
+			local groups = 0
+			for groupId in pairsSortByKey(self.displayItem.variantGroups) do
+				if groups < 6 and #self.displayItem:GetVariantGroupOptions(groupId, false) > 0 then
+					rows = rows + 1
+					groups = groups + 1
+				end
+			end
+			return rows > 0 and rows * 24 + 4 or 0
+		end
 		if not self.controls.displayItemVariant:IsShown() then
 			return 0
 		end
@@ -422,71 +436,81 @@ holding Shift will put it in the second.]])
 		(self.displayItem.hasAltVariant4 and 24 or 0) +
 		(self.displayItem.hasAltVariant5 and 24 or 0))
 	end})
-	self.controls.displayItemVariant = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemSectionVariant, "TOPLEFT" }, { 0, 0, 300, 20 }, nil, function(index, value)
-		self.displayItem.variant = index
+	self.controls.displayItemVersion = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemSectionVariant, "TOPLEFT" }, { 0, 0, 300, 20 }, nil, function(index, value)
+		self.displayItem.selectedVersion = index
+		self.displayItem:NormaliseVariantSelections()
 		self.displayItem:BuildAndParseRaw()
+		self:UpdateDisplayItemVariantControls()
 		self:UpdateRuneControls()
 		self:UpdateDisplayItemTooltip()
 		self:UpdateDisplayItemRangeLines()
 	end)
+	self.controls.displayItemVersion.maxDroppedWidth = 1000
+	self.controls.displayItemVersion.shown = function()
+		return self.displayItem and self.displayItem.usesVariantGroups
+			and self.displayItem.versionList and #self.displayItem.versionList > 1
+	end
+	self.controls.displayItemVariant = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemSectionVariant, "TOPLEFT" }, { 0, 0, 300, 20 }, nil, function(index, value)
+		self:SelectDisplayItemVariant(index, value, "variant", self.controls.displayItemVariant)
+	end)
+	self.controls.displayItemVariant.y = function()
+		return self.controls.displayItemVersion:IsShown() and 24 or 0
+	end
 	self.controls.displayItemVariant.maxDroppedWidth = 1000
 	self.controls.displayItemVariant.shown = function()
 		return self.displayItem.variantList and #self.displayItem.variantList > 1
 	end
 	self.controls.displayItemAltVariant = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemVariant, "BOTTOMLEFT" }, { 0, 4, 300, 20 }, nil, function(index, value)
-		self.displayItem.variantAlt = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateRuneControls()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
+		self:SelectDisplayItemVariant(index, value, "variantAlt", self.controls.displayItemAltVariant)
 	end)
 	self.controls.displayItemAltVariant.maxDroppedWidth = 1000
 	self.controls.displayItemAltVariant.shown = function()
 		return self.displayItem.hasAltVariant
 	end
 	self.controls.displayItemAltVariant2 = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemAltVariant, "BOTTOMLEFT" }, { 0, 4, 300, 20 }, nil, function(index, value)
-		self.displayItem.variantAlt2 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateRuneControls()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
+		self:SelectDisplayItemVariant(index, value, "variantAlt2", self.controls.displayItemAltVariant2)
 	end)
 	self.controls.displayItemAltVariant2.maxDroppedWidth = 1000
 	self.controls.displayItemAltVariant2.shown = function()
 		return self.displayItem.hasAltVariant2
 	end
 	self.controls.displayItemAltVariant3 = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemAltVariant2, "BOTTOMLEFT" }, { 0, 4, 300, 20 }, nil, function(index, value)
-		self.displayItem.variantAlt3 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateRuneControls()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
+		self:SelectDisplayItemVariant(index, value, "variantAlt3", self.controls.displayItemAltVariant3)
 	end)
 	self.controls.displayItemAltVariant3.maxDroppedWidth = 1000
 	self.controls.displayItemAltVariant3.shown = function()
 		return self.displayItem.hasAltVariant3
 	end
 	self.controls.displayItemAltVariant4 = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemAltVariant3, "BOTTOMLEFT" }, { 0, 4, 300, 20 }, nil, function(index, value)
-		self.displayItem.variantAlt4 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateRuneControls()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
+		self:SelectDisplayItemVariant(index, value, "variantAlt4", self.controls.displayItemAltVariant4)
 	end)
 	self.controls.displayItemAltVariant4.maxDroppedWidth = 1000
 	self.controls.displayItemAltVariant4.shown = function()
 		return self.displayItem.hasAltVariant4
 	end
 	self.controls.displayItemAltVariant5 = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemAltVariant4, "BOTTOMLEFT" }, { 0, 4, 300, 20 }, nil, function(index, value)
-		self.displayItem.variantAlt5 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateRuneControls()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
+		self:SelectDisplayItemVariant(index, value, "variantAlt5", self.controls.displayItemAltVariant5)
 	end)
 	self.controls.displayItemAltVariant5.maxDroppedWidth = 1000
 	self.controls.displayItemAltVariant5.shown = function()
 		return self.displayItem.hasAltVariant5
+	end
+	for _, control in ipairs({
+		self.controls.displayItemVariant,
+		self.controls.displayItemAltVariant,
+		self.controls.displayItemAltVariant2,
+		self.controls.displayItemAltVariant3,
+		self.controls.displayItemAltVariant4,
+		self.controls.displayItemAltVariant5,
+	}) do
+		local legacyShown = control.shown
+		control.shown = function(c)
+			return self.displayItem and (self.displayItem.usesVariantGroups and c.newVariantVisible
+				or not self.displayItem.usesVariantGroups and legacyShown())
+		end
+		control.enabled = function(c)
+			return not self.displayItem or not self.displayItem.usesVariantGroups or c.newVariantEnabled
+		end
 	end
 
 	-- Section: Sockets and Links
@@ -1837,6 +1861,80 @@ function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 	end
 end
 
+function ItemsTabClass:SelectDisplayItemVariant(index, value, legacyField, control)
+	if self.displayItem.usesVariantGroups then
+		if not value or not value.variantId then
+			return
+		end
+		self.displayItem.variantGroupSelections[control.variantGroupId] = value.variantId
+		self.displayItem:NormaliseVariantSelections()
+	else
+		self.displayItem[legacyField] = index
+	end
+	self.displayItem:BuildAndParseRaw()
+	self:UpdateDisplayItemVariantControls()
+	self:UpdateRuneControls()
+	self:UpdateDisplayItemTooltip()
+	self:UpdateDisplayItemRangeLines()
+end
+
+function ItemsTabClass:UpdateDisplayItemVariantControls()
+	local item = self.displayItem
+	local controls = {
+		self.controls.displayItemVariant,
+		self.controls.displayItemAltVariant,
+		self.controls.displayItemAltVariant2,
+		self.controls.displayItemAltVariant3,
+		self.controls.displayItemAltVariant4,
+		self.controls.displayItemAltVariant5,
+	}
+	for _, control in ipairs(controls) do
+		control.newVariantVisible = false
+	end
+	if not item or not item.usesVariantGroups then
+		return
+	end
+
+	self.controls.displayItemVersion.list = item.versionList or { }
+	self.controls.displayItemVersion.selIndex = item.selectedVersion or 1
+	self.controls.displayItemVersion:CheckDroppedWidth(true)
+	local controlIndex = 1
+	for groupId in pairsSortByKey(item.variantGroups) do
+		local eligibleOptions = item:GetVariantGroupOptions(groupId, false)
+		if #eligibleOptions > 0 then
+			local control = controls[controlIndex]
+			if not control then
+				ConPrintf("Item '%s' has more than 6 variant groups", item.name)
+				break
+			end
+			local availableOptions = item:GetVariantGroupOptions(groupId, true)
+			local list = { }
+			local selectedIndex
+			for _, variantId in ipairs(availableOptions) do
+				t_insert(list, {
+					label = item.variantList[variantId],
+					variantId = variantId,
+				})
+				if item.variantGroupSelections[groupId] == variantId then
+					selectedIndex = #list
+				end
+			end
+			if #list == 0 then
+				t_insert(list, {
+					label = "No available variants",
+				})
+			end
+			control.list = list
+			control.selIndex = selectedIndex or 1
+			control.variantGroupId = groupId
+			control.newVariantVisible = true
+			control.newVariantEnabled = #availableOptions > 1
+			control:CheckDroppedWidth(true)
+			controlIndex = controlIndex + 1
+		end
+	end
+end
+
 -- Sets the display item to the given item
 function ItemsTabClass:SetDisplayItem(item)
 	self.displayItem = item
@@ -1845,30 +1943,34 @@ function ItemsTabClass:SetDisplayItem(item)
 		self:UpdateDisplayItemTooltip()
 		self.snapHScroll = "RIGHT"
 
-		self.controls.displayItemVariant.list = item.variantList
-		self.controls.displayItemVariant.selIndex = item.variant
-		self.controls.displayItemVariant:CheckDroppedWidth(true)
-		if item.hasAltVariant then
+		if item.usesVariantGroups then
+			self:UpdateDisplayItemVariantControls()
+		else
+			self.controls.displayItemVariant.list = item.variantList
+			self.controls.displayItemVariant.selIndex = item.variant
+			self.controls.displayItemVariant:CheckDroppedWidth(true)
+		end
+		if not item.usesVariantGroups and item.hasAltVariant then
 			self.controls.displayItemAltVariant.list = item.variantList
 			self.controls.displayItemAltVariant.selIndex = item.variantAlt
 			self.controls.displayItemAltVariant:CheckDroppedWidth(true)
 		end
-		if item.hasAltVariant2 then
+		if not item.usesVariantGroups and item.hasAltVariant2 then
 			self.controls.displayItemAltVariant2.list = item.variantList
 			self.controls.displayItemAltVariant2.selIndex = item.variantAlt2
 			self.controls.displayItemAltVariant2:CheckDroppedWidth(true)
 		end
-		if item.hasAltVariant3 then
+		if not item.usesVariantGroups and item.hasAltVariant3 then
 			self.controls.displayItemAltVariant3.list = item.variantList
 			self.controls.displayItemAltVariant3.selIndex = item.variantAlt3
 			self.controls.displayItemAltVariant3:CheckDroppedWidth(true)
 		end
-		if item.hasAltVariant4 then
+		if not item.usesVariantGroups and item.hasAltVariant4 then
 			self.controls.displayItemAltVariant4.list = item.variantList
 			self.controls.displayItemAltVariant4.selIndex = item.variantAlt4
 			self.controls.displayItemAltVariant4:CheckDroppedWidth(true)
 		end
-		if item.hasAltVariant5 then
+		if not item.usesVariantGroups and item.hasAltVariant5 then
 			self.controls.displayItemAltVariant5.list = item.variantList
 			self.controls.displayItemAltVariant5.selIndex = item.variantAlt5
 			self.controls.displayItemAltVariant5:CheckDroppedWidth(true)
@@ -2914,19 +3016,9 @@ function ItemsTabClass:CorruptDisplayItem() -- todo implement vaal orb new outco
 		local item = new("Item"):Item(self.displayItem:BuildRaw())
 		local offset = 20
 		for i, mod in ipairs(item.explicitModLines) do
-			local variantIds = {}
-			for id, _ in pairs(item.explicitModLines[i].variantList or {}) do
-				t_insert(variantIds, id)
-			end
-			local selectedVariant
-			for _, variantId in ipairs(variantIds) do
-				if item.variant == variantId or item.variantAlt == variantId or item.variantAlt2 == variantId or item.variantAlt3 == variantId or item.variantAlt4 == variantId or item.variantAlt5 == variantId then
-					selectedVariant = true
-				end
-			end
 			-- test if a mod is scalable at all. this will let through mods that scale, but don't actually change within the corrupt range
 			local testScaledLine = itemLib.applyRange(mod.line, mod.range or main.defaultItemAffixQuality, mod.valueScalar or 1, 2)
-			if not (testScaledLine == mod.line) and (#variantIds > 0 and selectedVariant or #variantIds == 0) then
+			if not (testScaledLine == mod.line) and item:CheckModLineVariant(mod) then
 				local label = ""
 				controls["rollRangeValue" .. i] = new("LabelControl"):LabelControl({ "TOPLEFT", nil, "TOPLEFT" }, { 10, 10 + offset, 200, 16 }, "^71.00")
 				controls["rollRangeSlider" .. i] = new("SliderControl"):SliderControl({ "LEFT", controls["rollRangeValue" .. i], "RIGHT" }, { 5, 0, 80, 18 }, function(val)
@@ -3415,7 +3507,21 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 
 	-- Special fields for database items
 	if dbMode then
-		if item.variantList then
+		if item.usesVariantGroups then
+			if item.versionList and item.selectedVersion then
+				tooltip:AddLine(fontSizeBig, "^xFFFF30Version: " .. item.versionList[item.selectedVersion], "FONTIN SC")
+			end
+			local selectedVariants = { }
+			for groupId in pairsSortByKey(item.variantGroups) do
+				local variantId = item.variantGroupSelections[groupId]
+				if variantId and item:IsVariantGroupOptionEligible(groupId, variantId) then
+					t_insert(selectedVariants, item.variantList[variantId])
+				end
+			end
+			if #selectedVariants > 0 then
+				tooltip:AddLine(fontSizeBig, "^xFFFF30Variants: " .. table.concat(selectedVariants, ", "), "FONTIN SC")
+			end
+		elseif item.variantList then
 			if #item.variantList == 1 then
 				tooltip:AddLine(fontSizeBig, "^xFFFF30Variant: "..item.variantList[1], "FONTIN SC")
 			else

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -417,11 +417,15 @@ holding Shift will put it in the second.]])
 		end
 		if self.displayItem.usesVariantGroups then
 			local rows = self.displayItem.versionList and #self.displayItem.versionList > 1 and 1 or 0
-			local groups = 0
-			for groupId in pairsSortByKey(self.displayItem.variantGroups) do
-				if groups < 6 and #self.displayItem:GetVariantGroupOptions(groupId, false) > 0 then
-					rows = rows + 1
-					groups = groups + 1
+			if self.displayItem.hasUngroupedVariants then
+				rows = rows + (#self.displayItem.variantList > 1 and 1 or 0)
+			else
+				local groups = 0
+				for groupId in pairsSortByKey(self.displayItem.variantGroups) do
+					if groups < 6 and #self.displayItem:GetVariantGroupOptions(groupId, false) > 0 then
+						rows = rows + 1
+						groups = groups + 1
+					end
 				end
 			end
 			return rows > 0 and rows * 24 + 4 or 0
@@ -1862,7 +1866,7 @@ function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 end
 
 function ItemsTabClass:SelectDisplayItemVariant(index, value, legacyField, control)
-	if self.displayItem.usesVariantGroups then
+	if self.displayItem.usesVariantGroups and not self.displayItem.hasUngroupedVariants then
 		if not value or not value.variantId then
 			return
 		end
@@ -1898,6 +1902,16 @@ function ItemsTabClass:UpdateDisplayItemVariantControls()
 	self.controls.displayItemVersion.list = item.versionList or { }
 	self.controls.displayItemVersion.selIndex = item.selectedVersion or 1
 	self.controls.displayItemVersion:CheckDroppedWidth(true)
+	if item.hasUngroupedVariants then
+		local control = self.controls.displayItemVariant
+		control.list = item.variantList
+		control.selIndex = item.variant
+		control.variantGroupId = nil
+		control.newVariantVisible = #item.variantList > 1
+		control.newVariantEnabled = #item.variantList > 1
+		control:CheckDroppedWidth(true)
+		return
+	end
 	local controlIndex = 1
 	for groupId in pairsSortByKey(item.variantGroups) do
 		local eligibleOptions = item:GetVariantGroupOptions(groupId, false)
@@ -3511,15 +3525,19 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 			if item.versionList and item.selectedVersion then
 				tooltip:AddLine(fontSizeBig, "^xFFFF30Version: " .. item.versionList[item.selectedVersion], "FONTIN SC")
 			end
-			local selectedVariants = { }
-			for groupId in pairsSortByKey(item.variantGroups) do
-				local variantId = item.variantGroupSelections[groupId]
-				if variantId and item:IsVariantGroupOptionEligible(groupId, variantId) then
-					t_insert(selectedVariants, item.variantList[variantId])
+			if item.hasUngroupedVariants then
+				tooltip:AddLine(fontSizeBig, "^xFFFF30Variant: " .. item.variantList[item.variant], "FONTIN SC")
+			else
+				local selectedVariants = { }
+				for groupId in pairsSortByKey(item.variantGroups) do
+					local variantId = item.variantGroupSelections[groupId]
+					if variantId and item:IsVariantGroupOptionEligible(groupId, variantId) then
+						t_insert(selectedVariants, item.variantList[variantId])
+					end
 				end
-			end
-			if #selectedVariants > 0 then
-				tooltip:AddLine(fontSizeBig, "^xFFFF30Variants: " .. table.concat(selectedVariants, ", "), "FONTIN SC")
+				if #selectedVariants > 0 then
+					tooltip:AddLine(fontSizeBig, "^xFFFF30Variants: " .. table.concat(selectedVariants, ", "), "FONTIN SC")
+				end
 			end
 		elseif item.variantList then
 			if #item.variantList == 1 then

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -415,9 +415,9 @@ holding Shift will put it in the second.]])
 		if not self.displayItem then
 			return 0
 		end
-		if self.displayItem.usesVariantGroups then
+		if self.displayItem:UsesVersionedOrGroupedVariants() then
 			local rows = self.displayItem.versionList and #self.displayItem.versionList > 1 and 1 or 0
-			if self.displayItem.hasUngroupedVariants then
+			if self.displayItem:HasIndependentVariants() then
 				rows = rows + (#self.displayItem.variantList > 1 and 1 or 0)
 			else
 				local groups = 0
@@ -451,7 +451,7 @@ holding Shift will put it in the second.]])
 	end)
 	self.controls.displayItemVersion.maxDroppedWidth = 1000
 	self.controls.displayItemVersion.shown = function()
-		return self.displayItem and self.displayItem.usesVariantGroups
+		return self.displayItem and self.displayItem:UsesVersionedOrGroupedVariants()
 			and self.displayItem.versionList and #self.displayItem.versionList > 1
 	end
 	self.controls.displayItemVariant = new("DropDownControl"):DropDownControl({ "TOPLEFT", self.controls.displayItemSectionVariant, "TOPLEFT" }, { 0, 0, 300, 20 }, nil, function(index, value)
@@ -509,11 +509,16 @@ holding Shift will put it in the second.]])
 	}) do
 		local legacyShown = control.shown
 		control.shown = function(c)
-			return self.displayItem and (self.displayItem.usesVariantGroups and c.newVariantVisible
-				or not self.displayItem.usesVariantGroups and legacyShown())
+			if not self.displayItem then
+				return false
+			end
+			if self.displayItem:UsesVersionedOrGroupedVariants() then
+				return c.newVariantVisible
+			end
+			return legacyShown()
 		end
 		control.enabled = function(c)
-			return not self.displayItem or not self.displayItem.usesVariantGroups or c.newVariantEnabled
+			return not self.displayItem or not self.displayItem:UsesVersionedOrGroupedVariants() or c.newVariantEnabled
 		end
 	end
 
@@ -1866,7 +1871,7 @@ function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 end
 
 function ItemsTabClass:SelectDisplayItemVariant(index, value, legacyField, control)
-	if self.displayItem.usesVariantGroups and not self.displayItem.hasUngroupedVariants then
+	if self.displayItem:HasVariantGroups() then
 		if not value or not value.variantId then
 			return
 		end
@@ -1895,14 +1900,14 @@ function ItemsTabClass:UpdateDisplayItemVariantControls()
 	for _, control in ipairs(controls) do
 		control.newVariantVisible = false
 	end
-	if not item or not item.usesVariantGroups then
+	if not item or not item:UsesVersionedOrGroupedVariants() then
 		return
 	end
 
 	self.controls.displayItemVersion.list = item.versionList or { }
 	self.controls.displayItemVersion.selIndex = item.selectedVersion or 1
 	self.controls.displayItemVersion:CheckDroppedWidth(true)
-	if item.hasUngroupedVariants then
+	if item:HasIndependentVariants() then
 		local control = self.controls.displayItemVariant
 		control.list = item.variantList
 		control.selIndex = item.variant
@@ -1956,35 +1961,36 @@ function ItemsTabClass:SetDisplayItem(item)
 		-- Update the display item controls
 		self:UpdateDisplayItemTooltip()
 		self.snapHScroll = "RIGHT"
+		local usesVersionedOrGroupedVariants = item:UsesVersionedOrGroupedVariants()
 
-		if item.usesVariantGroups then
+		if usesVersionedOrGroupedVariants then
 			self:UpdateDisplayItemVariantControls()
 		else
 			self.controls.displayItemVariant.list = item.variantList
 			self.controls.displayItemVariant.selIndex = item.variant
 			self.controls.displayItemVariant:CheckDroppedWidth(true)
 		end
-		if not item.usesVariantGroups and item.hasAltVariant then
+		if not usesVersionedOrGroupedVariants and item.hasAltVariant then
 			self.controls.displayItemAltVariant.list = item.variantList
 			self.controls.displayItemAltVariant.selIndex = item.variantAlt
 			self.controls.displayItemAltVariant:CheckDroppedWidth(true)
 		end
-		if not item.usesVariantGroups and item.hasAltVariant2 then
+		if not usesVersionedOrGroupedVariants and item.hasAltVariant2 then
 			self.controls.displayItemAltVariant2.list = item.variantList
 			self.controls.displayItemAltVariant2.selIndex = item.variantAlt2
 			self.controls.displayItemAltVariant2:CheckDroppedWidth(true)
 		end
-		if not item.usesVariantGroups and item.hasAltVariant3 then
+		if not usesVersionedOrGroupedVariants and item.hasAltVariant3 then
 			self.controls.displayItemAltVariant3.list = item.variantList
 			self.controls.displayItemAltVariant3.selIndex = item.variantAlt3
 			self.controls.displayItemAltVariant3:CheckDroppedWidth(true)
 		end
-		if not item.usesVariantGroups and item.hasAltVariant4 then
+		if not usesVersionedOrGroupedVariants and item.hasAltVariant4 then
 			self.controls.displayItemAltVariant4.list = item.variantList
 			self.controls.displayItemAltVariant4.selIndex = item.variantAlt4
 			self.controls.displayItemAltVariant4:CheckDroppedWidth(true)
 		end
-		if not item.usesVariantGroups and item.hasAltVariant5 then
+		if not usesVersionedOrGroupedVariants and item.hasAltVariant5 then
 			self.controls.displayItemAltVariant5.list = item.variantList
 			self.controls.displayItemAltVariant5.selIndex = item.variantAlt5
 			self.controls.displayItemAltVariant5:CheckDroppedWidth(true)
@@ -3521,11 +3527,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode, maxWidth)
 
 	-- Special fields for database items
 	if dbMode then
-		if item.usesVariantGroups then
+		if item:UsesVersionedOrGroupedVariants() then
 			if item.versionList and item.selectedVersion then
 				tooltip:AddLine(fontSizeBig, "^xFFFF30Version: " .. item.versionList[item.selectedVersion], "FONTIN SC")
 			end
-			if item.hasUngroupedVariants then
+			if item:HasIndependentVariants() then
 				tooltip:AddLine(fontSizeBig, "^xFFFF30Variant: " .. item.variantList[item.variant], "FONTIN SC")
 			else
 				local selectedVariants = { }

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -17,11 +17,9 @@ Limited to: 1
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
-Has Alt Variant: true
-Selected Variant: 2
-Selected Alt Variant: 6
-Variant: Pre 0.4.0
-Variant: Current
+Version: Pre 0.4.0
+Version: Current
+Selected Variant Group: 1=4
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -32,17 +30,17 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:3}Only affects Passives in Very Small Ring
-{variant:4}Only affects Passives in Small Ring
-{variant:5}Only affects Passives in Medium-Small Ring
-{variant:6}Only affects Passives in Medium Ring
-{variant:7}Only affects Passives in Medium-Large Ring
-{variant:8}Only affects Passives in Large Ring
-{variant:9}Only affects Passives in Very Large Ring
-{variant:10}Only affects Passives in Massive Ring
+{variant:1}{group:1}Only affects Passives in Very Small Ring
+{variant:2}{group:1}Only affects Passives in Small Ring
+{variant:3}{group:1}Only affects Passives in Medium-Small Ring
+{variant:4}{group:1}Only affects Passives in Medium Ring
+{variant:5}{group:1}Only affects Passives in Medium-Large Ring
+{variant:6}{group:1}Only affects Passives in Large Ring
+{variant:7}{group:1}Only affects Passives in Very Large Ring
+{variant:8}{group:1}Only affects Passives in Massive Ring
 Passives in Radius can be Allocated without being connected to your tree
 -(20-5)% to all Elemental Resistances
-{variant:1}-(23-3)% to Chaos Resistance
+{version:1}-(23-3)% to Chaos Resistance
 ]],[[
 Grand Spectrum
 Ruby

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -19,7 +19,7 @@ Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
 Version: Pre 0.4.0
 Version: Current
-Selected Variant Group: 1=4
+Selected Variant: 4
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -30,14 +30,14 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:1}{group:1}Only affects Passives in Very Small Ring
-{variant:2}{group:1}Only affects Passives in Small Ring
-{variant:3}{group:1}Only affects Passives in Medium-Small Ring
-{variant:4}{group:1}Only affects Passives in Medium Ring
-{variant:5}{group:1}Only affects Passives in Medium-Large Ring
-{variant:6}{group:1}Only affects Passives in Large Ring
-{variant:7}{group:1}Only affects Passives in Very Large Ring
-{variant:8}{group:1}Only affects Passives in Massive Ring
+{variant:1}Only affects Passives in Very Small Ring
+{variant:2}Only affects Passives in Small Ring
+{variant:3}Only affects Passives in Medium-Small Ring
+{variant:4}Only affects Passives in Medium Ring
+{variant:5}Only affects Passives in Medium-Large Ring
+{variant:6}Only affects Passives in Large Ring
+{variant:7}Only affects Passives in Very Large Ring
+{variant:8}Only affects Passives in Massive Ring
 Passives in Radius can be Allocated without being connected to your tree
 -(20-5)% to all Elemental Resistances
 {version:1}-(23-3)% to Chaos Resistance

--- a/src/Export/Scripts/uModsToText.lua
+++ b/src/Export/Scripts/uModsToText.lua
@@ -170,7 +170,9 @@ for _, name in ipairs(itemTypes) do
 			uniqueReqLevel = 0
 		elseif not specName or (sourceImplicitLines and sourceImplicitLines > 0) then
 			local prefix = ""
+			local versionString = line:match("({version:[%d,]+})")
 			local variantString = line:match("({variant:[%d,]+})")
+			local groupString = line:match("({group:[%d,]+})")
 			local fractured = line:match("({fractured})") or ""
 			local modName, legacy = stripLineTags(line):match("^([%a%d_]+)([%[%]-,%d]*)$")
 			local mod = base and (uniqueMods[modName] or modVeiled[modName])
@@ -188,9 +190,7 @@ for _, name in ipairs(itemTypes) do
 				grantedSkillLine = "Grants Skill: "..(naturalMaxLevel == 1 and "" or "Level (1-"..naturalMaxLevel..") ")..skillName
 			end
 			local isSourceImplicit = sourceImplicitLines and sourceImplicitLines > 0
-			if variantString then
-				prefix = prefix ..variantString
-			end
+			prefix = prefix .. (versionString or "") .. (variantString or "") .. (groupString or "")
 			if mod then
 				modLines = modLines + 1
 				prefix = prefix..(mod.unscalable and "{unscalable}" or "")
@@ -226,8 +226,8 @@ for _, name in ipairs(itemTypes) do
 				end 
 				for i, line in ipairs(legacyMod or mod) do
 					local order = math.floor(mod.statOrder[i])
-					local variantImplicitLines = variantString and variantBaseImplicitLines[modName]
-					if variantString and not variantImplicitLines and base.implicit then
+					local variantImplicitLines = (versionString or variantString) and variantBaseImplicitLines[modName]
+					if (versionString or variantString) and not variantImplicitLines and base.implicit then
 						for baseLine in base.implicit:gmatch("[^\n]+") do
 							if stripLineTags(baseLine) == stripLineTags(line) then
 								variantImplicitLines = { }

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -17,7 +17,7 @@ Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
 Version: Pre 0.4.0
 Version: Current
-Selected Variant Group: 1=4
+Selected Variant: 4
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -28,14 +28,14 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:1}{group:1}Only affects Passives in Very Small Ring
-{variant:2}{group:1}Only affects Passives in Small Ring
-{variant:3}{group:1}Only affects Passives in Medium-Small Ring
-{variant:4}{group:1}Only affects Passives in Medium Ring
-{variant:5}{group:1}Only affects Passives in Medium-Large Ring
-{variant:6}{group:1}Only affects Passives in Large Ring
-{variant:7}{group:1}Only affects Passives in Very Large Ring
-{variant:8}{group:1}Only affects Passives in Massive Ring
+{variant:1}Only affects Passives in Very Small Ring
+{variant:2}Only affects Passives in Small Ring
+{variant:3}Only affects Passives in Medium-Small Ring
+{variant:4}Only affects Passives in Medium Ring
+{variant:5}Only affects Passives in Medium-Large Ring
+{variant:6}Only affects Passives in Large Ring
+{variant:7}Only affects Passives in Very Large Ring
+{variant:8}Only affects Passives in Massive Ring
 JewelUniqueAllocateDisconnectedPassives
 UniqueAllResistances12
 {version:1}UniqueChaosResist18

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -15,11 +15,9 @@ Limited to: 1
 Controlled Metamorphosis
 Diamond
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
-Has Alt Variant: true
-Selected Variant: 2
-Selected Alt Variant: 6
-Variant: Pre 0.4.0
-Variant: Current
+Version: Pre 0.4.0
+Version: Current
+Selected Variant Group: 1=4
 Variant: Very Small Ring
 Variant: Small Ring
 Variant: Medium-Small Ring
@@ -30,17 +28,17 @@ Variant: Very Large Ring
 Variant: Massive Ring
 Limited to: 1
 Radius: Variable
-{variant:3}Only affects Passives in Very Small Ring
-{variant:4}Only affects Passives in Small Ring
-{variant:5}Only affects Passives in Medium-Small Ring
-{variant:6}Only affects Passives in Medium Ring
-{variant:7}Only affects Passives in Medium-Large Ring
-{variant:8}Only affects Passives in Large Ring
-{variant:9}Only affects Passives in Very Large Ring
-{variant:10}Only affects Passives in Massive Ring
+{variant:1}{group:1}Only affects Passives in Very Small Ring
+{variant:2}{group:1}Only affects Passives in Small Ring
+{variant:3}{group:1}Only affects Passives in Medium-Small Ring
+{variant:4}{group:1}Only affects Passives in Medium Ring
+{variant:5}{group:1}Only affects Passives in Medium-Large Ring
+{variant:6}{group:1}Only affects Passives in Large Ring
+{variant:7}{group:1}Only affects Passives in Very Large Ring
+{variant:8}{group:1}Only affects Passives in Massive Ring
 JewelUniqueAllocateDisconnectedPassives
 UniqueAllResistances12
-{variant:1}UniqueChaosResist18
+{version:1}UniqueChaosResist18
 ]],[[
 Grand Spectrum
 Ruby


### PR DESCRIPTION
### Description of the problem being solved:
Port PathOfBuildingCommunity/PathOfBuilding commit
89d8239bc50b224a6689b91a6a446fa8b549e04d (PR #10105).

Adds a new way to export Uniques so that the version is now it's own group seperate from the variants that can exist
Also adds support for groups on a unique so you can have a dropdown only show a limit pool of mods.
e.g. Prefix pool and suffix pool

This should be less confusing for users and makes it clearer for us which pools of mods are possible together and version related

### Before screenshot:
<img width="561" height="390" alt="image" src="https://github.com/user-attachments/assets/e73831db-7179-4fd7-bdd2-cd9fc05797b5" />

### After screenshot:
<img width="569" height="379" alt="image" src="https://github.com/user-attachments/assets/8b42670c-4cad-43e6-af4e-e6228c4d89d2" />
