### PR TITLE
Fix LuaJIT compatibility on dev

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -202,13 +202,13 @@ describe("TetsItemMods", function()
 		build.itemsTab.controls.craftingSorting:SelByValue("Life", "stat")
 		build.calcsTab.GetMiscCalculator = function()
 			return function(args)
-				calcCount += 1
+				calcCount = calcCount + 1
 				local life = 0
 				for _, modLine in ipairs(args.repItem.explicitModLines) do
 					if modLine.line == "+19 to maximum Life" then
-						retainedCount += 1
+						retainedCount = retainedCount + 1
 					end
-					life += tonumber(modLine.line:match("%+(%d+) to maximum Life")) or 0
+					life = life + (tonumber(modLine.line:match("%+(%d+) to maximum Life")) or 0)
 				end
 				return { Life = life }
 			end

--- a/spec/System/TestPassiveSpec_spec.lua
+++ b/spec/System/TestPassiveSpec_spec.lua
@@ -539,6 +539,29 @@ Item Level: 80
 		assert.are.equals("Witch", loadClass("0_4", 1))
 	end)
 
+	it("switches attribute nodes without copying the passive tree graph", function()
+		local source
+		for _, node in pairs(build.spec.tree.nodes) do
+			if node.isAttribute then
+				source = node
+				break
+			end
+		end
+		assert.is_not_nil(source)
+
+		local option = source.options[1]
+		build.spec:SwitchAttributeNode(source.id, 1)
+		local override = build.spec.hashOverrides[source.id]
+
+		assert.is_not_nil(override)
+		assert.are_not.equals(source, override)
+		assert.are.equals(source.group, override.group)
+		assert.are.equals(source.options, override.options)
+		assert.are.equals(option.name, override.dn)
+		assert.are.same(option.sd, override.sd)
+		assert.are_not.equals(option.sd, override.sd)
+	end)
+
 	local function allocNode(spec, nodeId, allocMode)
 		local node = spec.nodes[nodeId]
 		spec.allocMode = allocMode

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -710,10 +710,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 				local backupAffixList = { }
 				for modId, modData in pairs(self.affixes) do
 					-- these can produce false positives, and only ever exist on the monk glove base
-					if modId:match("^HandWraps") and not self.name:match("Fists of Stone") then
-						continue
-					end
-					if modData.affix == modName then
+					if not (modId:match("^HandWraps") and not self.name:match("Fists of Stone")) and modData.affix == modName then
 						if self:GetModSpawnWeight(modData) > 0 then
 							if modData.type == "Prefix" then
 								t_insert(self.pendingAffixList, { modId = modId, table = self.prefixes })
@@ -1396,7 +1393,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					local strippedModLine = getRuneLineParts(modLine.line)
 					if (disabledRuneLines[strippedModLine] or 0) > 0 then
 						modLine.disabled = true
-						disabledRuneLines[strippedModLine] -= 1
+						disabledRuneLines[strippedModLine] = disabledRuneLines[strippedModLine] - 1
 					end
 				end
 			end
@@ -1628,7 +1625,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 		if #self.modMagnitudeMods > 0 then
 			for _, modMagnitudeMod in ipairs(self.modMagnitudeMods) do
 				if self:UsesVersionedOrGroupedVariants() and not self:CheckModLineVariant(modMagnitudeMod.sourceLine) then
-					continue
+					goto continueMagnitudeMod
 				end
 				local modLists
 				if modMagnitudeMod.modType then
@@ -1640,7 +1637,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					for _, mod in ipairs(mods or {}) do
 						-- avoid scaling variant lines which are not active
 						if self:GetModLineVariantCount(mod) == 0 or mod.unscalable then
-							continue
+							goto continueMod
 						end
 						-- Modifiers that grant skills are not affected by modifier magnitude.
 						local grantsSkill = false
@@ -1690,8 +1687,10 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 								mod.extra = extra
 							end
 						end
+						::continueMod::
 					end
 				end
+				::continueMagnitudeMod::
 			end
 		end
 	end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -2717,11 +2717,14 @@ end
 
 function PassiveSpecClass:SwitchAttributeNode(nodeId, attributeIndex)
 	if self.tree.nodes[nodeId] then --Make sure node exists on current tree
-		local newNode = copyTableSafe(self.tree.nodes[nodeId], false, true)
+		local newNode = copyTableSafe(self.tree.nodes[nodeId], true, true)
 		if not newNode.isAttribute then return end -- safety check
 		
 		local option = newNode.options[attributeIndex]
 		self:ReplaceNode(newNode, option)
+		if newNode.sd then
+			newNode.sd = copyTable(newNode.sd, true)
+		end
 		self.tree:ProcessStats(newNode)
 		
 		self.hashOverrides[nodeId] = newNode

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -234,8 +234,8 @@ function TooltipClass:AddBuildPlannerNote(size, text, prefix)
 				depth, closeBrace = 1, openBrace + 1
 				while closeBrace <= finish and depth > 0 do
 					local char = text:sub(closeBrace, closeBrace)
-					if char == "{" then depth += 1 elseif char == "}" then depth -= 1 end
-					closeBrace += 1
+					if char == "{" then depth = depth + 1 elseif char == "}" then depth = depth - 1 end
+					closeBrace = closeBrace + 1
 				end
 			end
 			if validMarkup and depth == 0 then
@@ -247,9 +247,9 @@ function TooltipClass:AddBuildPlannerNote(size, text, prefix)
 					if tag == "s" then lineSize = m_floor(size * 0.75 + 0.5) elseif tag == "m" then lineSize = size elseif tag == "l" then lineSize = m_floor(size * 1.25 + 0.5) end
 					if font ~= nil or lineSize then
 						local line = 1
-						for _ in text:sub(1, tagStart - 1):gmatch("\n") do line += 1 end
+						for _ in text:sub(1, tagStart - 1):gmatch("\n") do line = line + 1 end
 						local lastLine = line
-						for _ in text:sub(tagStart, closeBrace - 1):gmatch("\n") do lastLine += 1 end
+						for _ in text:sub(tagStart, closeBrace - 1):gmatch("\n") do lastLine = lastLine + 1 end
 						for index = line, lastLine do
 							lineStyles[index] = lineStyles[index] or { }
 							if font ~= nil then lineStyles[index].font = font end
@@ -277,7 +277,7 @@ function TooltipClass:AddBuildPlannerNote(size, text, prefix)
 	for renderedLine in (renderedText .. "\n"):gmatch("([^\n]*)\n") do
 		local style = lineStyles[line]
 		self:AddLine(style and style.size or size, (line == 1 and (prefix or "") or "") .. renderedLine, style and style.font)
-		line += 1
+		line = line + 1
 	end
 end
 

--- a/src/Export/Scripts/uModsToText.lua
+++ b/src/Export/Scripts/uModsToText.lua
@@ -201,7 +201,7 @@ for _, name in ipairs(itemTypes) do
 				if mod.modTags then
 					for _, tag in ipairs(mod.modTags) do
 						if tag == "unveiled_mod" then
-							prefix ..= "{desecrated}"
+							prefix = prefix .. "{desecrated}"
 						end
 					end
 				end

--- a/src/Modules/BuildExportPoE2.lua
+++ b/src/Modules/BuildExportPoE2.lua
@@ -144,16 +144,16 @@ local function buildSkills(skillSet)
 				-- inactive skill sets don't have a display skill list so we need to make one
 				activeGem = activeSkillGems(group)[activeIdx]
 			end
-			if not activeGem then continue end
-			local activeId = activeGem.gemData?.gameId
+			if not activeGem then goto continue end
+			local activeId = activeGem.gemData and activeGem.gemData.gameId
 			if activeId then
 				local entry = { id = activeId }
 				local activeText = gemAdditionalText(activeGem, false)
 				if activeText then entry.additional_text = activeText end
 				local supports = {}
 				for _, gem in ipairs(group.gemList) do
-					if gem ~= activeGem and gem.enabled ~= false and gem.gemData?.grantedEffect.support then
-						local supId = gem.gemData?.gameId
+					if gem ~= activeGem and gem.enabled ~= false and gem.gemData and gem.gemData.grantedEffect and gem.gemData.grantedEffect.support then
+						local supId = gem.gemData.gameId
 						if supId then
 							local supText = gemAdditionalText(gem, true)
 							if supText then
@@ -172,6 +172,7 @@ local function buildSkills(skillSet)
 			else
 				ConPrintf("[PoE2Export] skipping active gem with no id in group '%s'", tostring(group.label or "?"))
 			end
+			::continue::
 		end
 	end
 	return out
@@ -272,9 +273,9 @@ function M.GetLoadouts(build)
 			t_insert(out, {
 				name = plainName,
 				fileName = displayName,
-				specIndex = loadout?.specId,
-				skillSetId = loadout?.skillSetId,
-				itemSetId = loadout?.itemSetId,
+				specIndex = loadout and loadout.specId,
+				skillSetId = loadout and loadout.skillSetId,
+				itemSetId = loadout and loadout.itemSetId,
 			})
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5188,7 +5188,7 @@ function calcs.offence(env, actor, activeSkill)
 			return baseVal
 		end
 
-		local critMetatable = { __index = |_, key| -> skillCfg.skillCond[key] or cfg.skillCond[key] }
+		local critMetatable = { __index = function(_, key) return skillCfg.skillCond[key] or cfg.skillCond[key] end }
 		---Calculate global / breakdown values for a damaging ailment
 		---@param ailment string
 		---@param ailmentDamageType table

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1588,7 +1588,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 					limit = { count = 0, max = dbMod.limit, names = { } }
 					augmentLimits[dbMod.limitId or augmentName] = limit
 				end
-				limit.count += count
+				limit.count = limit.count + count
 				t_insert(limit.names, augmentName)
 			end
 		end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -336,7 +336,7 @@ function main:SaveModCache()
 				out:write("end)();(function()\n")
 				count = 0
 			else
-				count += 1
+				count = count + 1
 			end
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Recent dev changes introduced syntax accepted by Luau but not by the LuaJIT 2.1 runtime used by Path of Building and its test workflow. Attribute-node switching also recursively deep-copies references into the passive-tree graph, which greatly increases allocation and can exhaust LuaJIT table capacity during replay-heavy workloads.

This replaces the incompatible operators, optional chaining, continue statements, and arrow function with LuaJIT-compatible equivalents. It also switches attribute nodes with a shallow structural copy while copying the stat-description array that ReplaceNode mutates.

### Steps taken to verify a working solution:

- Parsed all 1,121 Lua files with stock LuaJIT 2.1.
- Ran all 53 system spec files: 824 passed, 0 failed, 2 expected failures, 18 pending.
- Swept all 293 attribute nodes and verified each override while reducing allocation from about 5 MB to about 993 KB.

### Link to a build that showcases this PR:

N/A; this is runtime compatibility and passive-tree correctness.

### Before screenshot:

N/A

### After screenshot:

N/A