### PR TITLE
Added support for Decree of Loyalty mods

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6982,8 +6982,7 @@ c["Consume all Rage when Shapeshifting to Human form to recover 1% of maximum li
 c["Consumes Frenzy Charges on use"]={nil,"Consumes Frenzy Charges on use "}
 c["Consumes a Void Charge to Trigger Level 20 Void Shot when you fire Arrows with a Non-Triggered Skill"]={{},nil}
 c["Consuming Glory grants you 3% increased Attack damage per Glory consumed for 6 seconds, up to 60%"]={nil,"Consuming Glory grants you 3% increased Attack damage per Glory consumed for 6 seconds, up to 60% "}
-c["Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0%"]={nil,"Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0% "}
-c["Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0% Defend with 200% of Armour while you have Energy Shield"]={nil,"Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0% Defend with 200% of Armour while you have Energy Shield "}
+c["Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0%"]={{[1]={[1]={stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeConvertToArmour",type="BASE",value=1},[2]={[1]={stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeGainAsArmour",type="BASE",value=1}},nil}
 c["Convert 100% of Fire Damage with Mace Skills to Cold Damage"]={nil,"Convert 100% of Fire Damage with Mace Skills to Cold Damage "}
 c["Convert 100% of maximum Energy Shield to maximum Divinity"]={nil,"Convert 100% of maximum Energy Shield to maximum Divinity "}
 c["Convert 100% of maximum Energy Shield to maximum Divinity 100% increased maximum Divinity"]={nil,"Convert 100% of maximum Energy Shield to maximum Divinity 100% increased maximum Divinity "}
@@ -7183,13 +7182,12 @@ c["Defend against Hits as though you had 1% more Armour per 1% current Energy Sh
 c["Defend with 120% of Armour against Projectile Attacks"]={nil,"Defend with 120% of Armour against Projectile Attacks "}
 c["Defend with 120% of Armour while not on Low Energy Shield"]={{[1]={[1]={neg=true,type="Condition",var="LowEnergyShield"},flags=0,keywordFlags=0,name="ArmourDefense",source="Armour and Energy Shield Mastery",type="MAX",value=20}},nil}
 c["Defend with 150% of Armour against Hits from Enemies that are further than 6m away"]={nil,"Defend with 150% of Armour against Hits from Enemies that are further than 6m away "}
-c["Defend with 175% of Armour while you have Energy Shield"]={nil,"Defend with 175% of Armour while you have Energy Shield "}
+c["Defend with 175% of Armour while you have Energy Shield"]={{[1]={[1]={type="Condition",var="HaveEnergyShield"},flags=0,keywordFlags=0,name="ArmourDefense",type="MAX",value=75}},nil}
 c["Defend with 200% of Armour"]={{[1]={flags=0,keywordFlags=0,name="ArmourDefense",type="MAX",value=100}},nil}
 c["Defend with 200% of Armour against Critical Hits"]={nil,"Defend with 200% of Armour against Critical Hits "}
 c["Defend with 200% of Armour against Critical Hits +15 to Strength"]={nil,"Defend with 200% of Armour against Critical Hits +15 to Strength "}
 c["Defend with 200% of Armour during effect"]={{[1]={flags=0,keywordFlags=0,name="ArmourDefense",type="MAX",value=100}},nil}
-c["Defend with 200% of Armour while you have Energy Shield"]={nil,"Defend with 200% of Armour while you have Energy Shield "}
-c["Defend with 200% of Armour while you have Energy Shield Damage over Time cannot bypass your Energy Shield"]={nil,"Defend with 200% of Armour while you have Energy Shield Damage over Time cannot bypass your Energy Shield "}
+c["Defend with 200% of Armour while you have Energy Shield"]={{[1]={[1]={type="Condition",var="HaveEnergyShield"},flags=0,keywordFlags=0,name="ArmourDefense",type="MAX",value=100}},nil}
 c["Deflected Hits cannot inflict Bleeding on you"]={nil,"Deflected Hits cannot inflict Bleeding on you "}
 c["Deflected Hits cannot inflict Maim on you"]={nil,"Deflected Hits cannot inflict Maim on you "}
 c["Deflected Hits cannot inflict Maim on you Deflected Hits cannot inflict Bleeding on you"]={nil,"Deflected Hits cannot inflict Maim on you Deflected Hits cannot inflict Bleeding on you "}
@@ -10003,6 +10001,5 @@ c["you Shapeshift to an Animal form"]={nil,"you Shapeshift to an Animal form "}
 c["you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift"]={nil,"you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift "}
 c["your maximum number of Power Charges"]={nil,"your maximum number of Power Charges "}
 c["your maximum number of Power Charges +1 to Maximum Power Charges"]={nil,"your maximum number of Power Charges +1 to Maximum Power Charges "}
-end)();(function()
 end)();
 return c

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6982,7 +6982,7 @@ c["Consume all Rage when Shapeshifting to Human form to recover 1% of maximum li
 c["Consumes Frenzy Charges on use"]={nil,"Consumes Frenzy Charges on use "}
 c["Consumes a Void Charge to Trigger Level 20 Void Shot when you fire Arrows with a Non-Triggered Skill"]={{},nil}
 c["Consuming Glory grants you 3% increased Attack damage per Glory consumed for 6 seconds, up to 60%"]={nil,"Consuming Glory grants you 3% increased Attack damage per Glory consumed for 6 seconds, up to 60% "}
-c["Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0%"]={{[1]={[1]={stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeConvertToArmour",type="BASE",value=1},[2]={[1]={stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeGainAsArmour",type="BASE",value=1}},nil}
+c["Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0%"]={{[1]={[1]={div=1,stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeConvertToArmour",type="BASE",value=1},[2]={[1]={div=1,stat="ChaosResist",type="PerStat"},flags=0,keywordFlags=0,name="LifeGainAsArmour",type="BASE",value=1}},nil}
 c["Convert 100% of Fire Damage with Mace Skills to Cold Damage"]={nil,"Convert 100% of Fire Damage with Mace Skills to Cold Damage "}
 c["Convert 100% of maximum Energy Shield to maximum Divinity"]={nil,"Convert 100% of maximum Energy Shield to maximum Divinity "}
 c["Convert 100% of maximum Energy Shield to maximum Divinity 100% increased maximum Divinity"]={nil,"Convert 100% of maximum Energy Shield to maximum Divinity 100% increased maximum Divinity "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6311,10 +6311,10 @@ local specialModList = {
 	} end,
 	["you can socket an additional copy of each lineage support gem, in different skills"] = { mod("MaxLineageCount", "BASE", 1) },
 	["you can socket (%d+) additional copies of each lineage support gem, in different skills"] = function(num) return { mod("MaxLineageCount", "BASE", num) } end,
-    ["convert 1%% of maximum life to twice as much armour per 1%% chaos resistance above 0%%"] = { 
-		mod("LifeConvertToArmour", "BASE", 1, { type = "PerStat", stat = "ChaosResist"}),
-		mod("LifeGainAsArmour", "BASE", 1, { type = "PerStat", stat = "ChaosResist"})
-	},
+	["convert (%d+)%% of maximum life to twice as much armour per ([%d%.]+)%% chaos resistance above 0%%"] = function(life, _, res) return {
+		mod("LifeConvertToArmour", "BASE", tonumber(life), { type = "PerStat", stat = "ChaosResist", div = tonumber(res)}),
+		mod("LifeGainAsArmour", "BASE", tonumber(life), { type = "PerStat", stat = "ChaosResist", div = tonumber(res)})
+	} end,
 	-- handled in item parsing
 	["%d+%% [ir][ne][cd][ru][ec][ae][sd]e?d? ?[%a%s]* modifier magnitudes"] = {},
 	["%d+%% [ir][ne][cd][ru][ec][ae][sd]e?d? effect of [sp][ur][fe]fixes"] = {},

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2669,6 +2669,9 @@ local specialModList = {
 	["defend with (%d+)%% of armour while not on low energy shield"] = function(num) return {
 		mod("ArmourDefense", "MAX", num - 100, "Armour and Energy Shield Mastery", { type = "Condition", var = "LowEnergyShield", neg = true }),
 	} end,
+	["defend with (%d+)%% of armour while you have energy shield"] = function(num) return {
+		mod("ArmourDefense", "MAX", num - 100, { type = "Condition", var = "HaveEnergyShield" }),
+	} end,
 	["(%d+)%% increased armour and energy shield from equipped body armour if equipped helmet, gloves and boots all have armour and energy shield"] = function(num) return {
 		mod("Body ArmourESAndArmour", "INC", num,
 			{ type = "StatThreshold", stat = "ArmourOnGloves", threshold = 1},
@@ -6308,6 +6311,10 @@ local specialModList = {
 	} end,
 	["you can socket an additional copy of each lineage support gem, in different skills"] = { mod("MaxLineageCount", "BASE", 1) },
 	["you can socket (%d+) additional copies of each lineage support gem, in different skills"] = function(num) return { mod("MaxLineageCount", "BASE", num) } end,
+    ["convert 1%% of maximum life to twice as much armour per 1%% chaos resistance above 0%%"] = { 
+		mod("LifeConvertToArmour", "BASE", 1, { type = "PerStat", stat = "ChaosResist"}),
+		mod("LifeGainAsArmour", "BASE", 1, { type = "PerStat", stat = "ChaosResist"})
+	},
 	-- handled in item parsing
 	["%d+%% [ir][ne][cd][ru][ec][ae][sd]e?d? ?[%a%s]* modifier magnitudes"] = {},
 	["%d+%% [ir][ne][cd][ru][ec][ae][sd]e?d? effect of [sp][ur][fe]fixes"] = {},

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -6311,7 +6311,7 @@ local specialModList = {
 	} end,
 	["you can socket an additional copy of each lineage support gem, in different skills"] = { mod("MaxLineageCount", "BASE", 1) },
 	["you can socket (%d+) additional copies of each lineage support gem, in different skills"] = function(num) return { mod("MaxLineageCount", "BASE", num) } end,
-	["convert (%d+)%% of maximum life to twice as much armour per ([%d%.]+)%% chaos resistance above 0%%"] = function(life, _, res) return {
+	["convert ([%d%.]+)%% of maximum life to twice as much armour per ([%d%.]+)%% chaos resistance above 0%%"] = function(life, _, res) return {
 		mod("LifeConvertToArmour", "BASE", tonumber(life), { type = "PerStat", stat = "ChaosResist", div = tonumber(res)}),
 		mod("LifeGainAsArmour", "BASE", tonumber(life), { type = "PerStat", stat = "ChaosResist", div = tonumber(res)})
 	} end,


### PR DESCRIPTION
Add support for the following Decree of Loyalty unique modifiers:
* Convert 1% of maximum Life to twice as much Armour per 1% Chaos Resistance above 0%
* Defend with (150-200)% of Armour while you have Energy Shield

I left the final "Damage over time cannot bypass Energy Shield" modifier unimplemented because I am not  sure how to handle it.

### Steps taken to verify a working solution:
- Verified that life and armour values match in-game values on several test characters, including one with more than 100% life converted to other stats.

### Before screenshot:
<img width="652" height="365" alt="20260831_19h20m53s_grim" src="https://github.com/user-attachments/assets/3b81755d-a8f3-4fc8-a4c8-0ab57984ab93" />

### After screenshot:
<img width="647" height="391" alt="20260831_19h34m48s_grim" src="https://github.com/user-attachments/assets/35f60301-79f8-4b55-8f1d-5c8c30355700" />
<img width="507" height="37" alt="20260831_19h34m19s_grim" src="https://github.com/user-attachments/assets/398114cf-e912-4dab-b364-46f5764a3657" />
<img width="473" height="55" alt="20260831_19h34m09s_grim" src="https://github.com/user-attachments/assets/832f4ff8-f7ba-4b3f-bfe8-a189f7408e98" />

