### PR TITLE
Iterate flasks and charms in slot order

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1707,7 +1707,20 @@ function calcs.perform(env, skipEHP)
 		local flaskBuffsNonPlayer = {}
 		local flaskBuffsPerBaseNonPlayer = {}
 
+		local slotIndex = env.itemSlotIndex or { }
+		local orderedFlasks = { }
 		for item in pairs(flasks) do
+			t_insert(orderedFlasks, item)
+		end
+		table.sort(orderedFlasks, function(a, b)
+			local posA = slotIndex[a] or 0
+			local posB = slotIndex[b] or 0
+			if posA ~= posB then
+				return posA < posB
+			end
+			return (a.id or 0) < (b.id or 0)
+		end)
+		for _, item in ipairs(orderedFlasks) do
 			flaskBuffsPerBase[item.baseName] = flaskBuffsPerBase[item.baseName] or {}
 			flaskBuffsPerBaseNonPlayer[item.baseName] = flaskBuffsPerBaseNonPlayer[item.baseName] or {}
 			flaskConditions["UsingFlask"] = true
@@ -1810,7 +1823,20 @@ function calcs.perform(env, skipEHP)
 		local charmConditions = {}
 		local charmBuffsPerBase = {}
 
+		local slotIndex = env.itemSlotIndex or { }
+		local orderedCharms = { }
 		for item in pairs(charms) do
+			t_insert(orderedCharms, item)
+		end
+		table.sort(orderedCharms, function(a, b)
+			local posA = slotIndex[a] or 0
+			local posB = slotIndex[b] or 0
+			if posA ~= posB then
+				return posA < posB
+			end
+			return (a.id or 0) < (b.id or 0)
+		end)
+		for _, item in ipairs(orderedCharms) do
 			if charmLimit <= 0 then
 				break
 			end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1273,7 +1273,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 			local item = items[slotName]
 			local node = slot.nodeId and env.spec.nodes[slot.nodeId]
 			if item then
-				env.itemSlotIndex[item] = tonumber(slotName:match("%d+")) or 0
+				local slotIndex = tonumber(slotName:match("%d+")) or 0
+				-- Repeated flasks/charms keep their earliest active slot.
+				if not (env.flasks[item] or env.charms[item]) then
+					env.itemSlotIndex[item] = slotIndex
+				elseif slot.active then
+					env.itemSlotIndex[item] = m_min(env.itemSlotIndex[item], slotIndex)
+				end
 			end
 			if item and item.type == "Flask" then
 				if slot.active then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1267,10 +1267,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 			end
 		end
 
+		env.itemSlotIndex = { }
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
 			local item = items[slotName]
 			local node = slot.nodeId and env.spec.nodes[slot.nodeId]
+			if item then
+				env.itemSlotIndex[item] = tonumber(slotName:match("%d+")) or 0
+			end
 			if item and item.type == "Flask" then
 				if slot.active then
 					env.flasks[item] = true


### PR DESCRIPTION
### Description of the problem being solved:

env.flasks and env.charms are keyed by item table, so pairs() walks them in memory-address order, which differs between processes. That order reaches the modDB and, for charms, the limit loop stops early, so it also decided which charms applied. CalcSetup now records each slotted item's slot number in env.itemSlotIndex, and mergeFlasks/mergeCharms iterate in that order with item.id as the tiebreak.

### Steps taken to verify a working solution:

Has been running headless in poe.ninja for about a month.