### PR TITLE
Fix Bringer of Rain not importing off hand Shield

### DIFF
--- a/spec/System/TestImportReimport_spec.lua
+++ b/spec/System/TestImportReimport_spec.lua
@@ -238,6 +238,25 @@ Fireball 20/0  1
 		assert.are.equal(0, build.itemsTab.slots["Gloves Jewel Socket 2"].selItemId)
 	end)
 
+	it("keeps an imported shield equipped with Bringer of Rain and a two-handed mace", function()
+		build.importTab.controls.charImportItemsClearItems.state = true
+		build.importTab.controls.charImportItemsClearSkills.state = true
+
+		local shield = makeImportItem("Glacial Fortress", "Offhand2", "test-import-shield")
+		local weapon = makeImportItem("Ironwood Greathammer", "Weapon2", "test-import-two-handed-mace")
+		local helmet = makeImportItem("Decorated Helm", "Helm", "test-import-bringer-of-rain")
+		helmet.frameType = 3
+		helmet.name = "The Bringer of Rain"
+		helmet.explicitMods = {
+			"You can wield Two-Handed Axes, Maces and Swords in one hand",
+		}
+
+		build.importTab:ImportItemsAndSkills(buildImportPayload({ shield, weapon, helmet }, {}))
+
+		assert.are_not.equal(0, build.itemsTab.slots["Weapon 1 Swap"].selItemId)
+		assert.are_not.equal(0, build.itemsTab.slots["Weapon 2 Swap"].selItemId)
+	end)
+
 	it("uses unique database and rune levels when importing unique items from account data", function()
 		while main.uniqueDB.loading do
 			runCallback("OnFrame")

--- a/spec/System/TestImportReimport_spec.lua
+++ b/spec/System/TestImportReimport_spec.lua
@@ -250,11 +250,16 @@ Fireball 20/0  1
 		helmet.explicitMods = {
 			"You can wield Two-Handed Axes, Maces and Swords in one hand",
 		}
+		local maceStrike = makeGemEntry(false, "Mace Strike", 20)
+		maceStrike.weaponRequirements = {
+			{ name = "", values = { { "[Mace|Two Hand Mace]", 0 } } },
+		}
 
-		build.importTab:ImportItemsAndSkills(buildImportPayload({ shield, weapon, helmet }, {}))
+		build.importTab:ImportItemsAndSkills(buildImportPayload({ shield, weapon, helmet }, { maceStrike }))
 
 		assert.are_not.equal(0, build.itemsTab.slots["Weapon 1 Swap"].selItemId)
 		assert.are_not.equal(0, build.itemsTab.slots["Weapon 2 Swap"].selItemId)
+		assert.are.equal("Metadata/Items/Gems/SkillGemPlayerDefault2HMace", build.skillsTab.socketGroupList[1].gemList[1].gemId)
 	end)
 
 	it("uses unique database and rune levels when importing unique items from account data", function()

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1144,11 +1144,15 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 			gemId = "Metadata/Items/Gems/SkillGemSummonBeast"
 		end
 
-		-- This could be done better with the character melee skills data at some point.
+		-- Prefer the character skill requirement, then fall back to equipped items for older responses and dual wielding.
 		if typeLine:match("Mace Strike") then
+			local weaponRequirement = skillData.weaponRequirements and skillData.weaponRequirements[1]
+			local requiredWeaponType = weaponRequirement and escapeGGGString(weaponRequirement.values[1][1])
 			local weapon1Sel = self.build.itemsTab.activeItemSet["Weapon 1"] and self.build.itemsTab.activeItemSet["Weapon 1"].selItemId or 0
 			local weapon2Sel = self.build.itemsTab.activeItemSet["Weapon 2"] and self.build.itemsTab.activeItemSet["Weapon 2"].selItemId or 0
-			if weapon2Sel == 0 then
+			if requiredWeaponType == "Two Hand Mace" then
+				gemId = "Metadata/Items/Gems/SkillGemPlayerDefault2HMace"
+			elseif weapon2Sel == 0 then
 				if weapon1Sel == 0 or self.build.itemsTab.items[weapon1Sel].base.type == "One Hand Mace" then -- Facebreaker uses single handed mace strike
 					gemId = "Metadata/Items/Gems/SkillGemPlayerDefault1HMace"
 				elseif self.build.itemsTab.items[weapon1Sel].base.type == "Two Hand Mace" then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1318,6 +1318,7 @@ function ImportTabClass:ImportItemsAndSkills(charData)
 	if mainSkillEmpty then
 		self.build.mainSocketGroup = self:GuessMainSocketGroup()
 	end
+	self.build.calcsTab:BuildOutput()
 	self.build.itemsTab:PopulateSlots()
 	self.build.itemsTab:AddUndoState()
 	self.build.skillsTab:AddUndoState()


### PR DESCRIPTION
### Description of the problem being solved:
When you use the Bringer of Rain helmet, it allows you to equip a Two Handed weapon in your main hand and still have a shield in your off hand
The shield would not be equipped on import because the mod on the helmet wasn't checked until later
Also fixes an issue where the import wasn't using the correct Mace Strike skill

### Link to a build that showcases this PR:
https://poe.ninja/poe2/builds/runesofaldur/character/rabiescow-2503/RABIESCOW?i=0&search=items%3DThe%2BBringer%2Bof%2BRain

### Before screenshot:
<img width="430" height="51" alt="image" src="https://github.com/user-attachments/assets/3b9bc463-7101-4d93-b7be-3c8a6fc0b758" />

### After screenshot:
<img width="418" height="51" alt="image" src="https://github.com/user-attachments/assets/950b17d1-2dd5-4540-bc46-b0552e777888" />