### PR TITLE
Fix a bunch of unique export source files

### DIFF
--- a/spec/System/TestItemParse_spec.lua
+++ b/spec/System/TestItemParse_spec.lua
@@ -1003,7 +1003,7 @@ describe("TestItemParse", function()
 
 	it("parses Atziri's Splendour soul core socket types", function()
 		local item = new("Item"):Item(data.uniques.body[1])
-		item.variant = 1 -- Helmet
+		item.variantGroupSelections[1] = 1 -- Helmet
 		item:BuildModList()
 
 		assert.is_true(item.socketedSoulCoreTypes["helmet"])

--- a/spec/System/TestItemsTab_spec.lua
+++ b/spec/System/TestItemsTab_spec.lua
@@ -662,8 +662,9 @@ Ruby]])
 			it("uses variant socket types for valid augments", function ()
 				for _, itemRaw in ipairs({ data.uniques.belt[6], data.uniques.body[1] }) do
 					local item = new("Item"):Item(itemRaw)
-					item.variant = 1 -- Helmet
-					item:BuildModList()
+					build.itemsTab:SetDisplayItem(item)
+					build.itemsTab.controls.displayItemVariant:SetSel(1) -- Helmet
+					item = build.itemsTab.displayItem
 
 					local foundHelmetSoulCore = false
 					for _, rune in ipairs(build.itemsTab:GetValidRunesForItem(item)) do
@@ -710,11 +711,15 @@ Ruby]])
 
 			it("refreshes valid augments when the item variant changes", function ()
 				local item = new("Item"):Item(data.uniques.body[1])
-				item.variant = 3 -- Boots
+				item.variantGroupSelections[1] = 3 -- Boots
 				item:BuildModList()
 				build.itemsTab:SetDisplayItem(item)
+				assert.is_true(build.itemsTab.displayItem.socketedSoulCoreTypes["boots"])
+				assert.is_nil(build.itemsTab.displayItem.socketedSoulCoreTypes["helmet"])
 
 				build.itemsTab.controls.displayItemVariant:SetSel(1) -- Helmet
+				assert.is_true(build.itemsTab.displayItem.socketedSoulCoreTypes["helmet"])
+				assert.is_nil(build.itemsTab.displayItem.socketedSoulCoreTypes["boots"])
 
 				local foundMaximumRage = false
 				for _, rune in ipairs(build.itemsTab.controls.displayItemRune1.list) do
@@ -809,7 +814,7 @@ Ruby]])
 
 			it("deduplicates valid augments by socketed item name", function ()
 				local item = new("Item"):Item(data.uniques.body[1])
-				item.variant = 4 -- Shield
+				item.variantGroupSelections[1] = 4 -- Shield
 				item:BuildModList()
 
 				local ticabaCount = 0

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -8359,7 +8359,7 @@ c["Instant Recovery"]={{[1]={flags=0,keywordFlags=0,name="FlaskInstantRecovery",
 c["Insufficient Mana doesn't prevent your Melee Attacks"]={nil,"Insufficient Mana doesn't prevent your Melee Attacks "}
 c["Intimidate Enemies for 4 seconds on Hit with Attacks while at maximum Endurance Charges"]={{[1]={[1]={stat="EnduranceCharges",thresholdStat="EnduranceChargesMax",type="StatThreshold"},[2]={type="Condition",var="HitRecently"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Condition:Intimidated",type="FLAG",value=true}}}},nil}
 c["Intimidate Enemies on Block for 8 seconds"]={nil,"Intimidate Enemies on Block for 8 seconds "}
-c["Intimidate Enemies on Block for 8 seconds UniqueEnemiesBlockedAreIntimidated"]={nil,"Intimidate Enemies on Block for 8 seconds UniqueEnemiesBlockedAreIntimidated "}
+c["Intimidate Enemies on Block for 8 seconds Permanently Intimidate enemies on Block"]={nil,"Intimidate Enemies on Block for 8 seconds Permanently Intimidate enemies on Block "}
 c["Invocated Spells deal 15% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=15}},nil}
 c["Invocated Spells deal 70% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=70}},nil}
 c["Invocated Spells deal 82% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=82}},nil}
@@ -9701,7 +9701,6 @@ c["Undead Minions have 25% less maximum Life"]={{[1]={[1]={skillType=127,type="S
 c["Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
 c["Unique Tamed Beasts have 30% increased movement speed"]={nil,"Unique Tamed Beasts have 30% increased movement speed "}
 c["Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
-c["UniqueEnemiesBlockedAreIntimidated"]={nil,"UniqueEnemiesBlockedAreIntimidated "}
 c["Unwavering Stance"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Unwavering Stance"},[2]={flags=0,keywordFlags=0,name="Condition:HaveUnwaveringStance",type="FLAG",value=true}},nil}
 c["Unwithered enemies are Withered for 8 seconds when they enter your Presence"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanWither",type="FLAG",value=true}},nil}
 c["Upgrades Radius to Large"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="timeLostJewelRadiusOverride",value=3}}},nil}
@@ -10003,8 +10002,8 @@ c["as being boosted by Shocked Ground"]={nil,"as being boosted by Shocked Ground
 c["being Shapeshifted for at least 8 seconds"]={nil,"being Shapeshifted for at least 8 seconds "}
 c["for 4 seconds, every 0.25 seconds while raised"]={nil,"for 4 seconds, every 0.25 seconds while raised "}
 c["gain 6 Cold Surges or 6 Fire Surges"]={{}," Cold Surges or 6 Fire Surges "}
-end)();(function()
 c["the enemy's Power for 20 seconds, up to a total of 500"]={nil,"the enemy's Power for 20 seconds, up to a total of 500 "}
+end)();(function()
 c["their Explicit Modifiers are transformed into more powerful related Modifiers"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers "}
 c["their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves "}
 c["until you take no Damage to Life for 3 seconds"]={nil,"until you take no Damage to Life for 3 seconds "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2417,6 +2417,7 @@ c["15% increased Spell Damage while holding a Shield"]={{[1]={[1]={type="Conditi
 c["15% increased Spell Damage while wielding a Staff"]={{[1]={[1]={type="Condition",var="UsingStaff"},flags=2,keywordFlags=0,name="Damage",type="INC",value=15}},nil}
 c["15% increased Spell Damage while you have Arcane Surge"]={{[1]={[1]={type="Condition",var="AffectedByArcaneSurge"},flags=2,keywordFlags=0,name="Damage",type="INC",value=15}},nil}
 c["15% increased Spell damage for each 200 total Mana you have Spent Recently"]={{[1]={[1]={div=200,type="Multiplier",var="ManaSpentRecently"},flags=2,keywordFlags=0,name="Damage",type="INC",value=15}},nil}
+c["15% increased Spirit"]={{[1]={flags=0,keywordFlags=0,name="Spirit",type="INC",value=15}},nil}
 c["15% increased Strength"]={{[1]={flags=0,keywordFlags=0,name="Str",type="INC",value=15}},nil}
 c["15% increased Stun Buildup"]={{[1]={flags=0,keywordFlags=0,name="EnemyHeavyStunBuildup",type="INC",value=15}},nil}
 c["15% increased Stun Buildup with Melee Damage"]={{[1]={flags=256,keywordFlags=0,name="EnemyHeavyStunBuildup",type="INC",value=15}},nil}
@@ -5000,8 +5001,8 @@ c["75% increased chance to Shock"]={{[1]={flags=0,keywordFlags=0,name="EnemyShoc
 c["75% increased effect of Socketed Augment Items"]={{[1]={flags=0,keywordFlags=0,name="SocketedAugmentItemEffect",type="INC",value=75}},nil}
 c["75% more Stun Buildup with Lightning Damage"]={{[1]={[1]={type="Condition",var="LightningHasDamage"},flags=0,keywordFlags=0,name="EnemyHeavyStunBuildup",type="MORE",value=75}},nil}
 c["75% of Damage Converted to Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="DamageConvertToFire",type="BASE",value=75}},nil}
-c["75% of Volatility Physical Damage Taken as Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTakenAsCold",type="BASE",value=75}}," Volatility   "}
 end)();(function()
+c["75% of Volatility Physical Damage Taken as Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTakenAsCold",type="BASE",value=75}}," Volatility   "}
 c["75% reduced Amount Recovered"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecovery",type="INC",value=-75}},nil}
 c["75% reduced Charges per use"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesUsed",type="INC",value=-75}},nil}
 c["75% reduced Ignite Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=-75}},nil}
@@ -5418,7 +5419,6 @@ c["Adds 200 to 400 Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="ColdMin",ty
 c["Adds 201 to 333 Chaos damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosMin",type="BASE",value=201},[2]={flags=0,keywordFlags=0,name="ChaosMax",type="BASE",value=333}},nil}
 c["Adds 21 to 34 Chaos Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="ChaosMin",type="BASE",value=21},[2]={flags=0,keywordFlags=65536,name="ChaosMax",type="BASE",value=34}},nil}
 c["Adds 21 to 37 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=21},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=37}},nil}
-c["Adds 22 to 28 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=28}},nil}
 c["Adds 22 to 33 Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="ColdMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="ColdMax",type="BASE",value=33}},nil}
 c["Adds 22 to 35 Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="ColdMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="ColdMax",type="BASE",value=35}},nil}
 c["Adds 22 to 35 Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="FireMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="FireMax",type="BASE",value=35}},nil}
@@ -7761,6 +7761,7 @@ c["Gain Guard equal to 15% of missing Energy Shield for 4 seconds when you Dodge
 c["Gain Guard equal to 20% of missing Energy Shield for 4 seconds when you Dodge Roll"]={nil,"Guard equal to 20% of missing Energy Shield  when you Dodge Roll "}
 c["Gain Guard equal to 20% of missing Energy Shield for 4 seconds when you Dodge Roll Maximum amount of Guard is based on maximum Energy Shield instead"]={nil,"Guard equal to 20% of missing Energy Shield  when you Dodge Roll Maximum amount of Guard is based on maximum Energy Shield instead "}
 c["Gain Guard equal to Current Runic Ward for 10 seconds when Effect ends"]={nil,"Guard equal to Current Runic Ward  when Effect ends "}
+c["Gain Guard equal to Current Runic Ward for 10 seconds when Effect ends Excess Life Recovery added as Guard for 10 seconds"]={nil,"Guard equal to Current Runic Ward  when Effect ends Excess Life Recovery added as Guard  "}
 c["Gain Immunity to Physical Damage for 1.5 seconds on Rampage"]={nil,"Immunity to Physical Damage for 1.5 seconds on"}
 c["Gain Infernal Flame instead of spending Mana for Skill costs"]={nil,"Infernal Flame instead of spending Mana for Skill costs "}
 c["Gain Infernal Flame instead of spending Mana for Skill costs Take maximum Life and Energy Shield as Fire Damage when Infernal Flame reaches maximum"]={nil,"Infernal Flame instead of spending Mana for Skill costs Take maximum Life and Energy Shield as Fire Damage when Infernal Flame reaches maximum "}
@@ -8358,6 +8359,7 @@ c["Instant Recovery"]={{[1]={flags=0,keywordFlags=0,name="FlaskInstantRecovery",
 c["Insufficient Mana doesn't prevent your Melee Attacks"]={nil,"Insufficient Mana doesn't prevent your Melee Attacks "}
 c["Intimidate Enemies for 4 seconds on Hit with Attacks while at maximum Endurance Charges"]={{[1]={[1]={stat="EnduranceCharges",thresholdStat="EnduranceChargesMax",type="StatThreshold"},[2]={type="Condition",var="HitRecently"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Condition:Intimidated",type="FLAG",value=true}}}},nil}
 c["Intimidate Enemies on Block for 8 seconds"]={nil,"Intimidate Enemies on Block for 8 seconds "}
+c["Intimidate Enemies on Block for 8 seconds UniqueEnemiesBlockedAreIntimidated"]={nil,"Intimidate Enemies on Block for 8 seconds UniqueEnemiesBlockedAreIntimidated "}
 c["Invocated Spells deal 15% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=15}},nil}
 c["Invocated Spells deal 70% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=70}},nil}
 c["Invocated Spells deal 82% increased Damage"]={{[1]={[1]={type="Condition",var="InvocationSkill"},flags=0,keywordFlags=131072,name="Damage",type="INC",value=82}},nil}
@@ -9256,6 +9258,7 @@ c["Regenerate 5 Rage per second"]={{[1]={flags=0,keywordFlags=0,name="RageRegen"
 c["Regenerate 5% of maximum Life over 1 second when Stunned"]={nil,"Regenerate 5% of maximum Life over 1 second when Stunned "}
 c["Regenerate 5% of maximum Life per second if you have been Hit Recently"]={{[1]={[1]={type="Condition",var="BeenHitRecently"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=5}},nil}
 c["Regenerate 5% of maximum Life per second while Surrounded"]={{[1]={[1]={type="Condition",var="Surrounded"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=5}},nil}
+c["Regenerate 5.0% of maximum Runic Ward per second during Effect"]={{[1]={[1]={type="Condition",var="UsingFlask"},flags=0,keywordFlags=0,name="WardRegenPercent",type="BASE",value=5}},nil}
 c["Regenerate 6% of your maximum Rage per second"]={{[1]={flags=0,keywordFlags=0,name="RageRegenPercent",type="BASE",value=6}},nil}
 c["Regenerate 7 Life over 1 second when you Cast a Spell"]={nil,"Regenerate 7 Life over 1 second when you Cast a Spell "}
 c["Regenerate 75 Life per second per Endurance Charge"]={{[1]={[1]={type="Multiplier",var="EnduranceCharge"},flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=75}},nil}
@@ -9698,6 +9701,7 @@ c["Undead Minions have 25% less maximum Life"]={{[1]={[1]={skillType=127,type="S
 c["Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
 c["Unique Tamed Beasts have 30% increased movement speed"]={nil,"Unique Tamed Beasts have 30% increased movement speed "}
 c["Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds"]={nil,"Unique Tamed Beasts have 30% increased movement speed Unique Tamed Beasts are Possessed by random Azmeri Spirits, changing every 20 seconds "}
+c["UniqueEnemiesBlockedAreIntimidated"]={nil,"UniqueEnemiesBlockedAreIntimidated "}
 c["Unwavering Stance"]={{[1]={flags=0,keywordFlags=0,name="Keystone",type="LIST",value="Unwavering Stance"},[2]={flags=0,keywordFlags=0,name="Condition:HaveUnwaveringStance",type="FLAG",value=true}},nil}
 c["Unwithered enemies are Withered for 8 seconds when they enter your Presence"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanWither",type="FLAG",value=true}},nil}
 c["Upgrades Radius to Large"]={{[1]={flags=0,keywordFlags=0,name="JewelData",type="LIST",value={key="timeLostJewelRadiusOverride",value=3}}},nil}
@@ -9999,11 +10003,11 @@ c["as being boosted by Shocked Ground"]={nil,"as being boosted by Shocked Ground
 c["being Shapeshifted for at least 8 seconds"]={nil,"being Shapeshifted for at least 8 seconds "}
 c["for 4 seconds, every 0.25 seconds while raised"]={nil,"for 4 seconds, every 0.25 seconds while raised "}
 c["gain 6 Cold Surges or 6 Fire Surges"]={{}," Cold Surges or 6 Fire Surges "}
+end)();(function()
 c["the enemy's Power for 20 seconds, up to a total of 500"]={nil,"the enemy's Power for 20 seconds, up to a total of 500 "}
 c["their Explicit Modifiers are transformed into more powerful related Modifiers"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers "}
 c["their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves "}
 c["until you take no Damage to Life for 3 seconds"]={nil,"until you take no Damage to Life for 3 seconds "}
-end)();(function()
 c["until you take no Damage to Life for 5 seconds"]={nil,"until you take no Damage to Life for 5 seconds "}
 c["until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved"]={nil,"until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved "}
 c["you Shapeshift to an Animal form"]={nil,"you Shapeshift to an Animal form "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -2648,7 +2648,9 @@ c["18% of Damage taken Recouped as Life"]={{[1]={flags=0,keywordFlags=0,name="Li
 c["18% of Damage taken Recouped as Mana"]={{[1]={flags=0,keywordFlags=0,name="ManaRecoup",type="BASE",value=18}},nil}
 c["18% of Skill Mana Costs Converted to Life Costs"]={{[1]={flags=0,keywordFlags=0,name="HybridManaAndLifeCost_Life",type="BASE",value=18}},nil}
 c["18% reduced Attack Speed"]={{[1]={flags=1,keywordFlags=0,name="Speed",type="INC",value=-18}},nil}
+c["180% increased Armour and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEnergyShield",type="INC",value=180}},nil}
 c["180% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=180}},nil}
+c["180% increased Evasion and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EvasionAndEnergyShield",type="INC",value=180}},nil}
 c["19% increased Cast Speed"]={{[1]={flags=16,keywordFlags=0,name="Speed",type="INC",value=19}},nil}
 c["19% increased Freeze Buildup"]={{[1]={flags=0,keywordFlags=0,name="EnemyFreezeBuildup",type="INC",value=19}},nil}
 c["19% increased Ignite Magnitude"]={{[1]={flags=0,keywordFlags=8388608,name="AilmentMagnitude",type="INC",value=19}},nil}
@@ -3853,6 +3855,7 @@ c["300% increased Armour and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name=
 c["300% increased Armour and Evasion"]={{[1]={flags=0,keywordFlags=0,name="ArmourAndEvasion",type="INC",value=300}},nil}
 c["300% increased Armour while Chilled or Frozen"]={{[1]={[1]={type="Condition",var="Chilled"},flags=0,keywordFlags=0,name="Armour",type="INC",value=300}},"   or Frozen "}
 c["300% increased Armour, Evasion and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC",value=300},[2]={flags=0,keywordFlags=0,name="Evasion",type="INC",value=300},[3]={flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=300}},nil}
+c["300% increased Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=300}},nil}
 c["300% increased Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",type="INC",value=300}},nil}
 c["300% increased Evasion and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EvasionAndEnergyShield",type="INC",value=300}},nil}
 c["300% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=300}},nil}
@@ -4998,10 +5001,10 @@ c["75% of Damage Converted to Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="
 c["75% of Volatility Physical Damage Taken as Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTakenAsCold",type="BASE",value=75}}," Volatility   "}
 c["75% reduced Amount Recovered"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecovery",type="INC",value=-75}},nil}
 c["75% reduced Charges per use"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesUsed",type="INC",value=-75}},nil}
+end)();(function()
 c["75% reduced Ignite Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=-75}},nil}
 c["76% more Recovery if used while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="FlaskLifeRecoveryLowLife",type="MORE",value=76}},nil}
 c["76% more Recovery if used while on Low Mana"]={{[1]={[1]={type="Condition",var="LowMana"},flags=0,keywordFlags=0,name="FlaskLifeRecoveryLowLife",type="MORE",value=76}},"  if used  "}
-end)();(function()
 c["78% increased Amount Recovered"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecovery",type="INC",value=78}},nil}
 c["8 Life Regeneration per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=8}},nil}
 c["8 to 14 Fire Damage per Endurance Charge"]={{[1]={[1]={type="Multiplier",var="EnduranceCharge"},flags=0,keywordFlags=0,name="FireMin",type="BASE",value=8},[2]={[1]={type="Multiplier",var="EnduranceCharge"},flags=0,keywordFlags=0,name="FireMax",type="BASE",value=14}},nil}
@@ -10000,9 +10003,9 @@ c["until you take no Damage to Life for 3 seconds"]={nil,"until you take no Dama
 c["until you take no Damage to Life for 5 seconds"]={nil,"until you take no Damage to Life for 5 seconds "}
 c["until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved"]={nil,"until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved "}
 c["you Shapeshift to an Animal form"]={nil,"you Shapeshift to an Animal form "}
+end)();(function()
 c["you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift"]={nil,"you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift "}
 c["your maximum number of Power Charges"]={nil,"your maximum number of Power Charges "}
 c["your maximum number of Power Charges +1 to Maximum Power Charges"]={nil,"your maximum number of Power Charges +1 to Maximum Power Charges "}
-end)();(function()
 end)();
 return c

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -270,6 +270,7 @@ c["+100% of Armour also applies to Elemental Damage"]={{[1]={flags=0,keywordFlag
 c["+100% of Armour also applies to Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="ArmourAppliesToLightningDamageTaken",type="BASE",value=100}},nil}
 c["+100% of Armour applies to Elemental Damage"]={{[1]={flags=0,keywordFlags=0,name="ArmourAppliesToFireDamageTaken",type="BASE",value=100},[2]={flags=0,keywordFlags=0,name="ArmourAppliesToColdDamageTaken",type="BASE",value=100},[3]={flags=0,keywordFlags=0,name="ArmourAppliesToLightningDamageTaken",type="BASE",value=100}},nil}
 c["+100% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=100}},nil}
+c["+100% to Fire Resistance"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=100}},nil}
 c["+100% to Lightning Resistance"]={{[1]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=100}},nil}
 c["+1000 to Evasion Rating while on Full Life"]={{[1]={[1]={type="Condition",var="FullLife"},flags=0,keywordFlags=0,name="Evasion",type="BASE",value=1000}},nil}
 c["+1000 to Spectre maximum Life"]={{[1]={[1]={includeTransfigured=true,skillName="Raise Spectre",type="SkillName"},flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="Life",type="BASE",value=1000}}}},nil}
@@ -4846,6 +4847,7 @@ c["60% increased Ice Crystal Life"]={{[1]={flags=0,keywordFlags=0,name="IceCryst
 c["60% increased Intelligence Requirement"]={{[1]={flags=0,keywordFlags=0,name="IntRequirement",type="INC",value=60}},nil}
 c["60% increased Magnitude of Poison you inflict on targets that are not Poisoned"]={{[1]={[1]={actor="enemy",threshold=1,type="MultiplierThreshold",upper=true,var="PoisonStacks"},flags=0,keywordFlags=2097152,name="AilmentMagnitude",type="INC",value=60}},nil}
 c["60% increased Mana Cost Efficiency of Marks"]={{[1]={[1]={skillType=99,type="SkillType"},flags=0,keywordFlags=0,name="ManaCostEfficiency",type="INC",value=60}},nil}
+c["60% increased Mana Regeneration Rate"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=60}},nil}
 c["60% increased Mana Regeneration Rate while Surrounded"]={{[1]={[1]={type="Condition",var="Surrounded"},flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=60}},nil}
 c["60% increased Mana Regeneration Rate while stationary"]={{[1]={[1]={type="Condition",var="Stationary"},flags=0,keywordFlags=0,name="ManaRegen",type="INC",value=60}},nil}
 c["60% increased Melee Damage if you've dealt a Projectile Attack Hit in the past eight seconds"]={{[1]={[1]={type="Condition",var="HitProjectileRecently"},flags=256,keywordFlags=0,name="Damage",type="INC",value=60}},nil}
@@ -4999,9 +5001,9 @@ c["75% increased effect of Socketed Augment Items"]={{[1]={flags=0,keywordFlags=
 c["75% more Stun Buildup with Lightning Damage"]={{[1]={[1]={type="Condition",var="LightningHasDamage"},flags=0,keywordFlags=0,name="EnemyHeavyStunBuildup",type="MORE",value=75}},nil}
 c["75% of Damage Converted to Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="DamageConvertToFire",type="BASE",value=75}},nil}
 c["75% of Volatility Physical Damage Taken as Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTakenAsCold",type="BASE",value=75}}," Volatility   "}
+end)();(function()
 c["75% reduced Amount Recovered"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecovery",type="INC",value=-75}},nil}
 c["75% reduced Charges per use"]={{[1]={flags=0,keywordFlags=0,name="FlaskChargesUsed",type="INC",value=-75}},nil}
-end)();(function()
 c["75% reduced Ignite Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyIgniteDuration",type="INC",value=-75}},nil}
 c["76% more Recovery if used while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="FlaskLifeRecoveryLowLife",type="MORE",value=76}},nil}
 c["76% more Recovery if used while on Low Mana"]={{[1]={[1]={type="Condition",var="LowMana"},flags=0,keywordFlags=0,name="FlaskLifeRecoveryLowLife",type="MORE",value=76}},"  if used  "}
@@ -5303,6 +5305,7 @@ c["Adds 1 to 100 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="Lightnin
 c["Adds 1 to 11 Lightning Damage to Spells"]={{[1]={flags=0,keywordFlags=131072,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=131072,name="LightningMax",type="BASE",value=11}},nil}
 c["Adds 1 to 111 Lightning Damage to Unarmed Melee Hits"]={{[1]={flags=16777476,keywordFlags=0,name="LightningMin",type="BASE",value=1},[2]={flags=16777476,keywordFlags=0,name="LightningMax",type="BASE",value=111}},nil}
 c["Adds 1 to 113 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=0,name="LightningMax",type="BASE",value=113}},nil}
+c["Adds 1 to 115 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=0,name="LightningMax",type="BASE",value=115}},nil}
 c["Adds 1 to 120 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=0,name="LightningMax",type="BASE",value=120}},nil}
 c["Adds 1 to 2 Lightning damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=65536,name="LightningMax",type="BASE",value=2}},nil}
 c["Adds 1 to 200 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=0,name="LightningMax",type="BASE",value=200}},nil}
@@ -10000,10 +10003,10 @@ c["the enemy's Power for 20 seconds, up to a total of 500"]={nil,"the enemy's Po
 c["their Explicit Modifiers are transformed into more powerful related Modifiers"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers "}
 c["their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves"]={nil,"their Explicit Modifiers are transformed into more powerful related Modifiers Ignore Attribute Requirements to equip Gloves "}
 c["until you take no Damage to Life for 3 seconds"]={nil,"until you take no Damage to Life for 3 seconds "}
+end)();(function()
 c["until you take no Damage to Life for 5 seconds"]={nil,"until you take no Damage to Life for 5 seconds "}
 c["until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved"]={nil,"until you take no Damage to Life for 5 seconds Life that would be lost by taking Damage is instead Reserved "}
 c["you Shapeshift to an Animal form"]={nil,"you Shapeshift to an Animal form "}
-end)();(function()
 c["you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift"]={nil,"you Shapeshift to an Animal form Modifiers gained this way are lost after 30 seconds or when you next Shapeshift "}
 c["your maximum number of Power Charges"]={nil,"your maximum number of Power Charges "}
 c["your maximum number of Power Charges +1 to Maximum Power Charges"]={nil,"your maximum number of Power Charges +1 to Maximum Power Charges "}

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -167,7 +167,7 @@ Implicits: 1
 {tags:life}(2-4) Life Regeneration per second
 {tags:fire}+(10-20)% to Fire Resistance
 {tags:mana}(20-30)% increased Mana Regeneration Rate
-25% reduced Light Radius
+25% increased Light Radius
 Life Recovery from Regeneration is not applied
 Every 4 seconds, Recover 1 Life for every 0.2 Life Recovery per second from Regeneration
 ]],[[

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -154,11 +154,15 @@ Cannot be Blinded
 ]],[[
 Idol of Uldurn
 Crimson Amulet
+Version: Pre 0.5.0
+Version: Current
 Requires Level 24
 Implicits: 1
 {tags:life}(2-4) Life Regeneration per second
 {tags:life}+(60-80) to maximum Life
 {tags:attribute}+(10-20) to Dexterity
+{version:2}(20-40)% reduced Presence Area of Effect
+{version:2}(10-15)% increased Spirit
 Skills have +1 to Limit
 ]],[[
 Igniferis

--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -90,7 +90,7 @@ Implicits: 1
 {tags:mana}(20-30)% increased Mana Regeneration Rate
 {variant:1}{tags:mana}+50 to maximum Mana
 {variant:2}{tags:mana}+(40-60) to maximum Mana
-{tags:mana}50% increased Mana Regeneration Rate
+{tags:mana}(40-60)% increased Mana Regeneration Rate
 {variant:1}{tags:defences}Gain (20-30)% of maximum Mana as Extra maximum Energy Shield
 {variant:2}{tags:defences}Gain (4-6)% of maximum Mana as Extra maximum Energy Shield
 ]],[[
@@ -285,7 +285,7 @@ Implicits: 1
 {tags:attribute}+(10-15) to Strength
 {tags:life}(10-20)% increased maximum Life
 {variant:1,2}{tags:fire}+(30-40)% to Fire Resistance
-{variant:3}{tags:fire}+(20-30)% to Fire Resistance
+{variant:3}{tags:fire}+(50-100)% to Fire Resistance
 {variant:1}Enemies in your Presence have +1% to Fire Resistance
 {variant:2}Enemies in your Presence have -10% to Fire Resistance
 {variant:3}Enemies in your Presence have -25% to Fire Resistance

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -111,6 +111,7 @@ Vaal Cuirass
 ]],[[
 The Road Warrior
 Raider Plate
+Source: No longer obtainable
 Variant: Pre 0.1.1
 Variant: Current
 {variant:1}(50-100)% increased Armour
@@ -777,7 +778,6 @@ Anchorite Garb
 Variant: Pre 0.1.1
 Variant: Current
 +(50-70) to maximum Mana
-{variant:2}-15% to Cold Resistance
 {variant:1}+(20-30)% to Lightning Resistance
 {variant:2}+(20-30)% to Lightning Resistance
 20% chance to gain a Power Charge on Hit

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -25,18 +25,18 @@ Sockets: S S S S S S
 Implicits: 1
 +1 to Level of all Corrupted Skill Gems
 Only Soul Cores can be Socketed in this item
-{variant:3}This item gains bonuses from Socketed Soul Cores as though it was also Boots
-{variant:2}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
-{variant:1}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
-{variant:4}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
+{variant:3}{group:1}This item gains bonuses from Socketed Soul Cores as though it was also Boots
+{variant:2}{group:1}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
+{variant:1}{group:1}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
+{variant:4}{group:1}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
 Has no Attribute Requirements
-{variant:6}(200-300)% increased Armour
-{variant:7}(200-300)% increased Evasion Rating
-{variant:8}(200-300)% increased Energy Shield
-{variant:9}(120-180)% increased Armour and Evasion
-{variant:10}(120-180)% increased Armour and Energy Shield
-{variant:11}(120-180)% increased Evasion and Energy Shield
-{variant:5}(80-120)% increased Armour, Evasion and Energy Shield
+{variant:6}{group:2}(200-300)% increased Armour
+{variant:7}{group:2}(200-300)% increased Evasion Rating
+{variant:8}{group:2}(200-300)% increased Energy Shield
+{variant:9}{group:2}(120-180)% increased Armour and Evasion
+{variant:10}{group:2}(120-180)% increased Armour and Energy Shield
+{variant:11}{group:2}(120-180)% increased Evasion and Energy Shield
+{variant:5}{group:2}(80-120)% increased Armour, Evasion and Energy Shield
 +(10-20)% to all Elemental Resistances
 Skills from Corrupted Gems have 50% of Mana Costs Converted to Life Costs
 ]],[[

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -279,7 +279,7 @@ Smuggler Coat
 Variant: Pre 0.2.0
 Variant: Pre 0.4.0
 Variant: Current
-(100-150)% increased Evasion Rating
+(250-300)% increased Evasion Rating
 -(15-10)% to Fire Resistance
 +(25-30)% to Cold Resistance
 +(10-15)% to Lightning Resistance
@@ -794,7 +794,7 @@ Variant: Current
 +(50-70) to maximum Mana
 {variant:2}-15% to Cold Resistance
 {variant:1}+(20-30)% to Lightning Resistance
-{variant:2}+(30-40)% to Lightning Resistance
+{variant:2}+(20-30)% to Lightning Resistance
 20% chance to gain a Power Charge on Hit
 Lose all Power Charges on reaching maximum Power Charges
 Shocks you when you reach maximum Power Charges
@@ -805,7 +805,8 @@ Variant: Pre 0.4.0
 Variant: Pre 0.5.0
 Variant: Current
 (50-80)% increased Evasion and Energy Shield
-+(15-25)% to Lightning Resistance
+-15% to Cold Resistance
++(30-40)% to Lightning Resistance
 {variant:3}(15-30)% increased Energy Shield Recharge Rate
 {variant:1,2}(30-50)% faster start of Energy Shield Recharge
 {variant:2,3}All Damage taken from Hits Contributes to Magnitude of Chill inflicted on you

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -7,51 +7,36 @@ Atziri's Splendour
 Sacrificial Regalia
 Source: Drops from unique{Atziri's Vault} in normal{Vaal Temple}
 League: Fate of the Vaal
+Has Alt Variant: true
 Selected Variant: 1
-Variant: Helmet (AR/EV/ES)
-Variant: Gloves (AR/EV/ES)
-Variant: Boots (AR/EV/ES)
-Variant: Shield (AR/EV/ES)
-Variant: Helmet (AR)
-Variant: Gloves (AR)
-Variant: Boots (AR)
-Variant: Shield (AR)
-Variant: Shield (ES)
-Variant: Helmet (EV)
-Variant: Gloves (EV)
-Variant: Boots (EV)
-Variant: Shield (EV)
-Variant: Helmet (ES)
-Variant: Gloves (ES)
-Variant: Boots (ES)
-Variant: Helmet (AR/EV)
-Variant: Gloves (AR/EV)
-Variant: Boots (AR/EV)
-Variant: Shield (AR/EV)
-Variant: Helmet (AR/ES)
-Variant: Gloves (AR/ES)
-Variant: Boots (AR/ES)
-Variant: Shield (AR/ES)
-Variant: Helmet (EV/ES)
-Variant: Gloves (EV/ES)
-Variant: Boots (EV/ES)
-Variant: Shield (EV/ES)
+Selected Alt Variant: 5
+Variant: Helmet
+Variant: Gloves
+Variant: Boots
+Variant: Shield
+Variant: AR/EV/ES
+Variant: AR
+Variant: EV
+Variant: ES
+Variant: AR/EV
+Variant: AR/ES
+Variant: EV/ES
 Sockets: S S S S S S
 Implicits: 1
 +1 to Level of all Corrupted Skill Gems
 Only Soul Cores can be Socketed in this item
-{variant:3,7,11,15,19,23,27}This item gains bonuses from Socketed Soul Cores as though it was also Boots
-{variant:2,6,10,14,18,22,26}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
-{variant:1,5,9,13,17,21,25}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
-{variant:4,8,12,16,20,24,28}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
+{variant:3}This item gains bonuses from Socketed Soul Cores as though it was also Boots
+{variant:2}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
+{variant:1}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
+{variant:4}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
 Has no Attribute Requirements
-{variant:5,6,7,8}(200-300)% increased Armour
-{variant:9,10,11,12}(200-300)% increased Evasion Rating
-{variant:13,14,15,16}(200-300)% increased Energy Shield
-{variant:17,18,19,20}(120-180)% increased Armour and Evasion
-{variant:21,22,23,24}(120-180)% increased Armour and Energy Shield
-{variant:25,26,27,28}(120-180)% increased Evasion and Energy Shield
-{variant:1,2,3,4}(80-120)% increased Armour, Evasion and Energy Shield
+{variant:6}(200-300)% increased Armour
+{variant:7}(200-300)% increased Evasion Rating
+{variant:8}(200-300)% increased Energy Shield
+{variant:9}(120-180)% increased Armour and Evasion
+{variant:10}(120-180)% increased Armour and Energy Shield
+{variant:11}(120-180)% increased Evasion and Energy Shield
+{variant:5}(80-120)% increased Armour, Evasion and Energy Shield
 +(10-20)% to all Elemental Resistances
 Skills from Corrupted Gems have 50% of Mana Costs Converted to Life Costs
 ]],[[

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -7,20 +7,51 @@ Atziri's Splendour
 Sacrificial Regalia
 Source: Drops from unique{Atziri's Vault} in normal{Vaal Temple}
 League: Fate of the Vaal
-Variant: Helmet
-Variant: Gloves
-Variant: Boots
-Variant: Shield
+Selected Variant: 1
+Variant: Helmet (AR/EV/ES)
+Variant: Gloves (AR/EV/ES)
+Variant: Boots (AR/EV/ES)
+Variant: Shield (AR/EV/ES)
+Variant: Helmet (AR)
+Variant: Gloves (AR)
+Variant: Boots (AR)
+Variant: Shield (AR)
+Variant: Shield (ES)
+Variant: Helmet (EV)
+Variant: Gloves (EV)
+Variant: Boots (EV)
+Variant: Shield (EV)
+Variant: Helmet (ES)
+Variant: Gloves (ES)
+Variant: Boots (ES)
+Variant: Helmet (AR/EV)
+Variant: Gloves (AR/EV)
+Variant: Boots (AR/EV)
+Variant: Shield (AR/EV)
+Variant: Helmet (AR/ES)
+Variant: Gloves (AR/ES)
+Variant: Boots (AR/ES)
+Variant: Shield (AR/ES)
+Variant: Helmet (EV/ES)
+Variant: Gloves (EV/ES)
+Variant: Boots (EV/ES)
+Variant: Shield (EV/ES)
 Sockets: S S S S S S
 Implicits: 1
 +1 to Level of all Corrupted Skill Gems
 Only Soul Cores can be Socketed in this item
-{variant:3}This item gains bonuses from Socketed Soul Cores as though it was also Boots
-{variant:2}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
-{variant:1}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
-{variant:4}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
+{variant:3,7,11,15,19,23,27}This item gains bonuses from Socketed Soul Cores as though it was also Boots
+{variant:2,6,10,14,18,22,26}This item gains bonuses from Socketed Soul Cores as though it was also Gloves
+{variant:1,5,9,13,17,21,25}This item gains bonuses from Socketed Soul Cores as though it was also a Helmet
+{variant:4,8,12,16,20,24,28}This item gains bonuses from Socketed Soul Cores as though it was also a Shield
 Has no Attribute Requirements
-(80-120)% increased Armour, Evasion and Energy Shield
+{variant:5,6,7,8}(200-300)% increased Armour
+{variant:9,10,11,12}(200-300)% increased Evasion Rating
+{variant:13,14,15,16}(200-300)% increased Energy Shield
+{variant:17,18,19,20}(120-180)% increased Armour and Evasion
+{variant:21,22,23,24}(120-180)% increased Armour and Energy Shield
+{variant:25,26,27,28}(120-180)% increased Evasion and Energy Shield
+{variant:1,2,3,4}(80-120)% increased Armour, Evasion and Energy Shield
 +(10-20)% to all Elemental Resistances
 Skills from Corrupted Gems have 50% of Mana Costs Converted to Life Costs
 ]],[[

--- a/src/Data/Uniques/body.lua
+++ b/src/Data/Uniques/body.lua
@@ -14,13 +14,13 @@ Variant: Helmet
 Variant: Gloves
 Variant: Boots
 Variant: Shield
-Variant: AR/EV/ES
-Variant: AR
-Variant: EV
-Variant: ES
-Variant: AR/EV
-Variant: AR/ES
-Variant: EV/ES
+Variant: Armour/Evasion/Energy Shield
+Variant: Armour
+Variant: Evasion
+Variant: Energy Shield
+Variant: Armour/Evasion
+Variant: Armour/Energy Shield
+Variant: Evasion/Energy Shield
 Sockets: S S S S S S
 Implicits: 1
 +1 to Level of all Corrupted Skill Gems

--- a/src/Data/Uniques/flask.lua
+++ b/src/Data/Uniques/flask.lua
@@ -16,12 +16,15 @@ No Inherent loss of Rage during effect
 Olroth's Resolve
 Ultimate Life Flask
 Source: Drops from unique{Olroth, Origin of the Fall}
-Variant: Pre 0.4.0
-Variant: Current
-Instant Recovery
+Version: Pre 0.4.0
+Version: Pre 0.5.0
+Version: Current
+{version:1,2}Instant Recovery
 (100-150)% increased Charges per use
-{variant:1}Excess Life Recovery added as Guard for 10 seconds
-{variant:2}Excess Life Recovery added as Guard for 20 seconds
+{version:3}Regenerate (2.5-5)% of maximum Runic Ward per second during Effect
+{version:3}Gain Guard equal to Current Runic Ward for 10 seconds when Effect ends
+{version:1}Excess Life Recovery added as Guard for 10 seconds
+{version:2}Excess Life Recovery added as Guard for 20 seconds
 ]],[[
 Opportunity
 Ultimate Life Flask

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -24,7 +24,7 @@ Implicits: 1
 Dreadfist
 Bolstered Mitts
 League: Dawn of the Hunt
-(50-100)% increased Armour
+(60-100)% increased Armour
 (20-30)% increased Critical Damage Bonus
 Critical Hits inflict Impale
 Critical Hits cannot Extract Impale

--- a/src/Data/Uniques/gloves.lua
+++ b/src/Data/Uniques/gloves.lua
@@ -333,7 +333,7 @@ Curses you inflict are reflected back to you
 [[
 Blessed Bonds
 Linen Wraps
-Source: Drops from unique{Zarokh, the Temporal}
+Source: No longer obtainable
 Requires Level 56
 +(60-100) to Evasion Rating
 +(30-50) to maximum Energy Shield

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -177,7 +177,7 @@ Variant: Current
 {variant:1}+(40-60) to maximum Mana
 {variant:2}+(60-100) to maximum Mana
 {variant:1}(10-20)% increased Rarity of Items found
-{variant:2}(10-15)% increased Rarity of Items found
+{variant:2}(10-20)% increased Rarity of Items found
 {variant:1}Gain (25-30)% of maximum Life as Extra maximum Energy Shield
 {variant:2}Gain (10-15)% of maximum Life as Extra maximum Energy Shield
 {variant:1}(20-25)% of Damage taken bypasses Energy Shield

--- a/src/Data/Uniques/helmet.lua
+++ b/src/Data/Uniques/helmet.lua
@@ -553,6 +553,7 @@ Tribal Mask
 Variant: Pre 0.4.0
 Variant: Equipment
 Variant: Skill Gems
+Has no Attribute Requirements
 (100-150)% increased Evasion and Energy Shield
 (20-30)% increased Critical Hit Chance
 +(13-17)% to Chaos Resistance

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -231,7 +231,7 @@ Quecholli
 Crumbling Maul
 Implicits: 1
 Causes Enemies to Explode on Critical kill, for 10% of their Life as Physical Damage
-(80-120)% increased Physical Damage
+(100-150)% increased Physical Damage
 +(10-15) to all Attributes
 Gain 30 Life per enemy killed
 Hits with this Weapon have no Critical Damage Bonus

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -81,7 +81,7 @@ Source: Drops from unique{Olroth, Origin of the Fall}
 Variant: Pre 0.2.0
 Variant: Current
 {variant:1}Adds 1 to (60-80) Lightning Damage
-{variant:2}Adds 1 to (80-120) Lightning Damage
+{variant:2}Adds 1 to (60-80) Lightning Damage
 +(300-400) to Accuracy Rating
 (5-30)% increased Attack Speed
 On Hitting an enemy, gains maximum added Lightning damage equal to
@@ -161,7 +161,7 @@ Variant: Current
 {variant:1}Adds (10-12) to (18-22) Physical Damage
 {variant:2}Adds (18-22) to (24-28) Physical Damage
 {variant:1}Adds 1 to (36-42) Lightning Damage
-{variant:2}Adds 1 to (50-55) Lightning Damage
+{variant:2}Adds 1 to (110-115) Lightning Damage
 (10-15)% increased Attack Speed
 All damage with this Weapon causes Electrocution buildup
 ]],[[

--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -159,7 +159,6 @@ Studded Greatclub
 Variant: Pre 0.1.1
 Variant: Current
 {variant:1}Adds (10-12) to (18-22) Physical Damage
-{variant:2}Adds (18-22) to (24-28) Physical Damage
 {variant:1}Adds 1 to (36-42) Lightning Damage
 {variant:2}Adds 1 to (110-115) Lightning Damage
 (10-15)% increased Attack Speed

--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -71,6 +71,7 @@ Implicits: 1
 {tags:life}(3-6) Life Regeneration per second
 {variant:1}{tags:chaos,attack}Adds (2-3) to (4-5) Chaos Damage to Attacks
 {variant:2}{tags:chaos,attack}Adds (4-6) to (8-10) Chaos Damage to Attacks
+{variant:2}+(10-20)% of Armour also applies to Chaos Damage
 25% chance to Intimidate Enemies for 4 seconds on Hit
 ]],[[
 Blistering Bond

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -223,7 +223,7 @@ Spiked Buckler
 League: Dawn of the Hunt
 Implicits: 1
 Grants Skill: Parry
-(50-80)% increased Evasion Rating
+(60-100)% increased Evasion Rating
 +(10-15)% to all Elemental Resistances
 Parrying applies 10 Stacks of Critical Weakness
 100% increased Parry Damage
@@ -353,7 +353,7 @@ Variant: Current
 Implicits: 1
 Grants Skill: Raise Shield
 {variant:1,2}(30-40)% increased Block chance
-{variant:3}(10-15)% increased Block chance
+{variant:3}(15-20)% increased Block chance
 (30-50)% increased Armour and Energy Shield
 {variant:1}+(15-30) to maximum Mana
 {variant:2,3}+(50-70) to maximum Mana

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -137,12 +137,15 @@ for 4 seconds, every 0.25 seconds while raised
 ]],[[
 Wulfsbane
 Painted Tower Shield
+Version: Pre 0.3.0
+Version: Current
 Implicits: 1
 Grants Skill: Raise Shield
 +(40-60) to maximum Life
 +(10-15) to Strength
 +(60-80) to Stun Threshold
-Permanently Intimidate enemies on Block
+{version:2}Intimidate Enemies on Block for 8 seconds
+{version:1}UniqueEnemiesBlockedAreIntimidated
 ]],
 -- Shield: Evasion
 [[
@@ -333,6 +336,7 @@ No Movement Speed Penalty while Shield is Raised
 ]],[[
 Merit of Service
 Pelage Targe
+Source: No longer obtainable
 Variant: Pre 0.3.0
 Variant: Current
 Implicits: 1

--- a/src/Data/Uniques/shield.lua
+++ b/src/Data/Uniques/shield.lua
@@ -145,7 +145,7 @@ Grants Skill: Raise Shield
 +(10-15) to Strength
 +(60-80) to Stun Threshold
 {version:2}Intimidate Enemies on Block for 8 seconds
-{version:1}UniqueEnemiesBlockedAreIntimidated
+{version:1}Permanently Intimidate enemies on Block
 ]],
 -- Shield: Evasion
 [[

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -178,9 +178,9 @@ UniqueAllDamage2
 ]],[[
 Serpent's Egg
 Gold Amulet
-UniqueAllAttributes1
-UniqueChaosResist1
-UniqueManaRegeneration6
+UniqueAllAttributes10
+UniqueChaosResist17
+UniqueManaRegeneration23
 UniqueAdditionalChargeGeneration1
 ]],[[
 Stone of Lazhwar

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -8,7 +8,7 @@ Bloodstone Amulet
 Variant: Pre 0.2.0
 Variant: Pre 0.4.0
 Variant: Current
-UniqueMovementVelocity6
+UniqueMovementVelocity18
 UniqueIncreasedSkillSpeed2
 UniqueIncreasedPhysicalDamageReductionRatingPercent1
 {variant:1}UniqueBlockChanceIncrease1[20,20]
@@ -26,9 +26,9 @@ UniquePhysicalAttackDamageTaken2
 ]],[[
 Beacon of Azis
 Solar Amulet
-UniqueIncreasedMana12
+UniqueIncreasedMana31
 UniqueIncreasedSpirit5
-UniqueLightRadius7
+UniqueLightRadius13
 UniqueCriticalStrikesIgnoreResistances1
 ]],[[
 Carnage Heart
@@ -37,7 +37,7 @@ Variant: Pre 0.4.0
 Variant: Pre 0.5.0
 Variant: Current
 UniqueMaximumLifeIncrease3
-UniqueAllAttributes1
+UniqueAllAttributes4
 UniqueAllResistances6
 {variant:1}UniqueLifeLeechAmount1[100,100]
 {variant:2,3}UniqueLifeLeechAmount1
@@ -60,7 +60,7 @@ Variant: Pre 0.2.1
 Variant: Pre 0.4.0
 Variant: Current
 UniqueMaximumLifeIncrease6
-UniqueStrength2
+UniqueStrength25
 UniqueManaRegeneration13
 {variant:1}UniqueGainMissingLifeBeforeHit1[5,5]
 {variant:2}UniqueGainMissingLifeBeforeHit1[10,10]
@@ -101,7 +101,7 @@ Variant: Pre 0.2.0
 Variant: Current
 {variant:1}UniqueItemFoundRarityIncrease2[10,20]
 {variant:2}UniqueItemFoundRarityIncrease2
-UniqueManaRegeneration7
+UniqueManaRegeneration21
 UniqueTakeFireDamageOnIgnite1
 UniqueGlobalFireGemLevel1
 ]],[[
@@ -124,15 +124,15 @@ BlindImmunityUnique__1
 ]],[[
 Idol of Uldurn
 Crimson Amulet
-UniqueIncreasedLife14
-UniqueDexterity2
+UniqueIncreasedLife38
+UniqueDexterity29
 UniqueBaseLimit1
 ]],[[
 Igniferis
 Crimson Amulet
 UniqueFireResist23
-UniqueManaRegeneration6
-UniqueLightRadius1
+UniqueManaRegeneration24
+UniqueLightRadius14
 UniqueLifeRegenerationNotApplied1
 UniqueRecoverLifeBasedOnRegen1
 ]],[[
@@ -150,7 +150,7 @@ Ligurium Talisman
 Lapis Amulet
 UniqueIncreasedEnergyShield3
 UniqueIncreasedSpirit6
-UniqueIntelligence9
+UniqueIntelligence30
 UniqueEnergyShieldRegenerationFromLife1
 ]],[[
 The Pandemonius
@@ -165,14 +165,14 @@ UniqueOnHitBlindChilledEnemies1
 ]],[[
 Revered Resin
 Amber Amulet
-UniqueIncreasedLife3
+UniqueIncreasedLife41
 UniqueFlaskLifeRecoveryRate5
 UniqueLifeFlaskChargeGeneration2
 ]],[[
 Rondel of Fragility
 Lunar Amulet
 UniqueIncreasedSkillSpeed4
-UniqueCriticalStrikeChance1
+UniqueCriticalStrikeChance10
 UniqueAllResistances11
 UniqueAllDamage2
 ]],[[
@@ -192,7 +192,7 @@ UniqueBlockPercentWithFocus1
 ]],[[
 Surefooted Sigil
 Jade Amulet
-UniqueIncreasedLife3
+UniqueIncreasedLife36
 UniqueDexterity28
 UniqueDodgeRollDistance1
 UniqueEvasionRatingDodgeRoll1
@@ -208,11 +208,11 @@ Ungil's Harmony
 Azure Amulet
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedLife5
-UniqueIncreasedMana5
+UniqueIncreasedLife32
+UniqueIncreasedMana27
 {variant:1}UniqueCriticalStrikeChance9[100,100]
 {variant:2}UniqueCriticalStrikeChance9
-UniqueStunThreshold6
+UniqueStunThreshold14
 UniqueNoCriticalStrikeMultiplier1
 ]],[[
 Xoph's Blood
@@ -233,7 +233,7 @@ Bloodstone Amulet
 League: Dawn of the Hunt
 Variant: Pre 0.2.1
 Variant: Current
-UniqueAllResistances19
+UniqueAllResistances18
 UniqueElementalDamagePercent1
 {variant:1}UniqueEnemiesTakeIncreasedDamagePerAilmentType1[5,10]
 {variant:2}UniqueEnemiesTakeIncreasedDamagePerAilmentType1

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -73,7 +73,7 @@ Variant: Pre 0.2.0
 Variant: Current
 {variant:1}UniqueIncreasedMana32[50,50]
 {variant:2}UniqueIncreasedMana32
-UniqueManaRegeneration29
+UniqueManaRegeneration22
 {variant:1}UniqueGainManaAsExtraEnergyShield1[20,30]
 {variant:2}UniqueGainManaAsExtraEnergyShield1
 ]],[[
@@ -222,8 +222,8 @@ Variant: Pre 0.4.0
 Variant: Current
 Source: Drops from unique{Xesht, We That Are One} in normal{Twisted Domain}
 UniqueMaximumLifeIncrease7
-{variant:1,2}UniqueFireResist12[30,40]
-{variant:3}UniqueFireResist12
+{variant:1,2}UniqueFireResist25[30,40]
+{variant:3}UniqueFireResist25
 {variant:1}UniqueEnemiesInPresenceFireExposure1[1,1]
 {variant:2}UniqueEnemiesInPresenceFireExposure1[-10,-10]
 {variant:3}UniqueEnemiesInPresenceFireExposure1

--- a/src/Export/Uniques/amulet.lua
+++ b/src/Export/Uniques/amulet.lua
@@ -124,9 +124,13 @@ BlindImmunityUnique__1
 ]],[[
 Idol of Uldurn
 Crimson Amulet
+Version: Pre 0.5.0
+Version: Current
 UniqueIncreasedLife38
 UniqueDexterity29
 UniqueBaseLimit1
+{version:2}UniqueIncreasedMaximumSpiritPercent1
+{version:2}UniquePresenceRadius6
 ]],[[
 Igniferis
 Crimson Amulet

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -15,7 +15,7 @@ BeltImplicitIncreasedCharmChargesGained1
 ]],[[
 Birthright Buckle
 Wide Belt
-UniqueIncreasedPhysicalDamageReductionRating1
+UniqueIncreasedPhysicalDamageReductionRating2
 UniqueReducedFlaskChargesUsed3
 UniqueIncreasedFlaskChargesGained3
 UniqueInstantLifeFlaskOnLowLife1
@@ -25,11 +25,11 @@ Byrnabas
 Wide Belt
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedMana7
+UniqueIncreasedMana9
 {variant:1}UniqueLightningResist7[20,30]
 {variant:2}UniqueLightningResist7
 UniqueLifeRegeneration2
-Cannot be Shocked
+UniqueCannotBeShocked1
 ]],[[
 Cat O' Nine Tails
 Utility Belt
@@ -67,8 +67,8 @@ The Gnashing Sash
 Wide Belt
 League: Dawn of the Hunt
 UniqueFlaskLifeRecoveryRate7
-UniqueChaosResist14
-UniqueLifeDegenerationPercentGracePeriod2
+UniqueChaosResist33
+UniqueLifeDegenerationPercentGracePeriod1
 UniqueLifeFlasksOvercapLife1
 ]],[[
 Goregirdle
@@ -178,13 +178,13 @@ UniqueIncreasedFlaskChargesGained1
 ]],[[
 Midnight Braid
 Rawhide Belt
-UniqueIncreasedMana5
-UniqueAllResistances8
+UniqueIncreasedMana19
+UniqueAllResistances9
 UniqueDamageTakenGoesToMana1
 ]],[[
 Ryslatha's Coil
 Ornate Belt
-UniqueIncreasedLife7
+UniqueIncreasedLife19
 UniqueFlaskLifeRecoveryRate1
 UniquePhysicalMaximumDamageModifier1
 UniquePhysicalMinimumDamageModifier1
@@ -192,7 +192,7 @@ UniquePhysicalMinimumDamageModifier1
 Shavronne's Satchel
 Fine Belt
 UniqueFlaskLifeRecoveryRate3
-UniqueIntelligence9
+UniqueIntelligence20
 UniqueIncreasedFlaskChargesGained2
 UniqueFlaskLifeRecoveryEnergyShield1
 ]],[[
@@ -217,7 +217,7 @@ Waistgate
 Heavy Belt
 League: Dawn of the Hunt
 UniqueIncreasedLife45
-UniqueIncreasedMana50
+UniqueIncreasedMana38
 UniqueFlaskLifeRecoveryRate6
 UniqueFlaskManaRecoveryRate4
 UniqueLifeManaFlaskAnySlot1

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -11,7 +11,7 @@ UniqueIncreasedMana51
 UniqueGlobalCharmIncreasedDuration1
 UniqueAdditionalCharm3
 UniqueDexterity41
-BeltImplicitIncreasedCharmChargesGained1
+UniqueIncreasedCharmChargesGained2
 ]],[[
 Birthright Buckle
 Wide Belt

--- a/src/Export/Uniques/belt.lua
+++ b/src/Export/Uniques/belt.lua
@@ -199,7 +199,7 @@ UniqueFlaskLifeRecoveryEnergyShield1
 Soul Tether
 Long Belt
 UniqueIncreasedEnergyShield2
-UniqueIntelligence9
+UniqueIntelligence27
 UniqueLoseEnergyShieldPerSecond1
 UniqueLifeLeechExcessToEnergyShield1
 ]],[[

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -266,7 +266,7 @@ Smuggler Coat
 Variant: Pre 0.2.0
 Variant: Pre 0.4.0
 Variant: Current
-UniqueLocalIncreasedEvasionRatingPercent4
+UniqueLocalIncreasedEvasionRatingPercent19
 UniqueFireResist17
 UniqueColdResist17
 UniqueLightningResist14
@@ -752,8 +752,8 @@ Variant: Pre 0.1.1
 Variant: Current
 UniqueIncreasedMana16
 {variant:2}UniqueColdResist27
-{variant:1}UniqueLightningResist7[20,30]
-{variant:2}UniqueLightningResist7
+{variant:1}UniqueLightningResist12[20,30]
+{variant:2}UniqueLightningResist12
 UniquePowerChargeOnHit1
 UniqueLosePowerChargesOnMaxCharges1
 UniqueShockOnMaxPowerCharges1
@@ -764,9 +764,10 @@ Variant: Pre 0.4.0
 Variant: Pre 0.5.0
 Variant: Current
 UniqueLocalIncreasedEvasionAndEnergyShield5
-UniqueLightningResist2
+UniqueLightningResist5
+UniqueColdResist27
 {variant:1,2}UniqueEnergyShieldDelay1
-{variant:2,3}AllDamageTakenCanChillUnique__1
+{variant:2,3}AllDamageTakenCanChillUnique__2
 {variant:3}UniqueEnergyShieldRechargeRate8
 UniqueReverseChill1
 ]],[[

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -116,7 +116,7 @@ Greed's Embrace
 Vaal Cuirass
 UniqueIncreasedStrengthRequirements1
 UniqueMovementVelocity8
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent2
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent15
 UniqueItemFoundRarityIncrease12
 UniqueFireResist12
 ]],[[
@@ -256,7 +256,7 @@ Variant: Current
 {variant:2,3}UniqueLocalIncreasedEvasionRatingPercent23
 {variant:1}UniqueIncreasedLife1[30,50]
 {variant:2,3}UniqueIncreasedLife1
-UniqueChaosResist1
+UniqueChaosResist8
 UniqueLifeRegeneration1
 UniqueCannotBePoisoned1
 {variant:3}UniqueEvasionAppliesToDeflection2
@@ -424,10 +424,10 @@ Tetzlapokal's Desire
 Votive Raiment
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEnergyShieldPercent11
-UniqueStrength10
+UniqueLocalIncreasedEnergyShieldPercent17
+UniqueStrength22
 {variant:2}UniqueIntelligence32
-UniqueChaosResist1
+UniqueChaosResist13
 UniqueLifeRecharge1
 ]],[[
 Vis Mortis
@@ -454,9 +454,9 @@ Belly of the Beast
 Explorer Armour
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedArmourAndEvasion7
+UniqueLocalIncreasedArmourAndEvasion16
 UniqueIncreasedLife31
-UniqueStunThreshold9
+UniqueStunThreshold11
 UniqueInstantLifeFlaskRecovery1
 {variant:2}UniqueAttackerTakesDamage6
 ]],[[
@@ -659,7 +659,7 @@ Sacrificial Mantle
 League: Dawn of the Hunt
 Variant: Pre 0.5.0
 Variant: Current
-UniqueLocalIncreasedArmourAndEnergyShield12
+UniqueLocalIncreasedArmourAndEnergyShield13
 {variant:2}UniqueIncreasedSpirit15
 UniqueStrength42
 UniqueIntelligence40
@@ -773,9 +773,9 @@ UniqueReverseChill1
 Zerphi's Serape
 Scalper's Jacket
 League: Dawn of the Hunt
-UniqueLocalIncreasedEvasionAndEnergyShield11
-UniqueIncreasedMana7
-UniqueReducedLocalAttributeRequirements4
+UniqueLocalIncreasedEvasionAndEnergyShield9
+UniqueIncreasedMana21
+UniqueReducedLocalAttributeRequirements3
 UniqueLifeRegenerationRate2
 UniqueManaRegeneration31
 UniqueHasSoulEater1

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -7,20 +7,51 @@ Atziri's Splendour
 Sacrificial Regalia
 Source: Drops from unique{Atziri's Vault} in normal{Vaal Temple}
 League: Fate of the Vaal
-Variant: Helmet
-Variant: Gloves
-Variant: Boots
-Variant: Shield
+Selected Variant: 1
+Variant: Helmet (AR/EV/ES)
+Variant: Gloves (AR/EV/ES)
+Variant: Boots (AR/EV/ES)
+Variant: Shield (AR/EV/ES)
+Variant: Helmet (AR)
+Variant: Gloves (AR)
+Variant: Boots (AR)
+Variant: Shield (AR)
+Variant: Shield (ES)
+Variant: Helmet (EV)
+Variant: Gloves (EV)
+Variant: Boots (EV)
+Variant: Shield (EV)
+Variant: Helmet (ES)
+Variant: Gloves (ES)
+Variant: Boots (ES)
+Variant: Helmet (AR/EV)
+Variant: Gloves (AR/EV)
+Variant: Boots (AR/EV)
+Variant: Shield (AR/EV)
+Variant: Helmet (AR/ES)
+Variant: Gloves (AR/ES)
+Variant: Boots (AR/ES)
+Variant: Shield (AR/ES)
+Variant: Helmet (EV/ES)
+Variant: Gloves (EV/ES)
+Variant: Boots (EV/ES)
+Variant: Shield (EV/ES)
 Sockets: S S S S S S
 UniqueOnlySocketSoulCores1
 UniqueLocalNoAttributeRequirements2
-UniqueAtziriSplendourArmourEvasionAndEnergyShield1
+{variant:1,2,3,4}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
+{variant:5,6,7,8}UniqueAtziriSplendourArmour1
+{variant:9,10,11,12}UniqueAtziriSplendourEvasion1
+{variant:13,14,15,16}UniqueAtziriSplendourEnergyShield1
+{variant:17,18,19,20}UniqueAtziriSplendourArmourAndEvasion1
+{variant:21,22,23,24}UniqueAtziriSplendourArmourAndEnergyShield1
+{variant:25,26,27,28}UniqueAtziriSplendourEnergyShieldAndEvasion1
 UniqueAllResistances27
 UniqueCorruptedSkillGemManaCostConvertedToLife1
-{variant:1}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
-{variant:2}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
-{variant:3}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
-{variant:4}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
+{variant:1,5,9,13,17,21,25}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
+{variant:2,6,10,14,18,22,26}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
+{variant:3,7,11,15,19,23,27}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
+{variant:4,8,12,16,20,24,28}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
 ]],[[
 Blackbraid
 Fur Plate

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -24,19 +24,19 @@ Variant: EV/ES
 Sockets: S S S S S S
 UniqueOnlySocketSoulCores1
 UniqueLocalNoAttributeRequirements2
-{variant:5}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
-{variant:6}UniqueAtziriSplendourArmour1
-{variant:7}UniqueAtziriSplendourEvasion1
-{variant:8}UniqueAtziriSplendourEnergyShield1
-{variant:9}UniqueAtziriSplendourArmourAndEvasion1
-{variant:10}UniqueAtziriSplendourArmourAndEnergyShield1
-{variant:11}UniqueAtziriSplendourEnergyShieldAndEvasion1
+{variant:5}{group:2}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
+{variant:6}{group:2}UniqueAtziriSplendourArmour1
+{variant:7}{group:2}UniqueAtziriSplendourEvasion1
+{variant:8}{group:2}UniqueAtziriSplendourEnergyShield1
+{variant:9}{group:2}UniqueAtziriSplendourArmourAndEvasion1
+{variant:10}{group:2}UniqueAtziriSplendourArmourAndEnergyShield1
+{variant:11}{group:2}UniqueAtziriSplendourEnergyShieldAndEvasion1
 UniqueAllResistances27
 UniqueCorruptedSkillGemManaCostConvertedToLife1
-{variant:1}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
-{variant:2}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
-{variant:3}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
-{variant:4}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
+{variant:1}{group:1}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
+{variant:2}{group:1}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
+{variant:3}{group:1}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
+{variant:4}{group:1}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
 ]],[[
 Blackbraid
 Fur Plate

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -14,13 +14,13 @@ Variant: Helmet
 Variant: Gloves
 Variant: Boots
 Variant: Shield
-Variant: AR/EV/ES
-Variant: AR
-Variant: EV
-Variant: ES
-Variant: AR/EV
-Variant: AR/ES
-Variant: EV/ES
+Variant: Armour/Evasion/Energy Shield
+Variant: Armour
+Variant: Evasion
+Variant: Energy Shield
+Variant: Armour/Evasion
+Variant: Armour/Energy Shield
+Variant: Evasion/Energy Shield
 Sockets: S S S S S S
 UniqueOnlySocketSoulCores1
 UniqueLocalNoAttributeRequirements2

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -23,7 +23,7 @@ Variant: Armour/Energy Shield
 Variant: Evasion/Energy Shield
 Sockets: S S S S S S
 UniqueOnlySocketSoulCores1
-UniqueLocalNoAttributeRequirements2
+UniqueLocalNoAttributeRequirements1
 {variant:5}{group:2}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
 {variant:6}{group:2}UniqueAtziriSplendourArmour1
 {variant:7}{group:2}UniqueAtziriSplendourEvasion1
@@ -107,6 +107,7 @@ UniqueFireResist12
 ]],[[
 The Road Warrior
 Raider Plate
+Source: No longer obtainable
 Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalIncreasedPhysicalDamageReductionRatingPercent7
@@ -128,8 +129,8 @@ UniqueRemoveSpirit1
 ]],[[
 Kingsguard
 Full Plate
-UniqueIncreasedLife14
-UniqueIncreasedMana7
+UniqueIncreasedLife28
+UniqueIncreasedMana17
 UniqueAllResistances8
 UniqueEnduranceChargeDuration1
 UniqueLifeGainedOnEnduranceChargeConsumed1
@@ -150,9 +151,9 @@ Wandering Reliquary
 Steel Plate
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent7
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent13
 UniqueIncreasedMana7
-UniqueStrength2
+UniqueStrength12
 {variant:2}UniqueStunThreshold16
 UniquePhysicalDamagePreventedRecoup1
 ]],
@@ -162,8 +163,8 @@ Ashrend
 Pathfinder Coat
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedLife3
-{variant:2}UniqueStrength29
+UniqueIncreasedLife16
+{variant:2}UniqueStrength31
 {variant:1}UniqueFireResist8[20,30]
 {variant:2}UniqueFireResist8
 UniqueCannotBeIgnited1
@@ -187,7 +188,7 @@ Variant: Current
 {variant:2,3}UniqueLocalIncreasedEvasionRatingPercent22
 UniqueFlaskLifeRecoveryRate2
 UniqueFlaskManaRecoveryRate1
-UniqueDexterity3
+UniqueDexterity11
 UniqueColdResist10
 {variant:3}UniqueEvasionAppliesToDeflection1
 ]],[[
@@ -197,22 +198,22 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalIncreasedEvasionRatingPercent5[40,80]
 {variant:2}UniqueLocalIncreasedEvasionRatingPercent5
-UniqueIncreasedLife3
-{variant:2}UniqueLifeRegeneration11
+UniqueIncreasedLife4
+{variant:2}UniqueLifeRegeneration15
 {variant:1}UniqueGainRageWhenHit1[3,3]
 {variant:2}UniqueGainRageWhenHit1
 UniqueGainRageWhenCrit1
 ]],[[
 Dustbloom
 Studded Vest
-UniqueLocalIncreasedEvasionRatingPercent4
-UniqueColdResist10
+UniqueLocalIncreasedEvasionRatingPercent9
+UniqueColdResist11
 UniqueFragileRegrowth1
 ]],[[
 Foxshade
 Quilted Vest
 UniqueLocalIncreasedEvasionRating2
-UniqueDexterity3
+UniqueDexterity8
 UniqueMovementVelocityOnFullLife1
 UniqueGlobalEvasionOnFullLife1
 ]],[[
@@ -261,7 +262,7 @@ UniqueLightningResist14
 ]],[[
 The Rat Cage
 Scout's Vest
-UniqueLocalIncreasedEvasionRatingPercent4
+UniqueLocalIncreasedEvasionRatingPercent11
 UniqueIncreasedLife26
 UniqueReducedLocalAttributeRequirements1
 UniqueFireDamageTakenAsPhysical1
@@ -355,7 +356,7 @@ UniqueChaosResist4
 Gloamgown
 Elementalist Robe
 League: Dawn of the Hunt
-UniqueLocalIncreasedEnergyShieldPercent16
+UniqueLocalIncreasedEnergyShieldPercent23
 UniqueIncreasedSpirit10
 UniqueColdResist31
 UniqueEnergyShieldRechargeRate6
@@ -365,8 +366,8 @@ Necromantle
 Bone Raiment
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedLife3
-UniqueIncreasedMana5
+UniqueIncreasedLife18
+UniqueIncreasedMana8
 {variant:2}UniqueMinionChaosResistance1
 UniqueMinionLifeGainAsEnergyShield1
 UniqueMinionReviveSpeed1
@@ -375,7 +376,7 @@ Prayers for Rain
 Keth Raiment
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEnergyShieldPercent1
+UniqueLocalIncreasedEnergyShieldPercent9
 UniqueIntelligence13
 {variant:2}UniqueLightningResist22
 UniqueEnergyShieldDelay2
@@ -388,9 +389,9 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:2}UniqueLocalIncreasedEnergyShieldPercent27
 UniqueIncreasedSpirit11
-UniqueIntelligence39
+UniqueIntelligence37
 {variant:1}UniqueAllResistances6
-UniqueEnergyShieldRechargeRate4
+UniqueEnergyShieldRechargeRate7
 UniqueEnergyShieldAppliesElementalReduction1
 ]],[[
 Temporalis
@@ -399,7 +400,7 @@ Source: Drops from unique{Zarokh, the Temporal}
 Variant: Pre 0.2.0
 Variant: Current
 UniqueLocalIncreasedEnergyShield9
-UniqueAllResistances6
+UniqueAllResistances13
 UniqueDamageTakenGainedAsLife1
 UniqueDamageTakenGoesToMana2
 {variant:1}UniqueFlatCooldownRecovery1[-4000,-2000]
@@ -487,7 +488,7 @@ Irongrasp
 Vagabond Armour
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedArmourAndEvasion7
+UniqueLocalIncreasedArmourAndEvasion9
 {variant:2}UniqueStrength32
 UniqueStunThreshold9
 UniqueIronGrip1
@@ -538,7 +539,7 @@ Pragmatism
 Explorer Armour
 Source: Drops from unique{The King in the Mists} in normal{Crux of Nothingness}
 UniqueLocalIncreasedArmourAndEvasion22
-UniqueAllResistances6
+UniqueAllResistances15
 UniqueChaosResist19
 UniqueCharmsNoCharges1
 ]],[[
@@ -557,9 +558,9 @@ Knight Armour
 League: Dawn of the Hunt
 Variant: Pre 0.4.0
 Variant: Current
-UniqueLocalIncreasedArmourAndEvasion30
+UniqueLocalIncreasedArmourAndEvasion28
 UniqueIncreasedLife48
-UniqueChaosResist35
+UniqueChaosResist28
 UniqueAilmentThreshold2
 {variant:1}UniqueLifeLossReservesLife1[5000,5000]
 {variant:2}UniqueLifeLossReservesLife1
@@ -570,10 +571,10 @@ Couture of Crimson
 Gilded Vestments
 Variant: Pre 0.4.0
 Variant: Current
-UniqueLocalIncreasedArmourAndEnergyShield5
+UniqueLocalIncreasedArmourAndEnergyShield11
 {variant:1}UniqueMaximumLifeIncrease4[-25,-25]
 {variant:2}UniqueMaximumLifeIncrease4
-UniqueReducedBleedDuration1
+UniqueReducedBleedDuration2
 UniqueLifeLeechOvercapLife1
 ]],[[
 Decree of Loyalty
@@ -588,9 +589,9 @@ UniqueDamageOvertimeDoesNotBypassEnergyShield1
 ]],[[
 Enfolding Dawn
 Pilgrim Vestments
-UniqueLocalIncreasedArmourAndEnergyShield5
+UniqueLocalIncreasedArmourAndEnergyShield6
 UniqueIncreasedSpirit1
-UniqueAllResistances2
+UniqueAllResistances5
 UniqueNoManaPerIntelligence1
 ]],[[
 Reverie
@@ -631,10 +632,10 @@ Corvus Mantle
 League: Dawn of the Hunt
 Variant: Pre 0.4.0
 Variant: Current
-UniqueLocalIncreasedArmourAndEnergyShield23
-UniqueStrength33
+UniqueLocalIncreasedArmourAndEnergyShield19
+UniqueStrength35
 UniqueIntelligence33
-UniqueChaosResist33
+UniqueChaosResist26
 {variant:1}UniqueDamageTakenGainedAsLife2[5,10]
 {variant:2}UniqueDamageTakenGainedAsLife2
 UniqueLifeRecoupAppliesToEnergyShield1
@@ -668,7 +669,7 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:1}UniqueLocalIncreasedArmourAndEnergyShield9[100,150]
 {variant:2}UniqueLocalIncreasedArmourAndEnergyShield9
-UniqueMaximumManaIncrease2
+UniqueMaximumManaIncrease4
 {variant:2,3}UniqueChaosResist24
 UniquePowerChargeOnCritChance1
 ]],[[
@@ -686,8 +687,8 @@ UniqueGainManaAsExtraArmour1
 [[
 Apron of Emiran
 Hermit Garb
-UniqueLocalIncreasedEvasionAndEnergyShield1
-UniqueDexterity2
+UniqueLocalIncreasedEvasionAndEnergyShield6
+UniqueDexterity12
 UniqueReducedBleedDuration1
 UniqueBleedsAlwaysAggravated1
 ]],[[
@@ -726,7 +727,7 @@ Waxed Jacket
 Variant: Pre 0.1.1
 Variant: Current
 UniqueLocalIncreasedEvasionRatingPercent4
-UniqueDexterity2
+UniqueDexterity7
 {variant:2}UniqueFireResist29
 UniqueLightRadius2
 UniqueSmokeCloudWhenStationary1
@@ -736,7 +737,6 @@ Anchorite Garb
 Variant: Pre 0.1.1
 Variant: Current
 UniqueIncreasedMana16
-{variant:2}UniqueColdResist27
 {variant:1}UniqueLightningResist12[20,30]
 {variant:2}UniqueLightningResist12
 UniquePowerChargeOnHit1

--- a/src/Export/Uniques/body.lua
+++ b/src/Export/Uniques/body.lua
@@ -7,51 +7,36 @@ Atziri's Splendour
 Sacrificial Regalia
 Source: Drops from unique{Atziri's Vault} in normal{Vaal Temple}
 League: Fate of the Vaal
+Has Alt Variant: true
 Selected Variant: 1
-Variant: Helmet (AR/EV/ES)
-Variant: Gloves (AR/EV/ES)
-Variant: Boots (AR/EV/ES)
-Variant: Shield (AR/EV/ES)
-Variant: Helmet (AR)
-Variant: Gloves (AR)
-Variant: Boots (AR)
-Variant: Shield (AR)
-Variant: Shield (ES)
-Variant: Helmet (EV)
-Variant: Gloves (EV)
-Variant: Boots (EV)
-Variant: Shield (EV)
-Variant: Helmet (ES)
-Variant: Gloves (ES)
-Variant: Boots (ES)
-Variant: Helmet (AR/EV)
-Variant: Gloves (AR/EV)
-Variant: Boots (AR/EV)
-Variant: Shield (AR/EV)
-Variant: Helmet (AR/ES)
-Variant: Gloves (AR/ES)
-Variant: Boots (AR/ES)
-Variant: Shield (AR/ES)
-Variant: Helmet (EV/ES)
-Variant: Gloves (EV/ES)
-Variant: Boots (EV/ES)
-Variant: Shield (EV/ES)
+Selected Alt Variant: 5
+Variant: Helmet
+Variant: Gloves
+Variant: Boots
+Variant: Shield
+Variant: AR/EV/ES
+Variant: AR
+Variant: EV
+Variant: ES
+Variant: AR/EV
+Variant: AR/ES
+Variant: EV/ES
 Sockets: S S S S S S
 UniqueOnlySocketSoulCores1
 UniqueLocalNoAttributeRequirements2
-{variant:1,2,3,4}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
-{variant:5,6,7,8}UniqueAtziriSplendourArmour1
-{variant:9,10,11,12}UniqueAtziriSplendourEvasion1
-{variant:13,14,15,16}UniqueAtziriSplendourEnergyShield1
-{variant:17,18,19,20}UniqueAtziriSplendourArmourAndEvasion1
-{variant:21,22,23,24}UniqueAtziriSplendourArmourAndEnergyShield1
-{variant:25,26,27,28}UniqueAtziriSplendourEnergyShieldAndEvasion1
+{variant:5}UniqueAtziriSplendourArmourEvasionAndEnergyShield1
+{variant:6}UniqueAtziriSplendourArmour1
+{variant:7}UniqueAtziriSplendourEvasion1
+{variant:8}UniqueAtziriSplendourEnergyShield1
+{variant:9}UniqueAtziriSplendourArmourAndEvasion1
+{variant:10}UniqueAtziriSplendourArmourAndEnergyShield1
+{variant:11}UniqueAtziriSplendourEnergyShieldAndEvasion1
 UniqueAllResistances27
 UniqueCorruptedSkillGemManaCostConvertedToLife1
-{variant:1,5,9,13,17,21,25}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
-{variant:2,6,10,14,18,22,26}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
-{variant:3,7,11,15,19,23,27}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
-{variant:4,8,12,16,20,24,28}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
+{variant:1}UniqueLocalSoulCoreAlsoGainBenefitsFromHelmet1
+{variant:2}UniqueLocalSoulCoreAlsoGainBenefitsFromGloves1
+{variant:3}UniqueLocalSoulCoreAlsoGainBenefitsFromBoots1
+{variant:4}UniqueLocalSoulCoreAlsoGainBenefitsFromShield1
 ]],[[
 Blackbraid
 Fur Plate

--- a/src/Export/Uniques/boots.lua
+++ b/src/Export/Uniques/boots.lua
@@ -254,8 +254,8 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:1,2}UniqueMovementVelocity17[10,15]
 {variant:3}UniqueMovementVelocity17
-UniqueLocalIncreasedEvasionAndEnergyShield9
-UniqueIntelligence6
+UniqueLocalIncreasedEvasionAndEnergyShield11
+UniqueIntelligence26
 UniqueMaximumPowerCharges1
 {variant:1}UniqueCriticalMultiplierPerPowerCharge1[8,8]
 {variant:2,3}UniqueCriticalMultiplierPerPowerCharge1

--- a/src/Export/Uniques/boots.lua
+++ b/src/Export/Uniques/boots.lua
@@ -20,14 +20,14 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueMovementVelocity20[15,15]
 {variant:2}UniqueMovementVelocity20
-UniqueIncreasedLife3
-{variant:1}UniqueFireResist14[10,20]
-{variant:2}UniqueFireResist14
+UniqueIncreasedLife34
+{variant:1}UniqueFireResist21[10,20]
+{variant:2}UniqueFireResist21
 UniqueBurningGroundWhileMovingMaximumLife1
 ]],[[
 Corpsewade
 Iron Greaves
-UniqueMovementVelocity1
+UniqueMovementVelocity4
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent9
 UniqueStrength11
 UniqueTriggerDecomposeOnStep1
@@ -36,9 +36,9 @@ The Infinite Pursuit
 Bronze Greaves
 Variant: Pre 0.1.1
 Variant: Current
-UniqueMovementVelocity1
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent2
-UniqueIncreasedLife7
+UniqueMovementVelocity9
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent16
+UniqueIncreasedLife23
 UniqueAilmentChanceRecieved1
 {variant:1}UniqueMovementVelocityWithAilment1[20,20]
 {variant:2}UniqueMovementVelocityWithAilment1
@@ -60,8 +60,8 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueMovementVelocity5[10,10]
 {variant:2}UniqueMovementVelocity5
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent7
-UniqueReducedLocalAttributeRequirements3
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent10
+UniqueReducedLocalAttributeRequirements4
 UniqueOverkillDamagePhysical1
 ]],
 -- Boots: Evasion
@@ -71,8 +71,8 @@ Laced Boots
 Variant: Pre 0.1.1
 Variant: Current
 UniqueMovementVelocity19
-UniqueIncreasedLife3
-UniqueStunThreshold7
+UniqueIncreasedLife33
+UniqueStunThreshold15
 {variant:1}UniqueThornsCriticalStrikeChance1[15,15]
 {variant:2}UniqueThornsCriticalStrikeChance1
 {variant:2}UniqueAttackerTakesDamage4
@@ -80,8 +80,8 @@ UniqueStunThreshold7
 Bushwhack
 Lizardscale Boots
 UniqueMovementVelocity10
-UniqueLocalIncreasedEvasionRatingPercent2
-UniqueDexterity2
+UniqueLocalIncreasedEvasionRatingPercent10
+UniqueDexterity16
 UniquePhysicalDamagePin1
 ]],[[
 Gamblesprint
@@ -127,16 +127,16 @@ Luminous Pace
 Straw Sandals
 Variant: Pre 0.1.1
 Variant: Current
-UniqueMovementVelocity1
-{variant:2}UniqueLocalIncreasedEnergyShield10
-UniqueIntelligence3
+UniqueMovementVelocity7
+{variant:2}UniqueLocalIncreasedEnergyShield12
+UniqueIntelligence15
 UniqueEnergyShieldRechargeRate1
 UniqueEnergyShieldDelay3
 ]],[[
 Wanderlust
 Wrapped Sandals
 UniqueMovementVelocity11
-UniqueLocalIncreasedEnergyShield1
+UniqueLocalIncreasedEnergyShield6
 UniqueDexterity21
 UniqueNoSlowPotency1
 ]],[[
@@ -144,10 +144,10 @@ Windscream
 Feathered Sandals
 Variant: Pre 0.1.1
 Variant: Current
-{variant:1}UniqueMovementVelocity2[10,15]
-{variant:2}UniqueMovementVelocity2
-UniqueLocalIncreasedEnergyShieldPercent10
-UniqueIntelligence6
+{variant:1}UniqueMovementVelocity14[10,15]
+{variant:2}UniqueMovementVelocity14
+UniqueLocalIncreasedEnergyShieldPercent15
+UniqueIntelligence23
 {variant:2}UniqueCurseCastSpeed1
 UniqueCurseNoActivationDelay1
 ]],[[
@@ -172,9 +172,9 @@ Darkray Vectors
 Braced Sabatons
 UniqueLocalIncreasedArmourAndEvasion6
 UniqueLightningResist4
-UniqueLightRadius1
+UniqueLightRadius6
 UniqueMovementVelocityPerFrenzyCharge1
-MaximumFrenzyChargesUniqueBootsStrDex2_
+UniqueMaximumFrenzyCharges1
 ]],[[
 The Knight-errant
 Mail Sabatons
@@ -188,7 +188,7 @@ UniqueIronReflexes1
 ]],[[
 Obern's Bastion
 Stacked Sabatons
-UniqueLocalIncreasedArmourAndEvasion12
+UniqueLocalIncreasedArmourAndEvasion18
 UniqueLifeRegeneration8
 UniqueStunRecovery1
 UniqueReducedChillDuration1
@@ -243,7 +243,7 @@ Variant: Pre 0.4.0.
 Variant: Current
 {variant:2}UniqueMovementVelocity28
 UniqueLocalIncreasedEvasionAndEnergyShield7
-UniqueIncreasedMana5
+UniqueIncreasedMana10
 UniqueChaosResist1
 UniqueDodgeRollPhasing1
 ]],[[

--- a/src/Export/Uniques/bow.lua
+++ b/src/Export/Uniques/bow.lua
@@ -13,7 +13,7 @@ Variant: Current
 {variant:2}UniqueLocalCriticalMultiplier1[30,40]
 {variant:3,4}UniqueLocalCriticalMultiplier1
 {variant:1,2,3}UniqueAdditionalArrow1
-UniqueLifeGainedFromEnemyDeath4
+UniqueLifeGainedFromEnemyDeath5
 UniqueManaGainedFromEnemyDeath6
 {variant:4}UniqueAdditionalArrowChance1
 ]],[[
@@ -23,8 +23,8 @@ League: Dawn of the Hunt
 Variant: Pre 0.4.0
 Variant: Current
 UniqueLocalAddedPhysicalDamage7
-UniqueDexterity4
-UniqueManaRegeneration3
+UniqueDexterity17
+UniqueManaRegeneration5
 {variant:1}UniqueLocalPhysicalDamageAddedAsEachElement1[50,50]
 {variant:2}UniqueLocalPhysicalDamageAddedAsEachElement1
 ]],[[
@@ -67,7 +67,7 @@ Variant: Current
 UniqueLocalIncreasedPhysicalDamagePercent14
 UniqueLocalIncreasedAccuracy8
 UniqueLocalIncreasedAttackSpeed22
-UniqueDexterity44
+UniqueDexterity42
 UniqueLioneyeDodgeRoll1
 {variant:1}UniqueRepeatNoEnemyInPresence[1,1]
 {variant:2}UniqueRepeatNoEnemyInPresence
@@ -106,7 +106,7 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:1}UniqueLocalAddedLightningDamage6[1,1][200,300]
 {variant:2}UniqueLocalAddedLightningDamage6
-UniqueLocalIncreasedAttackSpeed17
+UniqueLocalIncreasedAttackSpeed13
 UniqueLightningDamageConvertToChaos1
 UniqueChaosDamageCanShock1
 ]],[[

--- a/src/Export/Uniques/flask.lua
+++ b/src/Export/Uniques/flask.lua
@@ -72,7 +72,7 @@ UniqueCharmRecoverManaBasedOnLifeFlask1
 Beira's Anguish
 Dousing Charm
 League: Dawn of the Hunt
-UniqueFlaskChanceRechargeOnKill2
+UniqueFlaskChanceRechargeOnKill1
 UniqueCharmIgniteEnemiesInPresence1
 ]],[[
 The Black Cat
@@ -105,7 +105,7 @@ UniqueCharmRecoupChaosDamagePrevented1
 Nascent Hope
 Thawing Charm
 League: Dawn of the Hunt
-UniqueFlaskChanceRechargeOnKill1
+UniqueFlaskChanceRechargeOnKill2
 UniqueCharmStartEnergyShieldRecharge1
 ]],[[
 Ngamahu's Chosen

--- a/src/Export/Uniques/flask.lua
+++ b/src/Export/Uniques/flask.lua
@@ -14,12 +14,14 @@ UniqueFlaskDuration__1
 Olroth's Resolve
 Ultimate Life Flask
 Source: Drops from unique{Olroth, Origin of the Fall}
-Variant: Pre 0.4.0
-Variant: Current
-UniqueFlaskFullInstantRecovery1
+Version: Pre 0.4.0
+Version: Pre 0.5.0
+Version: Current
+{version:1,2}UniqueFlaskFullInstantRecovery1
 UniqueFlaskChargesUsed1
-{variant:1}UniqueFlaskOverhealToGuard1[10,10]
-{variant:2}UniqueFlaskOverhealToGuard1
+{version:1}UniqueFlaskOverhealToGuard1[10,10]
+{version:2}UniqueFlaskOverhealToGuard1
+{version:3}UniqueFlaskWardGainedAsGuard1
 ]],[[
 Opportunity
 Ultimate Life Flask

--- a/src/Export/Uniques/focus.lua
+++ b/src/Export/Uniques/focus.lua
@@ -9,7 +9,7 @@ Variant: Pre 0.5.0
 Variant: Current
 League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShieldPercent13
-UniqueEnergyShieldRechargeRate7
+UniqueEnergyShieldRechargeRate4
 {variant:1}UniqueEnergyShieldDelay5
 UniqueElementalDamageTakenAsChaos1
 UniqueChanceToBePoisoned1

--- a/src/Export/Uniques/focus.lua
+++ b/src/Export/Uniques/focus.lua
@@ -19,9 +19,9 @@ Carrion Call
 Engraved Focus
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedEnergyShield3
-UniqueMinionLife1
-UniqueManaRegeneration6
+UniqueLocalIncreasedEnergyShield7
+UniqueMinionLife4
+UniqueManaRegeneration15
 {variant:2}UniqueMinionDamage1
 UniqueMinionResistanceEqualYours1
 ]],[[
@@ -42,7 +42,7 @@ UniqueLocalIncreasedEnergyShield14
 {variant:1,2}UniqueSpellDamageOnWeapon5[60,80]
 {variant:3}UniqueSpellDamageOnWeapon5
 UniqueIntelligence41
-UniqueChaosResist16
+UniqueChaosResist27
 {variant:1}UniqueCriticalWeaknessOnSpellCrit1[3,5]
 {variant:2,3}UniqueCriticalWeaknessOnSpellCrit1
 ]],[[
@@ -50,9 +50,9 @@ The Eternal Spark
 Crystal Focus
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEnergyShieldPercent3
+UniqueLocalIncreasedEnergyShieldPercent19
 UniqueMaximumLightningResist2
-RingImplicitLightningResistance1
+UniqueLightningResist16
 {variant:2}UniqueManaRegeneration28
 {variant:1}UniqueManaRegenerationWhileStationary1[50,50]
 {variant:2}UniqueManaRegenerationWhileStationary1

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -106,9 +106,9 @@ UniqueGainFearIncarnateOnCulling1
 ]],[[
 Idle Hands
 Sectioned Bracers
-UniqueLocalIncreasedEvasionRatingPercent3
+UniqueLocalIncreasedEvasionRatingPercent7
 UniqueIncreasedAccuracy4
-UniqueIntelligence3
+UniqueIntelligence19
 UniqueIncreasedAttackSpeedFullMana1
 UniqueFullManaThreshold1
 ]],[[
@@ -140,7 +140,7 @@ Snakebite
 Spined Bracers
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEvasionRatingPercent3
+UniqueLocalIncreasedEvasionRatingPercent8
 UniqueChaosResist6
 {variant:2}UniqueLifeRegeneration12
 {variant:1}UniqueBaseChanceToPoison1[20,20]
@@ -164,7 +164,7 @@ UniqueDoubleIgniteChance1
 ]],[[
 Demon Stitcher
 Intricate Gloves
-UniqueIncreasedEnergyShield2
+UniqueLocalIncreasedEnergyShield4
 UniqueIncreasedLife15
 UniqueIncreasedCastSpeed7
 UniqueSacrificeLifeToGainEnergyShield1
@@ -317,7 +317,7 @@ UniqueCannotImmobilise1
 ]],[[
 Shackles of the Wretched
 Aged Cuffs
-UniqueLocalIncreasedArmourAndEnergyShield2
+UniqueLocalIncreasedArmourAndEnergyShield3
 UniqueChillImmunityWhenChilled1
 UniqueFreezeImmunityWhenFrozen1
 UniqueIgniteImmunityWhenIgnited1
@@ -362,7 +362,7 @@ Gauze Wraps
 Variant: Pre 0.1.1
 Variant: Pre 0.5.0
 Variant: Current
-UniqueLocalIncreasedEvasionAndEnergyShield1
+UniqueLocalIncreasedEvasionAndEnergyShield4
 UniqueIncreasedAttackSpeed1
 {variant:3}UniqueCannotInflictElementalAilments1
 {variant:1}UniqueBaseChanceToPoison2[5,10]

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -23,7 +23,7 @@ Variant: Current
 Dreadfist
 Bolstered Mitts
 League: Dawn of the Hunt
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent10
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent6
 UniqueCriticalMultiplier2
 UniqueImpaleOnCriticalHit1
 UniqueCriticalsCannotConsumeImpale1

--- a/src/Export/Uniques/gloves.lua
+++ b/src/Export/Uniques/gloves.lua
@@ -56,7 +56,7 @@ Variant: Pre 0.1.1
 Variant: Current
 UniqueIncreasedSkillSpeed1
 {variant:2}UniqueLocalIncreasedPhysicalDamageReductionRating3
-UniqueIncreasedLife3
+UniqueIncreasedLife9
 UniqueMaximumManaIncrease3
 UniqueShareChargesWithAllies1
 ]],[[
@@ -64,7 +64,7 @@ Empire's Grasp
 Titan Mitts
 League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent30
-UniqueStrength23
+UniqueStrength41
 UniqueLifeGainedFromEnemyDeath11
 UniqueIncreasedPhysicalDamagePercent1
 UniqueEnemyKnockbackDirectionReversed1
@@ -117,9 +117,9 @@ Fine Bracers
 Variant: Pre 0.4.0
 Variant: Current
 UniqueLocalIncreasedEvasionRatingPercent12
-UniqueCriticalStrikeChance1
+UniqueCriticalStrikeChance5
 UniqueIncreasedAttackSpeed3
-UniqueDexterity2
+UniqueDexterity19
 {variant:2}UniqueCriticalStrikesCannotBeRerolled1
 UniqueCriticalStrikeMultiplierOverride1
 ]],[[
@@ -173,7 +173,7 @@ Doedre's Tenure
 Stitched Gloves
 Variant: Pre 0.1.1
 Variant: Current
-{variant:2}UniqueLocalIncreasedEnergyShield12
+{variant:2}UniqueLocalIncreasedEnergyShield10
 UniqueSpellDamage1
 UniqueIncreasedCastSpeed6
 UniqueIntelligence18
@@ -183,22 +183,22 @@ Furtive Wraps
 League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionAndEnergyShield17
 UniqueAddedLightningDamage3
-UniqueIntelligence31
+UniqueIntelligence34
 UniqueLightningResist26
 UniqueLeechEnergyShieldInsteadofLife1
 ]],[[
 Kitoko's Current
 Jewelled Gloves
 UniqueLocalIncreasedEnergyShieldPercent7
-UniqueDexterity2
+UniqueDexterity10
 UniqueAttackAndCastSpeed1
 UniqueLightningDamageCanElectrocute1
 ]],[[
 Leopold's Applause
 Embroidered Gloves
 League: Dawn of the Hunt
-UniqueLocalIncreasedEnergyShieldPercent1
-UniqueIncreasedMana12
+UniqueLocalIncreasedEnergyShieldPercent25
+UniqueIncreasedMana48
 UniqueItemFoundRarityIncrease21
 UniqueElementalPenetration1
 UniqueElementalPenetrationBelowZero1
@@ -206,10 +206,10 @@ UniqueElementalPenetrationBelowZero1
 Nightscale
 Pauascale Gloves
 League: Dawn of the Hunt
-UniqueLocalIncreasedEnergyShieldPercent25
+UniqueLocalIncreasedEnergyShieldPercent20
 UniqueCriticalStrikeChance14
-UniqueIntelligence29
-UniqueColdResist34
+UniqueIntelligence10
+UniqueColdResist30
 UniqueManaRegenerationRateIfCritRecently1
 UniqueNoManaRegenIfNotCritRecently1
 ]],[[
@@ -233,7 +233,7 @@ Aerisvane's Wings
 Burnished Gauntlets
 UniqueLocalIncreasedArmourAndEvasion15
 UniqueIncreasedAttackSpeed4
-UniqueIntelligence9
+UniqueIntelligence22
 UniqueDecimatingStrike1
 ]],[[
 Aurseize
@@ -245,10 +245,10 @@ UniqueMaximumLifeOnKillPercent1
 Death Articulated
 Ornate Gauntlets
 League: Dawn of the Hunt
-UniqueLocalIncreasedArmourAndEvasion26
-UniqueIncreasedAttackSpeed8
-UniqueChaosResist25
-UniqueLifeDegenerationPercentGracePeriod1
+UniqueLocalIncreasedArmourAndEvasion30
+UniqueIncreasedAttackSpeed9
+UniqueChaosResist35
+UniqueLifeDegenerationPercentGracePeriod3
 UniqueRageRegeneration1
 UniqueNonherentRageLoss1
 ]],[[
@@ -268,17 +268,17 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueLocalIncreasedArmourAndEvasion25
 UniqueAddedPhysicalDamage3
-UniqueIncreasedLife6
+UniqueIncreasedLife10
 UniqueIncreasedAttackSpeed2
 UniqueStrengthSatisfiesAllWeaponRequirements1
 ]],[[
 Valako's Vice
 Plate Gauntlets
 League: Dawn of the Hunt
-UniqueLocalIncreasedArmourAndEvasion6
-UniqueIncreasedAttackSpeed9
-UniqueStrength41
-UniqueDexterity37
+UniqueLocalIncreasedArmourAndEvasion19
+UniqueIncreasedAttackSpeed11
+UniqueStrength23
+UniqueDexterity24
 UniqueLightningResist23
 UniqueFireDamageConvertToLightning1
 ]],
@@ -289,7 +289,7 @@ Goldcast Cuffs
 Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueLocalIncreasedEnergyShield11
-UniqueIntelligence6
+UniqueIntelligence12
 UniqueFireResist7
 UniqueColdResist9
 UniqueFireDamageConvertToCold1
@@ -328,7 +328,7 @@ UniqueReflectCurseToSelf1
 [[
 Blessed Bonds
 Linen Wraps
-Source: Drops from unique{Zarokh, the Temporal}
+Source: No longer obtainable
 UniqueLocalBaseEvasionRatingAndEnergyShield1
 UniqueManaGainedFromEnemyDeath8
 UniqueColdExposureOnIgnite1
@@ -352,7 +352,7 @@ Linen Wraps
 Variant: Pre 0.1.1
 Variant: Current
 UniqueLocalIncreasedEvasionAndEnergyShield2
-UniqueIncreasedLife10
+UniqueIncreasedLife6
 {variant:2}UniqueCriticalMultiplier3
 UniqueLifeFlaskNoRecovery1
 UniqueDoubleOnKillEffects1
@@ -387,7 +387,7 @@ Source: Drops from unique{Arbiter of Ash} in normal{The Burning Monolith}
 Variant: Pre 0.4.0
 Variant: Pre 0.5.0
 Variant: Current
-UniqueIncreasedSkillSpeed1
+UniqueIncreasedSkillSpeed5
 {variant:1}UniqueLocalArmourAndEvasionAndEnergyShield3[40,60]
 {variant:2}UniqueLocalArmourAndEvasionAndEnergyShield3[100,150]
 {variant:3}UniqueLocalArmourAndEvasionAndEnergyShield3

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -5,8 +5,8 @@ return {
 [[
 Black Sun Crest
 Wrapped Greathelm
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent4
-UniqueLightRadius2
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent8
+UniqueLightRadius4
 UniquePercentageStrength1
 UniquePercentageDexterity1
 UniquePercentageIntelligence1
@@ -14,10 +14,10 @@ UniquePercentageIntelligence1
 Blood Price
 Fierce Greathelm
 League: Dawn of the Hunt
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent29
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent26
 UniqueEnemiesInPresenceReservesLife1
 UniqueLifeRegeneration18
-UniqueStunThreshold18
+UniqueStunThreshold17
 UniquePresenceRadius3
 ]],[[
 Corona of the Red Sun
@@ -34,8 +34,8 @@ Deidbell
 Elite Greathelm
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedPhysicalDamageReductionRatingPercent1
-{variant:2}UniqueStrength31
+UniqueLocalIncreasedPhysicalDamageReductionRatingPercent21
+{variant:2}UniqueStrength30
 UniqueWarcrySpeed1
 UniqueWarcryCorpseExplosion1
 UniqueWarcryAreaOfEffect1
@@ -57,7 +57,7 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueLocalIncreasedPhysicalDamageReductionRating5
 UniqueItemFoundRarityIncrease4
-UniqueStrength10
+UniqueStrength17
 UniqueRageOnHit1
 UniqueIncreasedArmourPerRage1
 ]],[[
@@ -71,7 +71,7 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueLocalIncreasedPhysicalDamageReductionRating5
 UniqueItemFoundRarityIncrease4
-UniqueDexterity3
+UniqueDexterity15
 UniqueRageOnHit1
 UniqueIncreasedStunThresholdPerRage1
 ]],
@@ -79,8 +79,8 @@ UniqueIncreasedStunThresholdPerRage1
 [[
 Alpha's Howl
 Armoured Cap
-UniqueLocalIncreasedEvasionRatingPercent1
-UniqueIncreasedSpirit1
+UniqueLocalIncreasedEvasionRatingPercent18
+UniqueIncreasedSpirit4
 UniqueColdResist16
 UniqueDoublePresenceRadius1
 ]],[[
@@ -88,7 +88,7 @@ The Black Insignia
 Corsair Cap
 League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent24
-UniqueItemFoundRarityIncrease14
+UniqueItemFoundRarityIncrease20
 UniqueLightningResist24
 UniqueTailwindOnCriticalStrike1
 UniqueLoseTailwindOnHit1
@@ -109,7 +109,7 @@ Hunter Hood
 Variant: Pre 0.1.1
 Variant: Pre 0.5.0
 Variant: Current
-UniqueLocalIncreasedEvasionRatingPercent2
+UniqueLocalIncreasedEvasionRatingPercent21
 {variant:1}UniqueDexterity26[10,20]
 {variant:2,3}UniqueDexterity26
 {variant:1,2}UniqueCharmChargeGeneration1[30,30]
@@ -127,9 +127,9 @@ Heatshiver
 Velvet Cap
 League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent31
-UniqueIncreasedMana45
+UniqueIncreasedMana47
 UniqueFireResist33
-UniqueColdResist28
+UniqueColdResist34
 UniqueColdAddedAsFireChilledEnemy1
 ]],[[
 Innsmouth
@@ -138,15 +138,15 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueLocalIncreasedEvasionRating5
 UniqueMaximumManaIncrease2
-UniqueColdResist3
+UniqueColdResist6
 UniqueChaosResist3
 UniqueManaRegeneration4
 ]],[[
 Myris Uxor
 Covert Hood
-UniqueLocalIncreasedEvasionRatingPercent3
-UniqueIncreasedAccuracy5
-UniqueIncreasedMana7
+UniqueLocalIncreasedEvasionRatingPercent14
+UniqueIncreasedAccuracy6
+UniqueIncreasedMana18
 UniqueCullingStrikeThreshold1
 ]],[[
 Radiant Grief
@@ -154,8 +154,8 @@ Lace Hood
 Variant: Pre 0.5.0
 Variant: Current
 UniqueLocalIncreasedEvasionRatingPercent1
-UniqueFireResist6
-UniqueLightRadius7
+UniqueFireResist15
+UniqueLightRadius10
 {variant:1}UniqueIgniteEnemiesInPresence1[100,100]
 {variant:2}UniqueIgniteEnemiesInPresence1
 ]],[[
@@ -164,8 +164,8 @@ Leatherbound Hood
 League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent26
 UniqueCriticalStrikeChance13
-UniqueDexterity38
-EvasionRatingPercentOnLowLifeUniqueHelmetDex4
+UniqueDexterity36
+UniqueEvasionRatingPercentOnLowLife1
 UniqueDamageRemovedFromCompanion1
 ]],
 -- Helmet: Energy Shield
@@ -186,10 +186,10 @@ Variant: Current
 Crown of Eyes
 Vermeil Circlet
 League: Dawn of the Hunt
-UniqueLocalIncreasedEnergyShieldPercent23
+UniqueLocalIncreasedEnergyShieldPercent16
 UniqueIncreasedAccuracy9
-UniqueAllAttributes7
-UniqueFireResist9
+UniqueAllAttributes13
+UniqueFireResist19
 UniqueSpellDamageModifiersApplyToAttackDamage1
 ]],[[
 Crown of Thorns
@@ -203,10 +203,10 @@ The Devouring Diadem
 Wicker Tiara
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEnergyShieldPercent1
-{variant:2}UniqueIncreasedLife42
-UniqueIntelligence6
-UniqueChaosResist3
+UniqueLocalIncreasedEnergyShieldPercent4
+{variant:2}UniqueIncreasedLife43
+UniqueIntelligence7
+UniqueChaosResist5
 UniqueConsumeCorpseRecoverLife1
 ]],[[
 Forbidden Gaze
@@ -248,7 +248,7 @@ Variant: Pre 0.2.0
 Variant: Pre 0.4.0
 Variant: Current
 UniqueLocalIncreasedEnergyShield8
-UniqueDexterity3
+UniqueDexterity30
 UniqueEnemiesInPresenceBlinded1
 {variant:1}UniqueEnemiesInPresenceGainCritWeakness1[1,1]
 {variant:2}UniqueEnemiesInPresenceGainCritWeakness1[15,15]
@@ -259,7 +259,7 @@ Jade Tiara
 League: Dawn of the Hunt
 UniqueLocalIncreasedEnergyShield17
 UniqueSpellDamage3
-UniqueIncreasedMana28
+UniqueIncreasedMana40
 UniqueIncreasedCastSpeed12
 UniquePhysicalDamageOnSkillUse1
 ]],[[
@@ -267,10 +267,10 @@ Visage of Ayah
 Beaded Circlet
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedEnergyShieldPercent2
+UniqueLocalIncreasedEnergyShieldPercent8
 UniqueItemFoundRarityIncrease8
 UniqueCriticalStrikeChance1
-{variant:2}UniqueLightningResist22
+{variant:2}UniqueLightningResist21
 UniqueEldritchBattery1
 ]],
 -- Helmet: Armour/Evasion
@@ -359,10 +359,10 @@ Ironride
 Visored Helm
 Variant: Pre 0.1.1
 Variant: Current
-UniqueLocalIncreasedArmourAndEvasion11
+UniqueLocalIncreasedArmourAndEvasion20
 {variant:2}UniqueIncreasedLife44
-UniqueIncreasedMana5
-UniqueLightningResist14
+UniqueIncreasedMana25
+UniqueLightningResist15
 UniqueAccuracyUnaffectedDistance1
 ]],[[
 The Smiling Knight
@@ -377,9 +377,9 @@ UniqueAggravateBleedOnCrit1
 ]],[[
 The Vile Knight
 Shielded Helm
-UniqueLocalIncreasedArmourAndEvasion2
-UniqueIncreasedAccuracy7
-UniqueLifeRegeneration3
+UniqueLocalIncreasedArmourAndEvasion17
+UniqueIncreasedAccuracy8
+UniqueLifeRegeneration7
 UniqueBuildDamageAgainstRareAndUnique1
 ]],
 -- Helmet: Armour/Energy Shield
@@ -389,7 +389,7 @@ Horned Crown
 Variant: Pre 0.1.1
 Variant: Current
 UniqueMovementVelocity6
-UniqueLocalIncreasedArmourAndEnergyShield5
+UniqueLocalIncreasedArmourAndEnergyShield8
 {variant:1}UniqueIncreasedLife12[40,60]
 {variant:2}UniqueIncreasedLife12
 UniqueReducedChillEffectOnSelf1
@@ -409,7 +409,7 @@ Variant: Pre 0.1.1
 Variant: Current
 UniqueLocalIncreasedArmourAndEnergyShield5
 UniqueIncreasedLife13
-UniqueItemFoundRarityIncrease3
+UniqueItemFoundRarityIncrease9
 {variant:2}UniqueAttackerTakesDamage5
 UniqueThornsOnAnyHit1
 ]],[[
@@ -417,8 +417,8 @@ Crown of the Victor
 Iron Crown
 Variant: Pre 0.2.0
 Variant: Current
-{variant:1}UniqueItemFoundRarityIncrease2[10,20]
-{variant:2}UniqueItemFoundRarityIncrease2
+{variant:1}UniqueItemFoundRarityIncrease7[10,20]
+{variant:2}UniqueItemFoundRarityIncrease7
 UniqueLifeGainedFromEnemyDeath2
 UniqueManaGainedFromEnemyDeath3
 UniqueGlobalSkillGemLevel1
@@ -473,8 +473,8 @@ Variant: Current
 {variant:2}UniqueLocalIncreasedEvasionAndEnergyShield14
 {variant:1}UniqueCriticalStrikeChance3[20,40]
 {variant:2}UniqueCriticalStrikeChance3
-UniqueDexterity2
-UniqueIntelligence6
+UniqueDexterity13
+UniqueIntelligence14
 UniquePoisonOnCrit1
 ]],[[
 Glimpse of Chaos
@@ -506,7 +506,7 @@ Leer Cast
 Hooded Mask
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedLife32
+UniqueIncreasedLife5
 UniqueIncreasedMana5
 UniqueNearbyAlliesAllDamage1
 {variant:2}UniqueDexterity32
@@ -517,7 +517,7 @@ Face Mask
 UniqueLocalBaseEvasionRatingAndEnergyShield2
 UniqueSpellCriticalStrikeChance1
 UniqueStrength8
-UniqueIntelligence10
+UniqueIntelligence6
 UniqueBloodMagic1
 ]],[[
 Mind of the Council
@@ -528,14 +528,14 @@ Variant: Current
 {variant:1}UniqueLocalIncreasedEvasionAndEnergyShield16[60,90]
 {variant:2}UniqueLocalIncreasedEvasionAndEnergyShield16
 UniqueIncreasedMana42
-UniqueLightningResist20
+UniqueLightningResist25
 UniqueAttackManaCost1
 UniqueAttackMaxLightningDamage1
 ]],[[
 The Three Dragons
 Solid Mask
 UniqueLocalIncreasedEvasionAndEnergyShield8
-UniqueAllResistances6
+UniqueAllResistances7
 UniqueFireShocks1
 UniqueColdIgnites1
 UniqueLightningFreezes1
@@ -559,8 +559,8 @@ Grand Visage
 Source: Drops from unique{Arbiter of Ash} in normal{The Burning Monolith}
 Variant: Pre 0.4.0
 Variant: Current
-UniqueIncreasedMana12
-UniqueLightRadius9
+UniqueIncreasedMana34
+UniqueLightRadius15
 {variant:1}UniqueLocalArmourAndEvasionAndEnergyShield2[100,150]
 {variant:2}UniqueLocalArmourAndEvasionAndEnergyShield2
 UniqueGlobalItemAttributeRequirements2

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -174,10 +174,10 @@ Atziri's Disdain
 Gold Circlet
 Variant: 0.2.0
 Variant: Current
-{variant:1}UniqueIncreasedMana12[40,60]
-{variant:2}UniqueIncreasedMana12
-{variant:1}UniqueItemFoundRarityIncrease2[10,20]
-{variant:2}UniqueItemFoundRarityIncrease2
+{variant:1}UniqueIncreasedMana26[40,60]
+{variant:2}UniqueIncreasedMana26
+{variant:1}UniqueItemFoundRarityIncrease14[10,20]
+{variant:2}UniqueItemFoundRarityIncrease14
 {variant:1}UniqueDamageBypassEnergyShieldPercent1[20,25]
 {variant:2}UniqueDamageBypassEnergyShieldPercent1
 {variant:1}UniqueEnergyShieldAsPercentOfLife1[25,30]
@@ -237,7 +237,7 @@ UniqueCannotRecoverManaExceptRegen1
 Mask of the Stitched Demon
 Feathered Tiara
 UniqueLocalIncreasedEnergyShieldPercent18
-UniqueChaosResist1
+UniqueChaosResist14
 UniqueCannotGainEnergyShield1
 UniqueLifeRegenPerEnergyShield1
 ]],[[
@@ -545,9 +545,9 @@ Tribal Mask
 Variant: Pre 0.4.0
 Variant: Equipment
 Variant: Skill Gems
-UniqueLocalIncreasedEvasionAndEnergyShield7
-UniqueCriticalStrikeChance1
-UniqueChaosResist2
+UniqueLocalIncreasedEvasionAndEnergyShield10
+UniqueCriticalStrikeChance8
+UniqueChaosResist15
 {variant:1}UniqueGlobalItemAttributeRequirements1
 {variant:2}UniqueGlobalEquipmentAttributeRequirements1
 {variant:3}UniqueGlobalGemAttributeRequirements1

--- a/src/Export/Uniques/helmet.lua
+++ b/src/Export/Uniques/helmet.lua
@@ -545,6 +545,7 @@ Tribal Mask
 Variant: Pre 0.4.0
 Variant: Equipment
 Variant: Skill Gems
+UniqueLocalNoAttributeRequirements2
 UniqueLocalIncreasedEvasionAndEnergyShield10
 UniqueCriticalStrikeChance8
 UniqueChaosResist15

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -36,7 +36,7 @@ Radius: Variable
 {variant:6}Only affects Passives in Large Ring
 {variant:7}Only affects Passives in Very Large Ring
 {variant:8}Only affects Passives in Massive Ring
-JewelUniqueAllocateDisconnectedPassives
+AllocateDisconnectedPassivesDonutUnique__1
 UniqueAllResistances12
 {version:1}UniqueChaosResist18
 ]],[[

--- a/src/Export/Uniques/mace.lua
+++ b/src/Export/Uniques/mace.lua
@@ -77,8 +77,8 @@ Torment Club
 Source: Drops from unique{Olroth, Origin of the Fall}
 Variant: Pre 0.2.0
 Variant: Current
-{variant:1}UniqueLocalAddedLightningDamage1[1,1][60,80]
-{variant:2}UniqueLocalAddedLightningDamage1
+{variant:1}UniqueLocalAddedLightningDamage4[1,1][60,80]
+{variant:2}UniqueLocalAddedLightningDamage4
 UniqueLocalIncreasedAccuracy5
 UniqueLocalIncreasedAttackSpeed10
 UniqueMaximumLightningDamagePerPower1
@@ -155,9 +155,9 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalAddedPhysicalDamage9[10,12][18,22]
 {variant:2}UniqueLocalAddedPhysicalDamage9
-{variant:1}UniqueLocalAddedLightningDamage3[1,1][36,42]
-{variant:2}UniqueLocalAddedLightningDamage3
-UniqueLocalIncreasedAttackSpeed5
+{variant:1}UniqueLocalAddedLightningDamage10[1,1][36,42]
+{variant:2}UniqueLocalAddedLightningDamage10
+UniqueLocalIncreasedAttackSpeed7
 UniqueLocalAllDamageCanElectrocute1
 ]],[[
 Chober Chaber

--- a/src/Export/Uniques/mace.lua
+++ b/src/Export/Uniques/mace.lua
@@ -220,8 +220,8 @@ UniqueAftershockChance1
 ]],[[
 Quecholli
 Crumbling Maul
-UniqueLocalIncreasedPhysicalDamagePercent4
-UniqueAllAttributes7
+UniqueLocalIncreasedPhysicalDamagePercent8
+UniqueAllAttributes8
 UniqueLifeGainedFromEnemyDeath8
 UniqueLocalCritChanceOverride1
 UniqueLocalNoCriticalStrikeMultiplier1

--- a/src/Export/Uniques/mace.lua
+++ b/src/Export/Uniques/mace.lua
@@ -18,7 +18,7 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalAddedPhysicalDamage5[3,4][6,8]
 {variant:2}UniqueLocalAddedPhysicalDamage5
-UniqueLocalIncreasedAccuracy1
+UniqueLocalIncreasedAccuracy2
 {variant:2}UniqueLocalIncreasedAttackSpeed12
 {variant:1}UniqueStrength15[5,10]
 {variant:2}UniqueStrength15
@@ -154,7 +154,6 @@ Studded Greatclub
 Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalAddedPhysicalDamage9[10,12][18,22]
-{variant:2}UniqueLocalAddedPhysicalDamage9
 {variant:1}UniqueLocalAddedLightningDamage10[1,1][36,42]
 {variant:2}UniqueLocalAddedLightningDamage10
 UniqueLocalIncreasedAttackSpeed7
@@ -168,7 +167,7 @@ Variant: Current
 UniqueIntelligenceRequirements1
 {variant:1}UniqueLocalIncreasedPhysicalDamagePercent4
 {variant:2,3}UniqueLocalAddedPhysicalDamage12
-UniqueIncreasedMana22
+UniqueIncreasedMana28
 {variant:2,3}UniqueIncreasedSpirit8
 {variant:1}UniqueLocalCriticalStrikeChance3
 UniqueMinionDamageAffectsYou1
@@ -214,7 +213,7 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalIncreasedPhysicalDamagePercent6[60,80]
 {variant:2}UniqueLocalIncreasedPhysicalDamagePercent6
-UniqueStrength3
+UniqueStrength26
 UniqueLifeGainedFromEnemyDeath6
 UniqueAftershockChance1
 ]],[[
@@ -273,7 +272,7 @@ Temple Maul
 League: Dawn of the Hunt
 UniqueDexterityRequirements1
 UniqueStrengthRequirements1
-UniqueLocalIncreasedPhysicalDamagePercent5
+UniqueLocalIncreasedPhysicalDamagePercent10
 UniqueLocalIncreasedAttackSpeed15
 UniqueLightRadius17
 UniqueAlwaysHits1

--- a/src/Export/Uniques/quiver.lua
+++ b/src/Export/Uniques/quiver.lua
@@ -8,8 +8,8 @@ Broadhead Quiver
 Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueAddedColdDamage2
-UniqueIncreasedAttackSpeed4
-UniqueColdResist4
+UniqueIncreasedAttackSpeed5
+UniqueColdResist18
 UniqueEnemiesChilledIncreasedDamageTaken1
 UniqueDamageAddedAsColdAttacks1
 ]],[[
@@ -26,7 +26,7 @@ Fire Quiver
 Variant: Pre 0.1.1
 Variant: Current
 {variant:2}UniqueAddedFireDamage1
-UniqueIncreasedMana5
+UniqueIncreasedMana23
 UniqueIgniteChanceIncrease3
 UniqueAlwaysPierceBurningEnemies1
 UniqueDamageAddedAsFireAttacks1
@@ -52,7 +52,7 @@ Sacral Quiver
 League: Dawn of the Hunt
 Variant: Pre 0.4.0
 Variant: Current
-UniqueIncreasedAttackSpeed5
+UniqueIncreasedAttackSpeed10
 UniqueLifeGainPerTarget2
 UniqueArrowPierceChance1
 {variant:1}UniqueBowDamageFromLifeFlaskCharges1[10,10][5,5]

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -63,6 +63,7 @@ UniqueLifeRegeneration4
 {variant:1}UniqueAddedChaosDamage1[2,3][4,5]
 {variant:2}UniqueAddedChaosDamage1
 UniqueChanceToIntimidateOnHit1
+{variant:2}UniqueArmourAppliesToChaosDamage1
 ]],[[
 Blistering Bond
 Ruby Ring

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -255,9 +255,9 @@ Seed of Cataclysm
 Lazuli Ring
 Variant: Pre 0.5.0
 Variant: Current
-UniqueSpellCriticalStrikeChance2
+UniqueSpellCriticalStrikeChance3
 {variant:1}UniqueSpellCriticalStrikeMultiplier1
-UniqueChaosResist2
+UniqueChaosResist20
 UniqueManaCostReduction2
 {variant:2}UniqueSpellCriticalStrikeMultiplierPerSpellCritRecently1
 {variant:2}UniqueChanceForSpellCriticalHitsToBeLucky1

--- a/src/Export/Uniques/ring.lua
+++ b/src/Export/Uniques/ring.lua
@@ -68,8 +68,8 @@ Blistering Bond
 Ruby Ring
 Variant: Pre 0.5.0
 Variant: Current
-UniqueIncreasedLife3
-UniqueFireResist18
+UniqueIncreasedLife40
+UniqueFireResist26
 UniqueColdResist22
 UniqueSelfBleedFireDamage1
 {variant:2}UniqueFireDamageAlsoContributesToBleed1
@@ -81,7 +81,7 @@ Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueColdResist23[-15,-10]
 {variant:2}UniqueColdResist23
-UniqueLightningResist4
+UniqueLightningResist20
 {variant:1}UniqueManaRegeneration27[25,35]
 {variant:2}UniqueManaRegeneration27
 UniqueEnemyExtraDamageRollsWithLightningDamage1
@@ -91,13 +91,13 @@ Unset Ring
 League: Dawn of the Hunt
 UniqueItemFoundRarityIncrease22
 UniqueChaosResist34
-UniqueLifeDegenerationPercentGracePeriod3
+UniqueLifeDegenerationPercentGracePeriod2
 UniquePhysicalDamageMaximumLife1
 ]],[[
 Call of the Brotherhood
 Topaz Ring
-UniqueIntelligence6
-UniqueManaRegeneration18
+UniqueIntelligence29
+UniqueManaRegeneration19
 UniqueFreezeDamageIncrease4
 UniqueLightningDamageConvertToCold1
 ]],[[
@@ -105,7 +105,7 @@ Cracklecreep
 Ruby Ring
 UniqueFireDamagePercent1
 UniqueLifeRegeneration9
-UniqueManaRegeneration6
+UniqueManaRegeneration16
 UniqueRingIgniteProliferation1
 ]],[[
 Death Rush
@@ -147,7 +147,7 @@ UniqueAllAttributes9
 Evergrasping Ring
 Pearl Ring
 League: Dawn of the Hunt
-UniqueIncreasedMana12
+UniqueIncreasedMana39
 UniqueAlliesInPresenceGainedAsChaos1
 UniqueEnemiesInPresenceGainedAsChaos1
 ]],[[
@@ -163,7 +163,7 @@ Glowswarm
 Lazuli Ring
 Variant: Pre 0.5.0
 Variant: Current
-UniqueIncreasedMana7
+UniqueIncreasedMana35
 UniqueFlaskManaRecoveryRate3
 UniqueManaFlaskChargeGeneration2
 {variant:2}UniqueGuardFromManaFlask1
@@ -171,7 +171,7 @@ UniqueManaFlaskChargeGeneration2
 Heartbound Loop
 Pearl Ring
 UniqueMinionLife3
-UniqueLifeRegeneration3
+UniqueLifeRegeneration6
 UniqueManaRegeneration11
 UniqueSelfPhysicalDamageOnMinionDeath1
 UniqueMinionReviveSpeed2
@@ -179,8 +179,8 @@ UniqueMinionReviveSpeed2
 Icefang Orbit
 Iron Ring
 League: Dawn of the Hunt
-UniqueAddedPhysicalDamage7
-UniqueDexterity37
+UniqueAddedPhysicalDamage8
+UniqueDexterity23
 UniqueBaseChanceToPoison3
 UniqueChilledWhilePoisoned1
 UniqueNonChilledEnemiesPoisonAndChill1
@@ -195,7 +195,7 @@ Levinstone
 Topaz Ring
 Variant: Pre 0.5.0
 Variant: Current
-UniqueIncreasedMana7
+UniqueIncreasedMana30
 UniqueShockChanceIncrease2
 {variant:1}UniqueGlobalLightningGemLevel1
 {variant:2}UniqueLightningSpellsChain1
@@ -203,7 +203,7 @@ UniqueShockChanceIncrease2
 ]],[[
 Ming's Heart
 Amethyst Ring
-UniqueMaximumLifeIncrease3
+UniqueMaximumLifeIncrease5
 UniqueDamageAddedAsChaos1
 UniqueAllDefences1
 ]],[[
@@ -217,15 +217,15 @@ UniqueElementalDamageConvertToChaos1
 ]],[[
 Perandus Seal
 Gold Ring
-UniqueIncreasedMana5
-UniqueAllAttributes2
+UniqueIncreasedMana24
+UniqueAllAttributes6
 UniqueGoldFoundIncrease1
 ]],[[
 Polcirkeln
 Sapphire Ring
 UniqueColdDamagePercent1
-UniqueIncreasedMana7
-UniqueStrength3
+UniqueIncreasedMana29
+UniqueStrength27
 UniqueChillHitsCauseShattering1
 ]],[[
 Prized Pain
@@ -233,7 +233,7 @@ Iron Ring
 Variant: Pre 0.5.0
 Variant: Current
 League: Dawn of the Hunt
-UniqueStrength41
+UniqueStrength36
 UniqueLifeCostAsManaCost2
 {variant:1}UniqueThornsDamageOnStun1
 UniqueAttackerTakesDamage7
@@ -301,8 +301,8 @@ UniqueHitDamageAgainstEnemiesInPresence1
 Venopuncture
 Iron Ring
 League: Dawn of the Hunt
-UniqueAddedPhysicalDamage8
-UniqueStrength41
+UniqueAddedPhysicalDamage7
+UniqueStrength20
 UniqueChilledWhileBleeding1
 UniqueNonChilledEnemiesBleedAndChill1
 UniqueGlobalChanceToBleed2

--- a/src/Export/Uniques/sceptre.lua
+++ b/src/Export/Uniques/sceptre.lua
@@ -7,8 +7,8 @@ The Dark Defiler
 Rattling Sceptre
 Variant: Pre 0.1.1
 Variant: Current
-UniqueIncreasedMana2
-UniqueIntelligence3
+UniqueIncreasedMana14
+UniqueIntelligence5
 UniqueManaRegeneration1
 {variant:1}UniqueExtraChaosDamagePerUndeadMinion1[3,3]
 {variant:2}UniqueExtraChaosDamagePerUndeadMinion1
@@ -16,7 +16,7 @@ UniqueManaRegeneration1
 Font of Power
 Omen Sceptre
 UniqueLocalIncreasedSpiritPercent1
-UniqueIncreasedMana7
+UniqueIncreasedMana15
 UniqueManaRegeneration6
 UniqueManaScarificeToAllies1
 ]],[[
@@ -53,7 +53,7 @@ UniqueDamageGainedAsCold1
 UniqueNearbyAlliesAddedColdDamage1
 UniqueBaseLifeRegenToAllies1
 UniqueIntelligence42
-UniqueLightRadius15
+UniqueLightRadius9
 UniqueColdShrine1
 ]],[[
 Guiding Palm of the Heart
@@ -66,7 +66,7 @@ UniqueDamageGainedAsFire2
 UniqueNearbyAlliesAddedFireDamage1
 UniqueBaseLifeRegenToAllies1
 UniqueStrength43
-UniqueLightRadius14
+UniqueLightRadius9
 UniqueFireShrine1
 ]],[[
 Guiding Palm of the Mind
@@ -78,8 +78,8 @@ Grants Skill: Level (1-20) Purity of Lightning
 UniqueDamageGainedAsLightning1
 UniqueNearbyAlliesAddedLightningDamage1
 UniqueBaseLifeRegenToAllies1
-UniqueDexterity42
-UniqueLightRadius11
+UniqueDexterity44
+UniqueLightRadius9
 UniqueLightningShrine1
 ]],[[
 Palm of the Dreamer

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -120,7 +120,7 @@ Version: Current
 UniqueIncreasedLife20
 UniqueStrength13
 UniqueStunThreshold8
-{version:1}UniqueEnemiesBlockedAreIntimidated
+{version:1}UniqueEnemiesBlockedAreIntimidated1
 {version:2}UniqueEnemiesBlockedAreIntimidatedDuration1
 ]],
 -- Shield: Evasion

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -7,7 +7,7 @@ Chernobog's Pillar
 Blacksteel Tower Shield
 League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent28
-UniqueFireResist8
+UniqueFireResist31
 UniqueChaosResist32
 UniqueStunThreshold19
 UniqueDamageGainedAsFirePerBlock1
@@ -17,8 +17,8 @@ Splintered Tower Shield
 Variant: Pre 0.1.1
 Variant: Current
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent17
-UniqueStrength3
-{variant:2}UniqueLifeRegeneration15
+UniqueStrength16
+{variant:2}UniqueLifeRegeneration11
 {variant:1}UniqueIncreasedStunThreshold1[30,30]
 {variant:2}UniqueIncreasedStunThreshold1
 UniqueDoubleStunThresholdWhileActiveBlock1
@@ -66,7 +66,7 @@ League: Dawn of the Hunt
 {variant:1}UniqueLocalBlockChance14[20,30]
 {variant:2}UniqueLocalBlockChance14
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent27
-UniqueStrength36
+UniqueStrength34
 UniqueStunThreshold18
 UniqueEnemiesInPresenceMonsterPower1
 ]],[[
@@ -75,7 +75,7 @@ The Surrender
 {variant:2}Vaal Tower Shield
 Variant: Pre 0.4.0
 Variant: Current
-UniqueLocalBlockChance7
+UniqueLocalBlockChance6
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent20
 UniqueStunThreshold12
 UniqueRecoverLifePercentOnBlock1
@@ -109,16 +109,19 @@ Window to Paradise
 Barricade Tower Shield
 League: Dawn of the Hunt
 UniqueLocalIncreasedPhysicalDamageReductionRatingPercent25
-UniqueIncreasedMana47
-UniqueAllResistances24
+UniqueIncreasedMana37
+UniqueAllResistances19
 UniqueRaiseShieldApplyExposure1
 ]],[[
 Wulfsbane
 Painted Tower Shield
-UniqueIncreasedLife3
-UniqueStrength3
-UniqueStunThreshold7
-UniqueEnemiesBlockedAreIntimidated1
+Version: Pre 0.3.0
+Version: Current
+UniqueIncreasedLife20
+UniqueStrength13
+UniqueStunThreshold8
+{version:1}UniqueEnemiesBlockedAreIntimidated
+{version:2}UniqueEnemiesBlockedAreIntimidatedDuration1
 ]],
 -- Shield: Evasion
 [[
@@ -136,9 +139,9 @@ UniqueApplyCorruptedBloodOnBlock1
 Calgyra's Arc
 Ornate Buckler
 League: Dawn of the Hunt
-UniqueLocalIncreasedEvasionRatingPercent28
-UniqueIncreasedMana12
-UniqueIntelligence6
+UniqueLocalIncreasedEvasionRatingPercent30
+UniqueIncreasedMana45
+UniqueIntelligence35
 UniqueProjectileParryInfiniteDistance1
 UniqueParriedDebuffDuration1
 ]],[[
@@ -157,7 +160,7 @@ Kaltenhalt
 Ridged Buckler
 League: Rise of the Abyssal
 UniqueLocalIncreasedEvasionRatingPercent15
-MaximumColdResistUniqueShieldDex1
+UniqueMaximumColdResist2
 UniqueColdResist15
 UniqueParryStunModifiersApplyToFreeze1
 UniqueParryConvertToCold1
@@ -167,7 +170,7 @@ Nocturne
 Wooden Buckler
 League: Dawn of the Hunt
 UniqueIncreasedMana44
-UniqueAllResistances25
+UniqueAllResistances24
 UniqueIncreasedAccuracyPercent1
 UniqueParriedCausesSpellDamageTaken1
 UniqueParriedDebuffDuration2
@@ -176,7 +179,7 @@ Rondel de Ezo
 Plated Buckler
 League: Dawn of the Hunt
 UniqueLocalIncreasedEvasionRatingPercent27
-UniqueDexterity2
+UniqueDexterity39
 UniqueLifeRegeneration24
 UniqueBlockChanceProjectiles1
 UniqueEnfeebleOnBlockChance1
@@ -230,8 +233,8 @@ Hardwood Targe
 Variant: Pre 0.1.1
 Variant: Current
 {variant:1}UniqueLocalBlockChance8
-UniqueLocalIncreasedArmourAndEvasion2
-{variant:2}UniqueIncreasedLife43
+UniqueLocalIncreasedArmourAndEvasion21
+{variant:2}UniqueIncreasedLife42
 {variant:2}UniqueIncreasedMana36
 UniqueMaximumLifeOnKillPercent2
 UniqueMaximumManaOnKillPercent1
@@ -261,6 +264,7 @@ UniqueNoMovementPenaltyRaisedShield1
 ]],[[
 Merit of Service
 Pelage Targe
+Source: No longer obtainable
 Variant: Pre 0.3.0
 Variant: Current
 {variant:1}UniqueLocalBlockChance4[30,50]
@@ -285,9 +289,9 @@ UniqueDamageBlockedRecoupedAsMana1
 ]],[[
 Crest of Ardura
 Jingling Crest Shield
-UniqueLocalIncreasedArmourAndEnergyShield14
-UniqueIntelligence6
-UniqueManaRegeneration3
+UniqueLocalIncreasedArmourAndEnergyShield15
+UniqueIntelligence25
+UniqueManaRegeneration14
 UniqueGlobalCooldownRecovery1
 ]],[[
 Mahuxotl's Machination
@@ -311,7 +315,7 @@ Sigil Crest Shield
 {variant:3}UniqueLocalBlockChance5
 UniqueLocalIncreasedArmourAndEnergyShield10
 {variant:1}UniqueIncreasedSpirit2
-UniqueChaosResist1
+UniqueChaosResist10
 {variant:2,3}UniqueLifeRegenerationRate1
 ]],[[
 Prism Guardian

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -184,8 +184,8 @@ UniqueEnfeebleOnBlockChance1
 Silverthorne
 Spiked Buckler
 League: Dawn of the Hunt
-UniqueLocalIncreasedEvasionRatingPercent29
-UniqueAllResistances19
+UniqueLocalIncreasedEvasionRatingPercent28
+UniqueAllResistances25
 UniqueCriticalWeaknessOnParry1
 UniqueParryDamage1
 ]],[[
@@ -276,8 +276,8 @@ Blazon Crest Shield
 Variant: Pre 0.1.1
 Variant: Pre 0.3.0
 Variant: Current
-{variant:1,2}UniqueLocalBlockChance1[30,40]
-{variant:3}UniqueLocalBlockChance1
+{variant:1,2}UniqueLocalBlockChance3[30,40]
+{variant:3}UniqueLocalBlockChance3
 UniqueLocalIncreasedArmourAndEnergyShield2
 {variant:1}UniqueIncreasedMana4[15,30]
 {variant:2,3}UniqueIncreasedMana4

--- a/src/Export/Uniques/shield.lua
+++ b/src/Export/Uniques/shield.lua
@@ -127,8 +127,8 @@ Iron Buckler
 Variant: Pre 0.3.0
 Variant: Current
 League: Dawn of the Hunt
-{variant:1}UniqueLocalBlockChance14[20,30]
-{variant:2}UniqueLocalBlockChance14
+{variant:1}UniqueLocalBlockChance11[20,30]
+{variant:2}UniqueLocalBlockChance11
 UniqueChaosResist31
 UniqueLifeRegeneration21
 UniqueApplyCorruptedBloodOnBlock1
@@ -333,7 +333,7 @@ Omen Crest Shield
 UniqueMaximumFireResist2
 UniqueFireResist16
 UniqueFireResistOnLowLife1
-LifeRegenerationRatePercentageUniqueShieldStrInt3
+UniqueLifeRegenerationPercent1
 UniqueLifeRegenerationPercentOnLowLife1
 ]],[[
 Saffell's Frame

--- a/src/Export/Uniques/spear.lua
+++ b/src/Export/Uniques/spear.lua
@@ -20,7 +20,7 @@ Hunting Spear
 League: Dawn of the Hunt
 UniqueLocalAddedPhysicalDamage19
 UniqueLocalIncreasedAccuracy7
-UniqueLocalIncreasedAttackSpeed1
+UniqueLocalIncreasedAttackSpeed18
 UniqueLocalAllDamageCanPin1
 UniqueLocalIncreasedProjectileSpeed1
 ]],[[
@@ -66,7 +66,7 @@ UniqueLocalPoisonOnHit1
 Skysliver
 Winged Spear
 League: Dawn of the Hunt
-UniqueLocalNoWeaponPhysicalDamage1
+UniqueLocalNoWeaponPhysicalDamage4
 UniqueLocalAddedLightningDamage1
 UniqueLocalIncreasedAttackSpeed3
 UniqueShockChanceIncrease1
@@ -94,7 +94,7 @@ League: Dawn of the Hunt
 UniqueLocalAddedPhysicalDamage21
 {variant:1}UniqueLocalCriticalStrikeChance8[1000,2000]
 {variant:2}UniqueLocalCriticalStrikeChance8
-UniqueIntelligence34
+UniqueIntelligence38
 UniqueRollCriticalChanceTwice1
 UniqueLifeCost2
 ]],[[

--- a/src/Export/Uniques/staff.lua
+++ b/src/Export/Uniques/staff.lua
@@ -37,8 +37,8 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:1}UniqueLightningDamageOnWeapon1
 {variant:2}UniqueSpellDamageOnWeapon11
-UniqueIncreasedCastSpeed4
-UniqueManaRegeneration6
+UniqueIncreasedCastSpeed10
+UniqueManaRegeneration25
 {variant:2}UniqueShockChanceIncrease4
 UniqueTriggerSparkOnKillingShockedEnemy1
 ]],[[
@@ -65,9 +65,9 @@ Sire of Shards
 Chiming Staff
 League: Dawn of the Hunt
 UniqueSpellDamageOnWeapon7
-UniqueIncreasedCastSpeed4
+UniqueIncreasedCastSpeed13
 UniqueAllResistances22
-LightRadiusUniqueStaff10_
+UniqueLightRadius18
 UniqueSpellAdditionalProjectilesInCircle1
 ]],[[
 Taryn's Shiver
@@ -76,7 +76,7 @@ Variant: Pre 0.4.0
 Variant: Current
 {variant:1}UniqueColdDamageOnWeapon1
 {variant:2}UniqueSpellDamageOnWeapon10
-UniqueIncreasedCastSpeed4
+UniqueIncreasedCastSpeed5
 {variant:1}UniqueFreezeDamageIncrease1[100,100]
 {variant:2}UniqueFreezeDamageIncrease1
 {variant:1}UniqueFrozenMonstersTakeIncreasedDamage1[50,50]
@@ -135,7 +135,7 @@ Variant: Current
 {variant:2}UniqueLocalAddedLightningDamage5
 UniqueLocalCriticalStrikeChance2
 UniqueLocalIncreasedAttackSpeed9
-UniqueManaRegeneration13
+UniqueManaRegeneration17
 UniqueHalvedSpiritReservation1
 ]],[[
 Nazir's Judgement
@@ -145,7 +145,7 @@ Variant: Pre 0.3.0
 Variant: Current
 {variant:1}UniqueLocalIncreasedPhysicalDamagePercent4
 {variant:2,3}UniqueLocalAddedPhysicalDamage13
-UniqueIncreasedAccuracy2
+UniqueLocalIncreasedAccuracy4
 UniqueStunDuration1
 UniqueLocalDazeBuildup1
 {variant:3}UniqueMeleeDamageAgainstStunnedEnemies1
@@ -169,8 +169,8 @@ Variant: Current
 {variant:2}UniqueLocalAddedFireDamage3
 {variant:2}UniqueLocalIncreasedAccuracy6
 UniqueFireResist13
-UniqueIgniteChanceIncrease1
-UniqueLightRadius7
+UniqueIgniteChanceIncrease2
+UniqueLightRadius8
 ]],[[
 The Unborn Lich
 Ravenous Staff

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -33,7 +33,7 @@ UniqueLifeGainedFromEnemyDeath10
 ]],[[
 Enezun's Charge
 Volatile Wand
-UniqueSpellDamageOnWeapon2
+UniqueSpellDamageOnWeapon4
 UniqueSpellCriticalStrikeChance2
 UniqueManaGainedFromEnemyDeath9
 UniqueChanceToNotConsumeCorpse1
@@ -74,7 +74,7 @@ The Wicked Quill
 Withered Wand
 League: Dawn of the Hunt
 UniqueSpellDamageOnWeapon6
-UniqueIncreasedMana12
+UniqueIncreasedMana41
 UniqueChaosResist29
 UniqueSpellWitherOnHitChance1
 ]],


### PR DESCRIPTION
### Description of the problem being solved:

Adds the other armour type inc lines to the item db unique. The second commit also fixes a bunch of mod ids by cross-referencing with Rasmus' json. This does update values for some items, too.

There are a lot more incorrect ones (200+)  which have the same values, but I didn't want to go through them here

### Steps taken to verify a working solution:
- Item manually tested

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="412" height="201" alt="image" src="https://github.com/user-attachments/assets/e9269053-e2e3-4c36-a15f-5a6188e851c0" />

