### PR TITLE
Add Rune influenced mods to crafter

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3475,10 +3475,11 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 				end)
 			end
 		elseif sourceId == "RUNEINFLUENCED" then
-			local tags = data.runeInfluences[self.displayItem.base.type] or {}
+			local baseType, specificType = self.displayItem:GetSocketedAugmentTypes()
+			local tags = data.runeInfluences[specificType] or data.runeInfluences[baseType] or {}
 			for _, tag in ipairs(tags) do
 				for _, mod in pairsSortByKey(self.displayItem.affixes) do
-					if modHasSpawnTag(mod, tag) then
+					if modHasSpawnTag(mod, tag) and self.displayItem:GetModSpawnWeight(mod, { [tag] = true }) > 0 then
 						t_insert(modList, {
 							label = mod.affix .. "   ^8[" .. table.concat(mod, "/") .. "]",
 							mod = mod,

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3356,6 +3356,39 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 			controls.modSelect:SetSel(1, true)
 		end
 	end
+	local function modHasSpawnTag(mod, tag)
+		local idx = 1
+		while mod.weightKey[idx] do
+			if (mod.weightKey[idx] == tag) and (mod.weightVal[idx] > 0) then
+				return true
+			end
+			idx = idx + 1
+		end
+		return false
+	end
+	local function desecratedSortFunc(a, b)
+		local modA = a.mod
+		local modB = b.mod
+
+		-- Desecrated specific mods always come first
+		if a.desecratedSpecific ~= b.desecratedSpecific then
+			return a.desecratedSpecific == true
+		end
+
+		for i = 1, m_max(#modA.statOrder or 0, #modB.statOrder or 0) do
+			local statA = modA.statOrder and modA.statOrder[i]
+			local statB = modB.statOrder and modB.statOrder[i]
+
+			if not statA then
+				return true
+			elseif not statB then
+				return false
+			elseif statA ~= statB then
+				return statA < statB
+			end
+		end
+		return (modA.level or 0) > (modB.level or 0)
+	end
 	---Mutates modList to contain mods from the specified source
 	---@param sourceId string @The crafting source id to build the list of mods for
 	local function buildMods(sourceId)
@@ -3441,6 +3474,20 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 					end
 				end)
 			end
+		elseif sourceId == "RUNEINFLUENCED" then
+			local tags = data.runeInfluences[self.displayItem.base.type] or {}
+			for _, tag in ipairs(tags) do
+				for _, mod in pairsSortByKey(self.displayItem.affixes) do
+					if modHasSpawnTag(mod, tag) then
+						t_insert(modList, {
+							label = mod.affix .. "   ^8[" .. table.concat(mod, "/") .. "]",
+							mod = mod,
+							type = "custom",
+						})
+					end
+				end
+			end
+			table.sort(modList, desecratedSortFunc)
 		elseif sourceId == "DESECRATED" then
 			local function isDesecratedMod(mod)
 				for _, tag in ipairs(mod.modTags or { }) do
@@ -3468,29 +3515,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 					})
 				end
 			end
-			table.sort(modList, function(a, b)
-				local modA = a.mod
-				local modB = b.mod
-
-				-- Desecrated specific mods always come first
-				if a.desecratedSpecific ~= b.desecratedSpecific then
-					return a.desecratedSpecific == true
-				end
-
-				for i = 1, m_max(#modA.statOrder or 0, #modB.statOrder or 0) do
-					local statA = modA.statOrder and modA.statOrder[i]
-					local statB = modB.statOrder and modB.statOrder[i]
-
-					if not statA then
-						return true
-					elseif not statB then
-						return false
-					elseif statA ~= statB then
-						return statA < statB
-					end
-				end
-				return (modA.level or 0) > (modB.level or 0)
-			end)
+			table.sort(modList, desecratedSortFunc)
 		end
 		setDefaultSortOrder(modList)
 	end
@@ -3500,6 +3525,8 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	end
 	buildMods("DESECRATED")
 	local hasDesecratedMods = #modList > 0
+	buildMods("RUNEINFLUENCED")
+	local hasRuneInfluencedMods = #modList > 0
 	buildMods("ESSENCE") 	-- This is technically a waste if there aren't any essence mods,
 									-- but it makes it so we don't have to maintain a list of applicable essence-able base types
 	if #modList > 0 then
@@ -3507,6 +3534,9 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	end
 	if hasDesecratedMods then
 		t_insert(sourceList, { label = "Desecrated", sourceId = "DESECRATED" })
+	end
+	if hasRuneInfluencedMods then
+		t_insert(sourceList, { label = "Rune-Influenced", sourceId = "RUNEINFLUENCED" })
 	end
 	if self.displayItem.base.type == "Jewel" then
 		buildMods("EMOTION")

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -606,8 +606,6 @@ function TradeQueryGeneratorClass:InitMods()
 
 	-- 0.5 rune influence mods. e.g. can roll chronomancy modifiers
 
-	-- a map of slot to weight key which is on the mods
-	local runeInfluences = { Boots = { "chronomancy" }, Gloves = { "marksman", "decay" }, Helmets = { "berserking" }, Weapon = { "destruction" }, ["Body Armour"] = { "soul" } }
 	local function hasSpawnTag(mod, tag)
 		local idx = 1
 		while mod.weightKey[idx] do
@@ -618,7 +616,7 @@ function TradeQueryGeneratorClass:InitMods()
 		end
 		return false
 	end
-	for slot, tags in pairsSortByKey(runeInfluences) do
+	for slot, tags in pairsSortByKey(data.runeInfluences) do
 		for _, tag in ipairs(tags) do
 			local mods = {}
 			for _, mod in pairsSortByKey(data.itemMods.Item) do

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -606,6 +606,8 @@ function TradeQueryGeneratorClass:InitMods()
 
 	-- 0.5 rune influence mods. e.g. can roll chronomancy modifiers
 
+	-- a map of slot to weight key which is on the mods
+	local runeInfluences = { Boots = { "chronomancy" }, Gloves = { "marksman", "decay" }, Helmets = { "berserking" }, Weapon = { "destruction" }, ["Body Armour"] = { "soul" } }
 	local function hasSpawnTag(mod, tag)
 		local idx = 1
 		while mod.weightKey[idx] do
@@ -616,7 +618,7 @@ function TradeQueryGeneratorClass:InitMods()
 		end
 		return false
 	end
-	for slot, tags in pairsSortByKey(data.runeInfluences) do
+	for slot, tags in pairsSortByKey(runeInfluences) do
 		for _, tag in ipairs(tags) do
 			local mods = {}
 			for _, mod in pairsSortByKey(data.itemMods.Item) do

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -1149,5 +1149,12 @@ data.flavourText = LoadModule("Data/FlavourText")
 data.worldAreas = {}
 LoadModule("Data/WorldAreas")(data.worldAreas)
 
--- a map of slot to weight key which is on the mods
-data.runeInfluences = { Boots = { "chronomancy" }, Gloves = { "marksman", "decay" }, Helmets = { "berserking" }, Weapon = { "destruction" }, ["Body Armour"] = { "soul" } }
+-- Maps socketed augment types to the spawn tags granted by their influence runes.
+data.runeInfluences = {
+	boots = { "chronomancy" },
+	gloves = { "marksman", "decay" },
+	helmet = { "berserking" },
+	weapon = { "destruction" },
+	caster = { "destruction" },
+	["body armour"] = { "soul" },
+}

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -1148,3 +1148,6 @@ data.questRewards = LoadModule("Data/QuestRewards")
 data.flavourText = LoadModule("Data/FlavourText")
 data.worldAreas = {}
 LoadModule("Data/WorldAreas")(data.worldAreas)
+
+-- a map of slot to weight key which is on the mods
+data.runeInfluences = { Boots = { "chronomancy" }, Gloves = { "marksman", "decay" }, Helmets = { "berserking" }, Weapon = { "destruction" }, ["Body Armour"] = { "soul" } }


### PR DESCRIPTION
### Description of the problem being solved:

Adds the related mods to the custom mod menu under the "Rune-influenced" label

### Steps taken to verify a working solution:
- Tested each slot

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="947" height="416" alt="image" src="https://github.com/user-attachments/assets/437b2dcb-d74b-4d3c-b39c-958d7c3a0d19" />
