### PR TITLE
Fix double clicking and dragging items causing issues - #10149

### DIFF
--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -324,7 +324,7 @@ function ItemDBClass:Draw(viewPort)
 end
 
 function ItemDBClass:GetRowValue(column, index, item)
-	if column == 1 then
+	if item and column == 1 then
 		return colorCodes[item.rarity] .. item.name
 	end
 end
@@ -371,6 +371,10 @@ function ItemDBClass:OnSelClick(index, item, doubleClick)
 		self.itemsTab:AddUndoState()
 		self.itemsTab.build.buildFlag = true
 	elseif doubleClick then
+		-- disallow dragging after double click since the window can jump when
+		-- the display item tooltip is created, which might cause the drag item
+		-- to get stuck to the cursor
+		self.selDragging = false
 		self.itemsTab:CreateDisplayItemFromRaw(item.raw, true)
 		return false
 	end

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -319,6 +319,9 @@ function ItemListClass:OnSelClick(index, itemId, doubleClick)
 			self.itemsTab.build.buildFlag = true
 		end
 	elseif doubleClick then
+		-- disallow dragging since if the cursor is outside the selection after
+		-- the second click, the item will be stuck onto the cursor
+		self.selDragging = false
 		local newItem = new("Item"):Item(item:BuildRaw())
 		newItem.id = item.id
 		self.itemsTab:SetDisplayItem(newItem)


### PR DESCRIPTION
### Description of the problem being solved:

Fixes item being attached to tooltip after double clicking it in items tab

https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/10149

https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/10134

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
