### PR TITLE
Show red text for unsupported rune mods

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -813,7 +813,11 @@ holding Shift will put it in the second.]])
 					tooltip:AddLine(14, "^7" .. s_format("Requires: Level %d", value.req))
 				end
 				for _, line in ipairs(value.lines) do
-					tooltip:AddLine(14, colorCodes.MAGIC .. line)
+					-- rune mod lines don't need a range applied to them
+					local stripped = line:gsub("Bonded: ", "")
+					local modList, extra = modLib.parseMod(stripped)
+					local colour = ((not not modList) and not extra) and colorCodes.MAGIC or colorCodes.UNSUPPORTED
+					tooltip:AddLine(14, colour .. line)
 				end
 				-- Adding Comparison
 				local compLines = { type = "Rune" }


### PR DESCRIPTION
### Description of the problem being solved:

Shows red text for unsupported rune mods in the dropdown tooltip

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="861" height="153" alt="image" src="https://github.com/user-attachments/assets/858e9398-ef45-4b89-9335-f1d7cd2195d7" />
