### PR TITLE
Treat Lavianga's Spirits as mana regen

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -2569,6 +2569,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		local durationInc = calcLocal(modList, "Duration", "INC", 0)
 		local durationMore = calcLocal(modList, "Duration", "MORE", 0)
 		if self.base.flask.life or self.base.flask.mana then
+			self.hasConstantManaEffect = calcLocal(modList, "ConstantFlaskEffect", "FLAG", 0)
 			-- Recovery flask
 			flaskData.instantPerc = calcLocal(modList, "FlaskInstantRecovery", "BASE", 0)
 			local recoveryMod = 1 + calcLocal(modList, "FlaskRecovery", "INC", 0) / 100

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -9596,8 +9596,7 @@ c["The next Attack you use within 4 seconds after Heavy Stunning a Rare or Uniqu
 c["The next Attack you use within 4 seconds after Heavy Stunning a Rare or Unique Enemy is Ancestrally Boosted Ancestrally Boosted Attacks deal 30% increased Damage"]={nil,"The next Attack you use within 4 seconds after Heavy Stunning a Rare or Unique Enemy is Ancestrally Boosted Ancestrally Boosted Attacks deal 30% increased Damage "}
 c["The next Fire Spell you cast yourself after using a Warcry is Ancestrally Boosted"]={nil,"The next Fire Spell you cast yourself after using a Warcry is Ancestrally Boosted "}
 c["There is no Limit on the number of Banners you can place"]={nil,"There is no Limit on the number of Banners you can place "}
-c["This Flask cannot be Used but applies its Effect constantly"]={nil,"This Flask cannot be Used but applies its Effect constantly "}
-c["This Flask cannot be Used but applies its Effect constantly 80% reduced Amount Recovered"]={nil,"This Flask cannot be Used but applies its Effect constantly 80% reduced Amount Recovered "}
+c["This Flask cannot be Used but applies its Effect constantly"]={{[1]={flags=0,keywordFlags=0,name="ConstantFlaskEffect",type="FLAG",value=true}},nil}
 c["This Weapon's Critical Hit Chance is 100%"]={{[1]={flags=0,keywordFlags=0,name="WeaponData",type="LIST",value={key="CritChance",value=100}}},nil}
 c["This item gains bonuses from Socketed Items as though it was Boots"]={{},nil}
 c["This item gains bonuses from Socketed Items as though it was Gloves"]={{},nil}

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1280,6 +1280,9 @@ function calcs.initEnv(build, mode, override, specEnv)
 					if item.flaskData.lifeTotal > highestLifeRecovery then
 						env.itemModDB.multipliers["LifeFlaskRecovery"] = item.flaskData.lifeTotal
 					end
+					-- lavianga's spirits regen
+				elseif item.hasConstantManaEffect then
+					modDB:NewMod("ManaRegen", "BASE", item.flaskData.manaGradual, "Constant Mana Flask")
 				end
 				env.itemModDB.multipliers[item.base.subType..slotName:gsub(" ", "").."MaxCharges"] = item.flaskData.chargesMax
 				item = nil

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4426,6 +4426,7 @@ local specialModList = {
 	} end,
 	["(%d+)%% increased movement speed while on full life"] = function(num) return { mod("MovementSpeed", "INC", num, { type = "Condition", var = "FullLife" }) } end,
 	["when you warcry, you and nearby allies gain onslaught for 4 seconds"] = { mod("ExtraAura", "LIST", { mod = flag("Onslaught") }, { type = "Condition", var = "UsedWarcryRecently" }) },
+	["this flask cannot be used but applies its effect constantly"] = { flag("ConstantFlaskEffect") },
 	["warcries grant arcane surge to you and allies, with (%d+)%% increased effect per (%d+) power, up to (%d+)%%"] = function(num, _, div, limit) return {
 		mod("ExtraAura", "LIST", { mod = flag("Condition:ArcaneSurge")}, { type = "Condition", var = "UsedWarcryRecently" }),
 		mod("ArcaneSurgeEffect", "INC", num, { type = "PerStat", stat = "WarcryPower", div = tonumber(div), globalLimit = tonumber(limit), globalLimitKey = "Brinerot Flag"}, { type = "Condition", var = "UsedWarcryRecently" }),


### PR DESCRIPTION
### Description of the problem being solved:

This adds basic Lavianga's Spirits support by simply adding it as base regen.

### Steps taken to verify a working solution:
- Manually tested

### After screenshot:
<img width="743" height="182" alt="image" src="https://github.com/user-attachments/assets/03d8f5ec-0828-40ee-b20d-84d84a9ff938" />
