### PR TITLE
Fix radius jewel mods stacking each time Show Node Power is used

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -2621,6 +2621,12 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		end
 
 		local jewelData = self.jewelData
+		-- Rebuild rather than append: GetActiveModListForSlotNum rebuilds the
+		-- mod list without going through BuildModList, the only place that
+		-- resets jewelData, so this list would grow on every rebuild.
+		-- Cleared to nil, not {}, because CalcSetup falls back to the default
+		-- radius func with `funcList or { ... }` and {} is truthy in Lua.
+		jewelData.funcList = nil
 		for _, func in ipairs(modList:List(nil, "JewelFunc")) do
 			jewelData.funcList = jewelData.funcList or { }
 			t_insert(jewelData.funcList, func)


### PR DESCRIPTION
### Description of the problem being solved:

Using Show Node Power makes radius jewels apply their mods again on every
recalculation, and the old ones are never removed, so the build's stats keep
climbing. On a level 44 Ranger with a single Time-Lost Sapphire, seven rebuilds
took Hit DPS from 2,387 to 47,268 — Average Damage 2,186 to 43,285 and Crit
Multiplier 366% to 1713%.

It's easy to miss because nothing changes on screen right away. The inflated
numbers only show up the next time you change a setting and the build
recalculates.

jewelData.funcList was appended to but never cleared. BuildModList resets
jewelData, but GetActiveModListForSlotNum rebuilds the mod list without going
through it, so the list grew on every rebuild. CalcSetup adds one radiusJewelList
entry per item in that list, which is why the jewel's mods get applied again.
That jewel has 4 JewelFunc mods and each rebuild runs the engine twice (MAIN and
CALCS), so radiusJewelList went 4, 12, 20, 28, 36, 44, 52 — eight more each time.

Cleared to nil rather than {} because CalcSetup falls back to the default radius
func with `funcList or { ... }`, and an empty table is truthy in Lua — {} would
silently disable radius jewels that don't grant a JewelFunc of their own.

Only jewels with JewelFunc mods are affected; ordinary jewels append nothing.

This is on dev and beta only. master doesn't have GetActiveModListForSlotNum, so
there every path still goes through BuildModList and the reset covers it.

### Steps taken to verify a working solution:
- Tested on a dev checkout at 3887ae6, same build before and after the change
- Before: seven rebuilds, Hit DPS 2,387 → 47,268, radiusJewelList 4 → 52
- After: seven rebuilds, Hit DPS stays at 2,386.6 and Average Damage at
  2,185.5198873772306; nothing else moves either
- Dumped node power for the whole tree after each run: identical between runs
  with the fix, differing on 631-834 nodes without it
- Also reproduced and fixed on a level 98 Monk with a different Time-Lost jewel,
  Crit Multiplier 893% → 1566% over five rebuilds
- Checked ordinary radius jewels still work

### Link to a build that showcases this PR:

[https://pobb.in/t8UGd32NHZPV](https://pobb.in/t8UGd32NHZPV)

Level 44 Ranger, 53 allocated nodes, one Time-Lost Sapphire. Tick Show Node
Power, then change the heat map metric and change it back a few times, watching
Average Damage in the sidebar.

### Before:
<img width="276" height="117" alt="before" src="https://github.com/user-attachments/assets/50982a48-8060-448b-8c2c-7f61a56b2afa" />

### After:
<img width="283" height="118" alt="after" src="https://github.com/user-attachments/assets/6701d94b-f00c-4506-802a-18de611b2187" />
